### PR TITLE
Proper reading of parquet columns

### DIFF
--- a/kernel/examples/dump-table/Cargo.toml
+++ b/kernel/examples/dump-table/Cargo.toml
@@ -13,5 +13,6 @@ deltakernel = { path = "../../../kernel", features = [
   "developer-visibility",
 ] }
 env_logger = "0.11.3"
+itertools = "0.12.1"
 url = "2"
 

--- a/kernel/examples/dump-table/src/main.rs
+++ b/kernel/examples/dump-table/src/main.rs
@@ -62,14 +62,17 @@ fn main() -> DeltaResult<()> {
         Some(cols) => {
             use itertools::Itertools;
             let table_schema = snapshot.schema();
-            let selected_fields: Vec<StructField> =
-                cols.iter()
-                    .map(|col| {
-                        table_schema.field(col).cloned().ok_or(
-                            deltakernel::Error::Generic(format!("Table has no such column: {col}")),
-                        )
-                    })
-                    .try_collect()?;
+            let selected_fields: Vec<StructField> = cols
+                .iter()
+                .map(|col| {
+                    table_schema
+                        .field(col)
+                        .cloned()
+                        .ok_or(deltakernel::Error::Generic(format!(
+                            "Table has no such column: {col}"
+                        )))
+                })
+                .try_collect()?;
             let read_schema = Arc::new(Schema::new(selected_fields));
             let builder = ScanBuilder::new(snapshot).with_schema(read_schema);
             builder.build()

--- a/kernel/examples/dump-table/src/main.rs
+++ b/kernel/examples/dump-table/src/main.rs
@@ -9,6 +9,7 @@ use deltakernel::client::default::executor::tokio::TokioBackgroundExecutor;
 use deltakernel::client::default::DefaultEngineInterface;
 use deltakernel::client::sync::SyncEngineInterface;
 use deltakernel::scan::ScanBuilder;
+use deltakernel::schema::{Schema, StructField};
 use deltakernel::{DeltaResult, EngineInterface, Table};
 
 use clap::{Parser, ValueEnum};
@@ -25,6 +26,10 @@ struct Cli {
     /// Which EngineInterface to use
     #[arg(short, long, value_enum, default_value_t = Interface::Default)]
     interface: Interface,
+
+    /// Comma separated list of columns to select
+    #[arg(long, value_delimiter=',', num_args(0..))]
+    columns: Option<Vec<String>>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -53,7 +58,24 @@ fn main() -> DeltaResult<()> {
     let table = Table::new(url);
     let snapshot = table.snapshot(engine_interface.as_ref(), None)?;
 
-    let scan = ScanBuilder::new(snapshot).build();
+    let scan = match cli.columns {
+        Some(cols) => {
+            use itertools::Itertools;
+            let table_schema = snapshot.schema();
+            let selected_fields: Vec<StructField> =
+                cols.iter()
+                    .map(|col| {
+                        table_schema.field(col).map(|f| f.clone()).ok_or(
+                            deltakernel::Error::Generic(format!("Table has no such column: {col}")),
+                        )
+                    })
+                    .try_collect()?;
+            let read_schema = Arc::new(Schema::new(selected_fields));
+            let builder = ScanBuilder::new(snapshot).with_schema(read_schema);
+            builder.build()
+        }
+        None => ScanBuilder::new(snapshot).build(),
+    };
 
     let mut batches = vec![];
     for res in scan.execute(engine_interface.as_ref())?.into_iter() {

--- a/kernel/examples/dump-table/src/main.rs
+++ b/kernel/examples/dump-table/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> DeltaResult<()> {
             let selected_fields: Vec<StructField> =
                 cols.iter()
                     .map(|col| {
-                        table_schema.field(col).map(|f| f.clone()).ok_or(
+                        table_schema.field(col).cloned().ok_or(
                             deltakernel::Error::Generic(format!("Table has no such column: {col}")),
                         )
                     })

--- a/kernel/src/client/arrow_data.rs
+++ b/kernel/src/client/arrow_data.rs
@@ -172,7 +172,6 @@ impl ArrowEngineData {
         Ok(ArrowEngineData::new(data?))
     }
 
-    // TODO needs to apply the schema to the parquet read
     pub fn try_create_from_parquet(schema: SchemaRef, location: Url) -> DeltaResult<Self> {
         let file = File::open(
             location
@@ -187,7 +186,7 @@ impl ArrowEngineData {
             .fields
             .iter()
             .map(|field| {
-                // todo: handle nested
+                // todo: handle nested (then use `leaves` not `roots` below
                 parquet_schema.index_of(field.name())
             })
             .try_collect()?;
@@ -195,7 +194,7 @@ impl ArrowEngineData {
         let mask = if parquet_schema.fields.size() == requested_schema.fields.size() {
             ProjectionMask::all()
         } else {
-            ProjectionMask::leaves(builder.parquet_schema(), indicies.clone())
+            ProjectionMask::roots(builder.parquet_schema(), indicies.clone())
         };
 
         let builder = builder.with_projection(mask);

--- a/kernel/src/client/arrow_data.rs
+++ b/kernel/src/client/arrow_data.rs
@@ -180,16 +180,16 @@ impl ArrowEngineData {
         let metadata = ArrowReaderMetadata::load(&file, Default::default())?;
         let parquet_schema = metadata.schema();
         let requested_schema: ArrowSchema = (&*schema).try_into()?;
-        let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+        let mut builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
         let indicies: Vec<usize> = get_requested_indicies(&requested_schema, parquet_schema)?;
-        let mask = generate_mask(
+        if let Some(mask) = generate_mask(
             &requested_schema,
             parquet_schema,
             builder.parquet_schema(),
             &indicies,
-        );
-
-        let builder = builder.with_projection(mask);
+        ) {
+            builder = builder.with_projection(mask);
+        }
         let mut reader = builder.build()?;
         let data = reader
             .next()

--- a/kernel/src/client/arrow_data.rs
+++ b/kernel/src/client/arrow_data.rs
@@ -181,7 +181,7 @@ impl ArrowEngineData {
         let parquet_schema = metadata.schema();
         let requested_schema: ArrowSchema = (&*schema).try_into()?;
         let mut builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
-        let indicies: Vec<usize> = get_requested_indicies(&requested_schema, parquet_schema)?;
+        let indicies = get_requested_indicies(&requested_schema, parquet_schema)?;
         if let Some(mask) = generate_mask(
             &requested_schema,
             parquet_schema,

--- a/kernel/src/client/arrow_data.rs
+++ b/kernel/src/client/arrow_data.rs
@@ -1,4 +1,4 @@
-use super::arrow_utils::{generate_mask, get_requested_indicies, reorder_record_batch};
+use super::arrow_utils::{generate_mask, get_requested_indices, reorder_record_batch};
 use crate::engine_data::{EngineData, EngineList, EngineMap, GetData};
 use crate::schema::{DataType, PrimitiveType, Schema, SchemaRef, StructField};
 use crate::{DataVisitor, DeltaResult, Error};
@@ -181,7 +181,7 @@ impl ArrowEngineData {
         let parquet_schema = metadata.schema();
         let requested_schema: ArrowSchema = (&*schema).try_into()?;
         let mut builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
-        let indicies = get_requested_indicies(&requested_schema, parquet_schema)?;
+        let indicies = get_requested_indices(&requested_schema, parquet_schema)?;
         if let Some(mask) = generate_mask(
             &requested_schema,
             parquet_schema,

--- a/kernel/src/client/arrow_utils.rs
+++ b/kernel/src/client/arrow_utils.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use parquet::{arrow::ProjectionMask, schema::types::SchemaDescriptor};
 
 /// Get the indicies in `parquet_schema` of the specified columns in `requested_schema`
-pub(crate) fn get_requested_indicies(
+pub(crate) fn get_requested_indices(
     requested_schema: &ArrowSchema,
     parquet_schema: &ArrowSchemaRef,
 ) -> DeltaResult<Vec<usize>> {

--- a/kernel/src/client/arrow_utils.rs
+++ b/kernel/src/client/arrow_utils.rs
@@ -25,39 +25,54 @@ pub(crate) fn get_requested_indicies(
     Ok(indicies)
 }
 
+/// Create a mask that will only select the specified indicies from the parquet. Currently we only
+/// handle "root" level columns, and hence use `ProjectionMask::roots`, but will support leaf
+/// selection in the future
 pub(crate) fn generate_mask(
     requested_schema: &ArrowSchema,
     parquet_schema: &ArrowSchemaRef,
     parquet_physical_schema: &SchemaDescriptor,
     indicies: &[usize],
-) -> ProjectionMask {
+) -> Option<ProjectionMask> {
     if parquet_schema.fields.size() == requested_schema.fields.size() {
-        ProjectionMask::all()
+        // we assume that in get_requested_indicies we will have caught any column name mismatches,
+        // so here we can just say that if we request the same # of columns as the parquet file
+        // actually has, we don't need to mask anything out
+        None
     } else {
-        ProjectionMask::roots(parquet_physical_schema, indicies.to_owned())
+        Some(ProjectionMask::roots(
+            parquet_physical_schema,
+            indicies.to_owned(),
+        ))
     }
 }
 
+/// Reorder a RecordBatch to match `requested_schema`. This method takes `indicies` as computed by
+/// [`get_requested_indicies`] as an optimization. If the indicies are in order, then we don't need
+/// to do any re-ordering.
 pub(crate) fn reorder_record_batch(
     requested_schema: Arc<ArrowSchema>,
     input_data: RecordBatch,
     indicies: &[usize],
 ) -> DeltaResult<RecordBatch> {
     if indicies.windows(2).all(|is| is[0] <= is[1]) {
-        // indicies is already sorted, so we don't need to do anything more
+        // indicies is already sorted, meaning we requested in the order that the columns were
+        // stored in the parquet
         Ok(input_data)
     } else {
         // requested an order different from the parquet, reorder
-        let mut cols = Vec::with_capacity(input_data.num_columns());
-        for field in requested_schema.fields.iter() {
-            let col = input_data
-                .column_by_name(field.name())
-                .ok_or(Error::generic(
-                    "request_schema had a field that didn't exist in final result. This is a bug",
-                ))?;
-            cols.push(col.clone());
-        }
-        let reordered = RecordBatch::try_new(requested_schema, cols)?;
-        Ok(reordered)
+        let reordered_columns = requested_schema
+            .fields
+            .iter()
+            .map(|field| {
+                input_data
+                    .column_by_name(field.name())
+                    .cloned() // cheap clones of `Arc`s
+                    .ok_or(Error::generic(
+                        "request_schema had a field that didn't exist in final result. This is a bug",
+                    ))
+            })
+            .try_collect()?;
+        Ok(RecordBatch::try_new(requested_schema, reordered_columns)?)
     }
 }

--- a/kernel/src/client/arrow_utils.rs
+++ b/kernel/src/client/arrow_utils.rs
@@ -1,0 +1,63 @@
+//! Some utilities for working with arrow data types
+
+use std::sync::Arc;
+
+use crate::{DeltaResult, Error};
+
+use arrow_array::RecordBatch;
+use arrow_schema::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
+use itertools::Itertools;
+use parquet::{arrow::ProjectionMask, schema::types::SchemaDescriptor};
+
+/// Get the indicies in `parquet_schema` of the specified columns in `requested_schema`
+pub(crate) fn get_requested_indicies(
+    requested_schema: &ArrowSchema,
+    parquet_schema: &ArrowSchemaRef,
+) -> DeltaResult<Vec<usize>> {
+    let indicies = requested_schema
+        .fields
+        .iter()
+        .map(|field| {
+            // todo: handle nested (then use `leaves` not `roots` below in generate_mask)
+            parquet_schema.index_of(field.name())
+        })
+        .try_collect()?;
+    Ok(indicies)
+}
+
+pub(crate) fn generate_mask(
+    requested_schema: &ArrowSchema,
+    parquet_schema: &ArrowSchemaRef,
+    parquet_physical_schema: &SchemaDescriptor,
+    indicies: &[usize],
+) -> ProjectionMask {
+    if parquet_schema.fields.size() == requested_schema.fields.size() {
+        ProjectionMask::all()
+    } else {
+        ProjectionMask::roots(parquet_physical_schema, indicies.to_owned())
+    }
+}
+
+pub(crate) fn reorder_record_batch(
+    requested_schema: Arc<ArrowSchema>,
+    input_data: RecordBatch,
+    indicies: &[usize],
+) -> DeltaResult<RecordBatch> {
+    if indicies.windows(2).all(|is| is[0] <= is[1]) {
+        // indicies is already sorted, so we don't need to do anything more
+        Ok(input_data)
+    } else {
+        // requested an order different from the parquet, reorder
+        let mut cols = Vec::with_capacity(input_data.num_columns());
+        for field in requested_schema.fields.iter() {
+            let col = input_data
+                .column_by_name(field.name())
+                .ok_or(Error::generic(
+                    "request_schema had a field that didn't exist in final result. This is a bug",
+                ))?;
+            cols.push(col.clone());
+        }
+        let reordered = RecordBatch::try_new(requested_schema, cols)?;
+        Ok(reordered)
+    }
+}

--- a/kernel/src/client/default/parquet.rs
+++ b/kernel/src/client/default/parquet.rs
@@ -12,7 +12,7 @@ use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStream
 
 use super::file_handler::{FileOpenFuture, FileOpener};
 use crate::client::arrow_data::ArrowEngineData;
-use crate::client::arrow_utils::{generate_mask, get_requested_indicies, reorder_record_batch};
+use crate::client::arrow_utils::{generate_mask, get_requested_indices, reorder_record_batch};
 use crate::client::default::executor::TaskExecutor;
 use crate::client::default::file_handler::FileStream;
 use crate::schema::SchemaRef;
@@ -130,7 +130,7 @@ impl FileOpener for ParquetOpener {
             let mut reader = ParquetObjectReader::new(store, meta);
             let metadata = ArrowReaderMetadata::load_async(&mut reader, Default::default()).await?;
             let parquet_schema = metadata.schema();
-            let indicies = get_requested_indicies(&table_schema, parquet_schema)?;
+            let indicies = get_requested_indices(&table_schema, parquet_schema)?;
             let options = ArrowReaderOptions::new(); //.with_page_index(enable_page_index);
             let mut builder =
                 ParquetRecordBatchStreamBuilder::new_with_options(reader, options).await?;

--- a/kernel/src/client/default/parquet.rs
+++ b/kernel/src/client/default/parquet.rs
@@ -130,13 +130,13 @@ impl FileOpener for ParquetOpener {
             let mut reader = ParquetObjectReader::new(store, meta);
             let metadata = ArrowReaderMetadata::load_async(&mut reader, Default::default()).await?;
             let parquet_schema = metadata.schema();
-            let indicies = get_requested_indicies(&table_schema, &parquet_schema)?;
+            let indicies = get_requested_indicies(&table_schema, parquet_schema)?;
             let options = ArrowReaderOptions::new(); //.with_page_index(enable_page_index);
             let mut builder =
                 ParquetRecordBatchStreamBuilder::new_with_options(reader, options).await?;
             if let Some(mask) = generate_mask(
                 &table_schema,
-                &parquet_schema,
+                parquet_schema,
                 builder.parquet_schema(),
                 &indicies,
             ) {

--- a/kernel/src/client/mod.rs
+++ b/kernel/src/client/mod.rs
@@ -9,6 +9,9 @@ pub mod arrow_expression;
 #[cfg(any(feature = "default-client", feature = "sync-client"))]
 pub mod arrow_data;
 
+#[cfg(any(feature = "default-client", feature = "sync-client"))]
+pub mod arrow_utils;
+
 #[cfg(feature = "default-client")]
 pub mod default;
 

--- a/kernel/src/client/sync/parquet.rs
+++ b/kernel/src/client/sync/parquet.rs
@@ -14,7 +14,7 @@ impl ParquetHandler for SyncParquetHandler {
         schema: SchemaRef,
         _predicate: Option<Expression>,
     ) -> DeltaResult<FileDataReadResultIterator> {
-        debug!("Reading parquet files: {:#?}", files);
+        debug!("Reading parquet files: {files:#?} with schema {schema:#?}");
         if files.is_empty() {
             return Ok(Box::new(std::iter::empty()));
         }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -175,13 +175,14 @@ pub trait JsonHandler {
 /// Connectors can leverage this interface to provide their own custom
 /// implementation of Parquet data file functionalities to Delta Kernel.
 pub trait ParquetHandler: Send + Sync {
-    /// Read and parse the JSON format file at given locations and return
-    /// the data as EngineData with the columns requested by physical schema.
+    /// Read and parse the Parquet file at given locations and return the data as EngineData with
+    /// the columns requested by physical schema . The ParquetHandler _must_ return exactly the
+    /// columns specified in `physical_schema`, and they _must_ be in schema order.
     ///
     /// # Parameters
     ///
     /// - `files` - File metadata for files to be read.
-    /// - `physical_schema` - Select list of columns to read from the JSON file.
+    /// - `physical_schema` - Select list and order of columns to read from the Parquet file.
     /// - `predicate` - Optional push-down predicate hint (engine is free to ignore it).
     fn read_parquet_files(
         &self,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -13,7 +13,6 @@ use crate::{DeltaResult, EngineData, EngineInterface, Error, FileMeta};
 mod data_skipping;
 pub mod file_stream;
 
-// TODO projection: something like fn select(self, columns: &[&str])
 /// Builder to scan a snapshot of a table.
 pub struct ScanBuilder {
     snapshot: Arc<Snapshot>,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -190,7 +190,23 @@ impl Scan {
             })
             .collect();
         let read_schema = Arc::new(StructType::new(read_fields));
+        debug!("Executing scan with read schema {read_schema:#?}");
         let output_schema = DataType::Struct(Box::new(self.schema().as_ref().clone()));
+
+        // // start col_mapping hack
+        // let mut p = 0;
+        // let fields = self
+        //     .schema()
+        //     .fields()
+        //     .map(|field| {
+        //         let f =
+        //             StructField::new(format!("f{}", p), field.data_type().clone(), field.nullable);
+        //         p += 1;
+        //         f
+        //     })
+        //     .collect();
+        // // end hack
+        //let output_schema = DataType::Struct(Box::new(StructType::new(fields)));
         let parquet_handler = engine_interface.get_parquet_handler();
 
         let mut results: Vec<ScanResult> = vec![];
@@ -204,7 +220,7 @@ impl Scan {
             };
 
             let read_results =
-                parquet_handler.read_parquet_files(&[meta], self.read_schema.clone(), None)?;
+                parquet_handler.read_parquet_files(&[meta], read_schema.clone(), None)?;
 
             let read_expression = if have_partition_cols {
                 // Loop over all fields and create the correct expressions for them

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -51,6 +51,15 @@ impl ScanBuilder {
         self
     }
 
+    /// Optionally provide a [`Schema`] for columns to select from the [`Snapshot`]. See
+    /// [`with_schema`] for details. If schema_opt is `None` this is a no-op.
+    pub fn with_schema_opt(self, schema_opt: Option<SchemaRef>) -> Self {
+        match schema_opt {
+            Some(schema) => self.with_schema(schema),
+            None => self,
+        }
+    }
+
     /// Predicates specified in this crate's [`Expression`] type.
     ///
     /// Can be used to filter the rows in a scan. For example, using the predicate

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -192,21 +192,6 @@ impl Scan {
         let read_schema = Arc::new(StructType::new(read_fields));
         debug!("Executing scan with read schema {read_schema:#?}");
         let output_schema = DataType::Struct(Box::new(self.schema().as_ref().clone()));
-
-        // // start col_mapping hack
-        // let mut p = 0;
-        // let fields = self
-        //     .schema()
-        //     .fields()
-        //     .map(|field| {
-        //         let f =
-        //             StructField::new(format!("f{}", p), field.data_type().clone(), field.nullable);
-        //         p += 1;
-        //         f
-        //     })
-        //     .collect();
-        // // end hack
-        //let output_schema = DataType::Struct(Box::new(StructType::new(fields)));
         let parquet_handler = engine_interface.get_parquet_handler();
 
         let mut results: Vec<ScanResult> = vec![];

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -10,7 +10,7 @@ use deltakernel::client::default::executor::tokio::TokioBackgroundExecutor;
 use deltakernel::client::default::DefaultEngineInterface;
 use deltakernel::expressions::{BinaryOperator, Expression};
 use deltakernel::scan::ScanBuilder;
-use deltakernel::schema::{StructField, Schema};
+use deltakernel::schema::{Schema, StructField};
 use deltakernel::{EngineData, Table};
 use object_store::{memory::InMemory, path::Path, ObjectStore};
 use parquet::arrow::arrow_writer::ArrowWriter;
@@ -395,7 +395,11 @@ macro_rules! assert_batches_sorted_eq {
     };
 }
 
-fn read_table_data(path: &str, select_cols: Option<&[&str]>, expected: Vec<&str>) -> Result<(), Box<dyn std::error::Error>> {
+fn read_table_data(
+    path: &str,
+    select_cols: Option<&[&str]>,
+    expected: Vec<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let path = std::fs::canonicalize(PathBuf::from(path))?;
     let url = url::Url::from_directory_path(path).unwrap();
     let table_client = DefaultEngineInterface::try_new(
@@ -410,11 +414,10 @@ fn read_table_data(path: &str, select_cols: Option<&[&str]>, expected: Vec<&str>
 
     if let Some(select_cols) = select_cols {
         let table_schema = snapshot.schema();
-        let selected_fields: Vec<StructField> =
-            select_cols.iter()
-            .map(|col| {
-                table_schema.field(col).map(|f| f.clone()).unwrap()
-            }).collect();
+        let selected_fields: Vec<StructField> = select_cols
+            .iter()
+            .map(|col| table_schema.field(col).map(|f| f.clone()).unwrap())
+            .collect();
         let read_schema = Arc::new(Schema::new(selected_fields));
         scan_builder = scan_builder.with_schema(read_schema);
     }
@@ -471,7 +474,11 @@ fn column_ordering() -> Result<(), Box<dyn std::error::Error>> {
         "| 3.3     | c      | 3      |",
         "+---------+--------+--------+",
     ];
-    read_table_data("./tests/data/basic_partitioned", Some(&["a_float", "letter", "number"]), expected)?;
+    read_table_data(
+        "./tests/data/basic_partitioned",
+        Some(&["a_float", "letter", "number"]),
+        expected,
+    )?;
 
     Ok(())
 }
@@ -490,7 +497,11 @@ fn column_ordering_and_projection() -> Result<(), Box<dyn std::error::Error>> {
         "| 3.3     | 3      |",
         "+---------+--------+",
     ];
-    read_table_data("./tests/data/basic_partitioned", Some(&["a_float", "number"]), expected)?;
+    read_table_data(
+        "./tests/data/basic_partitioned",
+        Some(&["a_float", "number"]),
+        expected,
+    )?;
 
     Ok(())
 }

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -416,7 +416,7 @@ fn read_table_data(
         let table_schema = snapshot.schema();
         let selected_fields: Vec<StructField> = select_cols
             .iter()
-            .map(|col| table_schema.field(col).map(|f| f.clone()).unwrap())
+            .map(|col| table_schema.field(col).cloned().unwrap())
             .collect();
         let read_schema = Arc::new(Schema::new(selected_fields));
         scan_builder = scan_builder.with_schema(read_schema);

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -21,7 +21,7 @@ const PARQUET_FILE2: &str = "part-00001-c506e79a-0bf8-4e2b-a42b-9731b2e490ae-c00
 
 const METADATA: &str = r#"{"commitInfo":{"timestamp":1587968586154,"operation":"WRITE","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]"},"isBlindAppend":true}}
 {"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
-{"metaData":{"id":"5fba94ed-9794-4965-ba6e-6ee3c0d22af9","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}"#;
+{"metaData":{"id":"5fba94ed-9794-4965-ba6e-6ee3c0d22af9","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},{\"name\":\"val\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}"#;
 
 enum TestAction {
     Add(String),


### PR DESCRIPTION
This PR adds:

- push schema down into parquet reader
- use the schema to prune to only selected columns
- reorder columns read from parquet files into the order requested by the schema
- allow specifying columns to select in the `dump-table` command
- some tests for the above

Note that for now this only supports specifying root level columns. Nested support is future work.