### PR TITLE
Read and verify dat data + initial bit of timestamp_ntz

### DIFF
--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -11,7 +11,10 @@ readme.workspace = true
 version.workspace = true
 
 [dependencies]
-arrow = { version = "^49.0", features = ["json", "prettyprint"] }
+arrow-array = { version = "^49.0" }
+arrow-ord = { version = "^49.0" }
+arrow-select = { version = "^49.0" }
+arrow-schema = { version = "^49.0" }
 deltakernel = { path = "../kernel", features = ["default-client", "developer-visibility"] }
 futures = "0.3"
 object_store = "^0.8.0"

--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -11,9 +11,11 @@ readme.workspace = true
 version.workspace = true
 
 [dependencies]
-deltakernel = { path = "../kernel", features = ["developer-visibility"] }
+arrow = { version = "^49.0", features = ["json", "prettyprint"] }
+deltakernel = { path = "../kernel", features = ["default-client", "developer-visibility"] }
 futures = "0.3"
 object_store = "^0.8.0"
+parquet = { version = "^49.0" , features = ["object_store"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
@@ -25,7 +27,6 @@ flate2 = "1.0"
 tar = "0.4"
 
 [dev-dependencies]
-arrow = { version = "^49.0", features = ["json", "prettyprint"] }
 datatest-stable = "0.2"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tempfile = "3"

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use arrow::{
     compute::{concat_batches, filter_record_batch, lexsort_to_indices, take, SortColumn},
@@ -12,7 +12,7 @@ use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStream
 
 use crate::{TestCaseInfo, TestResult};
 
-pub async fn read_golden(path: &PathBuf, _version: Option<&str>) -> Option<RecordBatch> {
+pub async fn read_golden(path: &Path, _version: Option<&str>) -> Option<RecordBatch> {
     let expected_root = path.join("expected").join("latest").join("table_content");
     let store = Arc::new(LocalFileSystem::new_with_prefix(&expected_root).unwrap());
     let files = store.list(None).try_collect::<Vec<_>>().await.unwrap();
@@ -55,7 +55,7 @@ pub fn sort_record_batch(batch: RecordBatch) -> RecordBatch {
     let columns = batch
         .columns()
         .iter()
-        .map(|c| take(&*c, &indices, None).unwrap())
+        .map(|c| take(c, &indices, None).unwrap())
         .collect();
     RecordBatch::try_new(batch.schema(), columns).unwrap()
 }

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
-use arrow::{
-    compute::{concat_batches, filter_record_batch, lexsort_to_indices, take, SortColumn},
-    datatypes::DataType,
-    record_batch::RecordBatch,
-};
+use arrow_array::RecordBatch;
+use arrow_ord::sort::{lexsort_to_indices, SortColumn};
+use arrow_schema::DataType;
+use arrow_select::{concat::concat_batches, filter::filter_record_batch, take::take};
+
 use deltakernel::{client::arrow_data::ArrowEngineData, scan::ScanBuilder, EngineInterface, Table};
 use futures::{stream::TryStreamExt, StreamExt};
 use object_store::{local::LocalFileSystem, ObjectStore};

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -63,7 +63,7 @@ pub fn sort_record_batch(batch: RecordBatch) -> RecordBatch {
 static SKIPPED_TESTS: &[&str; 3] = &[
     // Kernel does not support column mapping yet
     "column_mapping",
-    // We don't support iceberg yet
+    // iceberg compat requires column mapping
     "iceberg_compat_v1",
     // For multi_partitioned_2: The golden table stores the timestamp as an INT96 (which is
     // nanosecond precision), while the spec says we should read partition columns as

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -1,0 +1,128 @@
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+use arrow::{
+    compute::{concat_batches, filter_record_batch, lexsort_to_indices, take, SortColumn},
+    datatypes::DataType,
+    record_batch::RecordBatch,
+};
+use deltakernel::{client::arrow_data::ArrowEngineData, scan::ScanBuilder, EngineInterface, Table};
+use futures::{stream::TryStreamExt, StreamExt};
+use object_store::{local::LocalFileSystem, ObjectStore};
+use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
+
+use crate::{TestCaseInfo, TestResult};
+
+pub async fn read_golden(path: &PathBuf, _version: Option<&str>) -> Option<RecordBatch> {
+    let expected_root = path.join("expected").join("latest").join("table_content");
+    let store = Arc::new(LocalFileSystem::new_with_prefix(&expected_root).unwrap());
+    let files = store.list(None).try_collect::<Vec<_>>().await.unwrap();
+    let mut batches = vec![];
+    let mut schema = None;
+    for meta in files.into_iter() {
+        if let Some(ext) = meta.location.extension() {
+            if ext == "parquet" {
+                let reader = ParquetObjectReader::new(store.clone(), meta);
+                let builder = ParquetRecordBatchStreamBuilder::new(reader).await.unwrap();
+                if schema.is_none() {
+                    schema = Some(builder.schema().clone());
+                }
+                let mut stream = builder.build().unwrap();
+                while let Some(batch) = stream.next().await {
+                    batches.push(batch.unwrap());
+                }
+            }
+        }
+    }
+    let all_data = concat_batches(&schema.unwrap(), batches.iter()).unwrap();
+    Some(all_data)
+}
+
+pub fn sort_record_batch(batch: RecordBatch) -> RecordBatch {
+    // Sort by all columns
+    let mut sort_columns = vec![];
+    for col in batch.columns() {
+        match col.data_type() {
+            DataType::Struct(_) | DataType::List(_) | DataType::Map(_, _) => {
+                // can't sort structs, lists, or maps
+            }
+            _ => sort_columns.push(SortColumn {
+                values: col.clone(),
+                options: None,
+            }),
+        }
+    }
+    let indices = lexsort_to_indices(&sort_columns, None).unwrap();
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|c| take(&*c, &indices, None).unwrap())
+        .collect();
+    RecordBatch::try_new(batch.schema(), columns).unwrap()
+}
+
+pub async fn assert_scan_data(
+    engine_interface: Arc<dyn EngineInterface>,
+    test_case: &TestCaseInfo,
+) -> TestResult<()> {
+    let root_dir = test_case.root_dir();
+    // if root_dir.ends_with("multi_partitioned_2") {
+    //     // Skip this test. The golden table stores the timestamp as an INT96 (which is nanosecond
+    //     // precision), while the spec says we should read partition columns as microseconds. This
+    //     // means the read and golden data don't line up. When this is fixed in `dat` upstream, we
+    //     // can remove this early return
+    //     return Ok(());
+    // }
+    let engine_interface = engine_interface.as_ref();
+    let table_root = test_case.table_root()?;
+    let table = Table::new(table_root);
+    let snapshot = table.snapshot(engine_interface, None)?;
+    let scan = ScanBuilder::new(snapshot).build();
+    let mut schema = None;
+    let batches: Vec<RecordBatch> = scan
+        .execute(engine_interface)?
+        .into_iter()
+        .map(|res| {
+            let data = res.raw_data.unwrap();
+            let record_batch: RecordBatch = data
+                .into_any()
+                .downcast::<ArrowEngineData>()
+                .unwrap()
+                .into();
+            if schema.is_none() {
+                schema = Some(record_batch.schema());
+            }
+            if let Some(mask) = res.mask {
+                filter_record_batch(&record_batch, &mask.into()).unwrap()
+            } else {
+                record_batch
+            }
+        })
+        .collect();
+    let all_data = concat_batches(&schema.unwrap(), batches.iter()).unwrap();
+    let all_data = sort_record_batch(all_data);
+
+    let golden = read_golden(test_case.root_dir(), None)
+        .await
+        .expect("Didn't find golden data");
+    let golden = sort_record_batch(golden);
+    let golden_schema = golden
+        .schema()
+        .as_ref()
+        .clone()
+        .with_metadata(HashMap::new());
+
+    assert!(
+        all_data.columns() == golden.columns(),
+        "Read data does not equal golden data"
+    );
+    assert!(
+        all_data.schema() == Arc::new(golden_schema),
+        "Schemas not equal"
+    );
+    assert!(
+        all_data.num_rows() == golden.num_rows(),
+        "Didn't have same number of rows"
+    );
+
+    Ok(())
+}

--- a/acceptance/src/lib.rs
+++ b/acceptance/src/lib.rs
@@ -1,4 +1,5 @@
 //! Helpers to validate Engineinterface implementations
 
+pub mod data;
 pub mod meta;
 pub use meta::*;

--- a/acceptance/src/meta.rs
+++ b/acceptance/src/meta.rs
@@ -42,6 +42,10 @@ impl TestCaseInfo {
         Url::from_directory_path(table_root).map_err(|_| AssertionError::InvalidTestCase)
     }
 
+    pub fn root_dir(&self) -> &PathBuf {
+        &self.root_dir
+    }
+
     async fn versions(&self) -> TestResult<(TableVersionMetaData, Vec<TableVersionMetaData>)> {
         let expected_root = self.root_dir.join("expected");
         let store = LocalFileSystem::new_with_prefix(&expected_root).unwrap();

--- a/acceptance/tests/dat_reader.rs
+++ b/acceptance/tests/dat_reader.rs
@@ -30,6 +30,9 @@ fn reader_test(path: &Path) -> datatest_stable::Result<()> {
             case.assert_metadata(engine_interface.clone())
                 .await
                 .unwrap();
+            acceptance::data::assert_scan_data(engine_interface.clone(), &case)
+                .await
+                .unwrap();
         });
     Ok(())
 }

--- a/kernel/src/client/arrow_conversion.rs
+++ b/kernel/src/client/arrow_conversion.rs
@@ -111,6 +111,9 @@ impl TryFrom<&DataType> for ArrowDataType {
                         // Issue: https://github.com/delta-io/delta/issues/643
                         Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
                     }
+                    PrimitiveType::TimestampNtz => {
+                        Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
+                    }
                 }
             }
             DataType::Struct(s) => Ok(ArrowDataType::Struct(

--- a/kernel/src/client/arrow_expression.rs
+++ b/kernel/src/client/arrow_expression.rs
@@ -59,7 +59,7 @@ impl Scalar {
                     PrimitiveType::Double => Arc::new(Float64Array::new_null(num_rows)),
                     PrimitiveType::String => Arc::new(StringArray::new_null(num_rows)),
                     PrimitiveType::Boolean => Arc::new(BooleanArray::new_null(num_rows)),
-                    PrimitiveType::Timestamp => {
+                    PrimitiveType::Timestamp | PrimitiveType::TimestampNtz => {
                         Arc::new(TimestampMicrosecondArray::new_null(num_rows))
                     }
                     PrimitiveType::Date => Arc::new(Date32Array::new_null(num_rows)),

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -179,7 +179,8 @@ impl PrimitiveType {
                 let days = date.signed_duration_since(*UNIX_EPOCH).num_days() as i32;
                 Ok(Scalar::Date(days))
             }
-            Timestamp => {
+            // TODO: Handle timezones properly
+            Timestamp | TimestampNtz => {
                 let timestamp = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f")
                     .map_err(|_| self.parse_error(raw))?;
                 let timestamp = Utc.from_utc_datetime(&timestamp);

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -317,6 +317,8 @@ pub enum PrimitiveType {
     Date,
     /// Microsecond precision timestamp, adjusted to UTC.
     Timestamp,
+    #[serde(rename = "timestamp_ntz")]
+    TimestampNtz,
     // TODO: timestamp without timezone
     #[serde(
         serialize_with = "serialize_decimal",
@@ -377,6 +379,7 @@ impl Display for PrimitiveType {
             PrimitiveType::Binary => write!(f, "binary"),
             PrimitiveType::Date => write!(f, "date"),
             PrimitiveType::Timestamp => write!(f, "timestamp"),
+            PrimitiveType::TimestampNtz => write!(f, "timestamp_ntz"),
             PrimitiveType::Decimal(precision, scale) => {
                 write!(f, "decimal({}, {})", precision, scale)
             }


### PR DESCRIPTION
This PR does two things:

1. Actually read and verify against the dat golden data
2. Add a `TimestampNtz` type so we can at least de-serialize schemas that mention it

adding `timestamp_ntz` is trivial. it's just a new type and copying what we're already doing for timestamp. Obviously more work to be done on the parquet reader to make this "correct".