### PR TITLE
Add backtrace option to errors

### DIFF
--- a/kernel/examples/dump-table/src/main.rs
+++ b/kernel/examples/dump-table/src/main.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::process::ExitCode;
 use std::sync::Arc;
 
 use arrow::compute::filter_record_batch;
@@ -40,8 +41,20 @@ enum Interface {
     Sync,
 }
 
-fn main() -> DeltaResult<()> {
+fn main() -> ExitCode {
     env_logger::init();
+    match try_main() {
+        Ok(()) => {
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            println!("{e:#?}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn try_main() -> DeltaResult<()> {
     let cli = Cli::parse();
     let url = url::Url::parse(&cli.path)?;
 

--- a/kernel/examples/dump-table/src/main.rs
+++ b/kernel/examples/dump-table/src/main.rs
@@ -44,9 +44,7 @@ enum Interface {
 fn main() -> ExitCode {
     env_logger::init();
     match try_main() {
-        Ok(()) => {
-            ExitCode::SUCCESS
-        }
+        Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             println!("{e:#?}");
             ExitCode::FAILURE

--- a/kernel/src/client/arrow_expression.rs
+++ b/kernel/src/client/arrow_expression.rs
@@ -163,14 +163,8 @@ fn evaluate_expression(
                 .iter()
                 .zip(schema.fields())
                 .map(|(expr, field)| evaluate_expression(expr, batch, Some(field.data_type())));
-            let mut fields = output_schema.all_fields();
-            fields.pop();
-            let fields: Vec<arrow_schema::Field> = fields.into_iter().cloned().collect();
-            let result = StructArray::try_new(
-                arrow_schema::Fields::from(fields),
-                columns.try_collect()?,
-                None,
-            )?;
+            let result =
+                StructArray::try_new(output_schema.fields().clone(), columns.try_collect()?, None)?;
             Ok(Arc::new(result))
         }
         (Struct(_), _) => Err(Error::generic(

--- a/kernel/src/client/arrow_expression.rs
+++ b/kernel/src/client/arrow_expression.rs
@@ -163,8 +163,11 @@ fn evaluate_expression(
                 .iter()
                 .zip(schema.fields())
                 .map(|(expr, field)| evaluate_expression(expr, batch, Some(field.data_type())));
+            let mut fields = output_schema.all_fields();
+            fields.pop();
+            let fields: Vec<arrow_schema::Field> = fields.into_iter().cloned().collect();
             let result =
-                StructArray::try_new(output_schema.fields().clone(), columns.try_collect()?, None)?;
+                StructArray::try_new(arrow_schema::Fields::from(fields), columns.try_collect()?, None)?;
             Ok(Arc::new(result))
         }
         (Struct(_), _) => Err(Error::generic(

--- a/kernel/src/client/arrow_expression.rs
+++ b/kernel/src/client/arrow_expression.rs
@@ -166,8 +166,11 @@ fn evaluate_expression(
             let mut fields = output_schema.all_fields();
             fields.pop();
             let fields: Vec<arrow_schema::Field> = fields.into_iter().cloned().collect();
-            let result =
-                StructArray::try_new(arrow_schema::Fields::from(fields), columns.try_collect()?, None)?;
+            let result = StructArray::try_new(
+                arrow_schema::Fields::from(fields),
+                columns.try_collect()?,
+                None,
+            )?;
             Ok(Arc::new(result))
         }
         (Struct(_), _) => Err(Error::generic(

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -10,6 +10,10 @@ pub type DeltaResult<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    // This is an error that includes a backtrace. To have a particular type of error include such
+    // backtrace (when RUST_BACKTRACE=1), annotate the error with `#[error(transparent)]` and then
+    // add the error type and enum variant to the `from_with_backtrace!` macro invocation below. See
+    // IOError for an example.
     #[error("{source}\n{backtrace}")]
     Backtraced {
         source: Box<Self>,
@@ -35,8 +39,8 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
-    #[error("IO error: {0}")]
-    IOError(#[from] std::io::Error),
+    #[error(transparent)]
+    IOError(std::io::Error),
 
     #[cfg(feature = "parquet")]
     #[error("Arrow error: {0}")]
@@ -73,8 +77,8 @@ pub enum Error {
     #[error("Invalid url: {0}")]
     InvalidUrl(#[from] url::ParseError),
 
-    #[error("Invalid url: {0}")]
-    MalformedJson(#[from] serde_json::Error),
+    #[error(transparent)]
+    MalformedJson(serde_json::Error),
 
     #[error("No table metadata found in delta log.")]
     MissingMetadata,
@@ -143,6 +147,23 @@ impl Error {
         }
     }
 }
+
+macro_rules! from_with_backtrace(
+    ( $(($error_type: ty, $error_variant: ident)), * ) => {
+        $(
+            impl From<$error_type> for Error {
+                fn from(value: $error_type) -> Self {
+                    Self::$error_variant(value).with_backtrace()
+                }
+            }
+        )*
+    };
+);
+
+from_with_backtrace!(
+    (serde_json::Error, MalformedJson),
+    (std::io::Error, IOError)
+);
 
 #[cfg(any(feature = "default-client", feature = "sync-client"))]
 impl From<arrow_schema::ArrowError> for Error {

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -1,4 +1,8 @@
-use std::{num::ParseIntError, string::FromUtf8Error, backtrace::{Backtrace, BacktraceStatus}};
+use std::{
+    backtrace::{Backtrace, BacktraceStatus},
+    num::ParseIntError,
+    string::FromUtf8Error,
+};
 
 use crate::schema::DataType;
 
@@ -135,18 +139,17 @@ impl Error {
                 source: Box::new(self),
                 backtrace: Box::new(backtrace),
             },
-            _ => self
+            _ => self,
         }
     }
 }
 
-#[cfg(feature = "object_store")]
+#[cfg(any(feature = "default-client", feature = "sync-client"))]
 impl From<arrow_schema::ArrowError> for Error {
     fn from(value: arrow_schema::ArrowError) -> Self {
         Self::Arrow(value).with_backtrace()
     }
 }
-
 
 #[cfg(feature = "object_store")]
 impl From<object_store::Error> for Error {


### PR DESCRIPTION
When debugging it can be difficult to know where an error occurred if  it is created in numerous places. For example, today if there's an error in expression eval and you run `dump-table`, you might simply see:

```
Error(Arrow(InvalidArgumentError("Incorrect number of arrays for StructArray fields, expected 2 got 3"))
```

But where in the numerous places arrow errors occur did this happen? Tracking this down can be tricky.

It turns out `thiserror` (the crate we use to create our `Error` class) does have support for backtrace capture (see the fourth code-block [here](https://docs.rs/thiserror/latest/thiserror/)). However, it relies on a nightly only api ([provide](https://doc.rust-lang.org/std/error/trait.Error.html#method.provide) which relies on [error_generic_member_access](https://github.com/rust-lang/rust/issues/99301)), so we can't use it.

This PR adds manual backtrace capture to our error type. We do this by:

1. Adding a method to wrap an existing error in a `Backtraced` variant, which captures the error and a backtrace
2. Manually implementing the `From` trait for errors where we want the backtrace.
3. Right now this is only done for `Arrow` errors, which are all over the place in our client code. But in the future, when debugging an issue, it will be easy to move other error types to do this as needed.

This means that for errors we add this manual `From`, a backtrace will be captured at the point they are converted into a `deltakernel::Error`. This is usually via a `?` somewhere in the kernel, so it is useful for debugging.

We also ensure that we only do this wrapping if backtracing is enabled (usually via `RUST_BACKTRACE=1`). Otherwise the wrapping method is a no-op, so this should have minimal perf impact.

Finally, we augment the `dump-table` command to pretty-print any errors it gets, which makes the backtrace more readable.

Now, we can get a nice error like this:
```
$ RUST_BACKTRACE=1 cargo run -- -- file:///home/nick/databricks/delta-kernel-rs/kernel/tests/data/basic_partitioned/
     Running `/home/nick/databricks/delta-kernel-rs/target/debug/dump-table -- 'file:///home/nick/databricks/delta-kernel-rs/kernel/tests/data/basic_partitioned/'`
Reading file:///home/nick/databricks/delta-kernel-rs/kernel/tests/data/basic_partitioned/
Backtraced {
    source: Arrow(
        InvalidArgumentError(
            "Incorrect number of arrays for StructArray fields, expected 2 got 3",
        ),
    ),
    backtrace: Backtrace [
        { fn: "deltakernel::error::Error::with_backtrace", file: "/home/nick/databricks/delta-kernel-rs/kernel/src/error.rs", line: 132 },
        { fn: "<deltakernel::error::Error as core::convert::From<arrow_schema::error::ArrowError>>::from", file: "/home/nick/databricks/delta-kernel-rs/kernel/src/error.rs", line: 146 },
        { fn: "<core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/result.rs", line: 1963 },
        { fn: "deltakernel::client::arrow_expression::evaluate_expression", file: "/home/nick/databricks/delta-kernel-rs/kernel/src/client/arrow_expression.rs", line: 170 },
        { fn: "<deltakernel::client::arrow_expression::DefaultExpressionEvaluator as deltakernel::ExpressionEvaluator>::evaluate", file: "/home/nick/databricks/delta-kernel-rs/kernel/src/client/arrow_expression.rs", line: 271 },
        { fn: "deltakernel::scan::Scan::execute", file: "/home/nick/databricks/delta-kernel-rs/kernel/src/scan/mod.rs", line: 249 },
        { fn: "dump_table::try_main", file: "./src/main.rs", line: 72 },
        { fn: "dump_table::main", file: "./src/main.rs", line: 41 },
        { fn: "core::ops::function::FnOnce::call_once", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs", line: 250 },
        { fn: "std::sys_common::backtrace::__rust_begin_short_backtrace", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs", line: 154 },
        { fn: "std::rt::lang_start::{{closure}}", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/rt.rs", line: 167 },
        { fn: "core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs", line: 284 },
        { fn: "std::panicking::try::do_call", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs", line: 552 },
        { fn: "std::panicking::try", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs", line: 516 },
        { fn: "std::panic::catch_unwind", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panic.rs", line: 142 },
        { fn: "std::rt::lang_start_internal::{{closure}}", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/rt.rs", line: 148 },
        { fn: "std::panicking::try::do_call", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs", line: 552 },
        { fn: "std::panicking::try", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs", line: 516 },
        { fn: "std::panic::catch_unwind", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panic.rs", line: 142 },
        { fn: "std::rt::lang_start_internal", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/rt.rs", line: 148 },
        { fn: "std::rt::lang_start", file: "/rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/rt.rs", line: 166 },
        { fn: "main" },
        { fn: "__libc_start_main" },
        { fn: "_start" },
    ],
}
```

We should be able to revert back to automatic backtracing via `thiserror` when `error_generic_member_access` stabilizes.