### PR TITLE
Split scan execute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "ffi",
     "kernel",
     "kernel/examples/dump-table", # todo: put back to `examples/*` when inspect-table is fixed
+    "kernel/examples/read-table-multi-threaded"
 ]
 # Only check / build main crates by default (check all with `--workspace`)
 default-members = ["acceptance", "kernel"]

--- a/ffi/cffi-test.c
+++ b/ffi/cffi-test.c
@@ -7,6 +7,13 @@ void visit_file(void *engine_context, struct KernelStringSlice file_name) {
     printf("file: %s\n", file_name.ptr);
 }
 
+void visit_data(void *engine_context, void *engine_data, struct KernelBoolSlice *selection_vec) {
+  printf("Got some data\n");
+  for (int i = 0; i < selection_vec->len; i++) {
+    printf("sel[i] = %b\n", selection_vec->ptr[i]);
+  }
+}
+
 int main(int argc, char* argv[]) {
 
   if (argc < 2) {
@@ -60,6 +67,29 @@ int main(int argc, char* argv[]) {
   }
 
   kernel_scan_files_free(file_iter);
+
+  ExternResult_____KernelScanDataIterator data_iter_res =
+    kernel_scan_data_init(snapshot_handle, table_client, NULL);
+  if (data_iter_res.tag != Ok_____KernelScanDataIterator) {
+    printf("Failed to construct scan dta iterator\n");
+    return -1;
+  }
+
+  KernelScanDataIterator *data_iter = data_iter_res.ok;
+
+  // iterate scan files
+  for (;;) {
+    ExternResult_bool ok_res = kernel_scan_data_next(data_iter, NULL, visit_data);
+    if (ok_res.tag != Ok_bool) {
+      printf("Failed to iterate scan data\n");
+      return -1;
+    } else if (!ok_res.ok) {
+      break;
+    }
+  }
+
+  kernel_scan_data_free(data_iter);
+
   drop_snapshot(snapshot_handle);
   drop_table_client(table_client);
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -15,7 +15,7 @@ use delta_kernel::expressions::{BinaryOperator, Expression, Scalar};
 use delta_kernel::scan::ScanBuilder;
 use delta_kernel::schema::{DataType, PrimitiveType, StructField, StructType};
 use delta_kernel::snapshot::Snapshot;
-use delta_kernel::{DeltaResult, EngineInterface, Error};
+use delta_kernel::{DeltaResult, EngineInterface, Error, EngineData};
 
 mod handle;
 use handle::{ArcHandle, BoxHandle, SizedArcHandle, Unconstructable};
@@ -109,6 +109,31 @@ impl TryFromStringSlice for String {
         std::str::from_utf8(slice).unwrap().to_string()
     }
 }
+
+/// TODO
+#[repr(C)]
+pub struct KernelBoolSlice {
+    ptr: *const bool,
+    len: usize,
+}
+
+impl Into<KernelBoolSlice> for Vec<bool> {
+    fn into(self) -> KernelBoolSlice {
+        let len = self.len();
+        let boxed = self.into_boxed_slice();
+        KernelBoolSlice {
+            ptr: Box::into_raw(boxed).cast(),
+            len
+        }
+    }
+}
+
+impl Drop for KernelBoolSlice {
+    fn drop(&mut self) {
+        let _ = unsafe { Box::from_raw(self.ptr as *mut bool) };
+    }
+}
+
 
 #[repr(C)]
 #[derive(Debug)]
@@ -707,6 +732,105 @@ pub extern "C" fn visit_expression_literal_long(
     value: i64,
 ) -> usize {
     wrap_expression(state, Expression::Literal(Scalar::from(value)))
+}
+
+// Intentionally opaque to the engine.
+pub struct KernelScanDataIterator {
+    // Box -> Wrap its unsized content this struct is fixed-size with thin pointers.
+    // Item = String -> Owned items because rust can't correctly express lifetimes for borrowed items
+    // (we would need a way to assert that item lifetimes are bounded by the iterator's lifetime).
+    data: Box<dyn Iterator<Item = DeltaResult<(Box<dyn EngineData>, Vec<bool>)>>>,
+
+    // Also keep a reference to the external client for its error allocator.
+    // Parquet and Json handlers don't hold any reference to the tokio reactor, so the iterator
+    // terminates early if the last table client goes out of scope.
+    table_client: Arc<dyn ExternEngineInterface>,
+}
+
+impl BoxHandle for KernelScanDataIterator {}
+
+impl Drop for KernelScanDataIterator {
+    fn drop(&mut self) {
+        debug!("dropping KernelScanDataIterator");
+    }
+}
+
+
+/// Get the data needed to perform a scan
+#[no_mangle]
+pub unsafe extern "C" fn kernel_scan_data_init(
+    snapshot: *const SnapshotHandle,
+    table_client: *const ExternEngineInterfaceHandle,
+    predicate: Option<&mut EnginePredicate>,
+) -> ExternResult<*mut KernelScanDataIterator> {
+    kernel_scan_data_init_impl(snapshot, table_client, predicate).into_extern_result(table_client)
+}
+
+fn kernel_scan_data_init_impl(
+    snapshot: *const SnapshotHandle,
+    extern_table_client: *const ExternEngineInterfaceHandle,
+    predicate: Option<&mut EnginePredicate>,
+) -> DeltaResult<*mut KernelScanDataIterator> {
+    let snapshot = unsafe { ArcHandle::clone_as_arc(snapshot) };
+    let extern_table_client = unsafe { ArcHandle::clone_as_arc(extern_table_client) };
+    let mut scan_builder = ScanBuilder::new(snapshot.clone());
+    if let Some(predicate) = predicate {
+        let mut visitor_state = KernelExpressionVisitorState::new();
+        let exprid = (predicate.visitor)(predicate.predicate, &mut visitor_state);
+        if let Some(predicate) = unwrap_kernel_expression(&mut visitor_state, exprid) {
+            debug!("Got predicate: {}", predicate);
+            scan_builder = scan_builder.with_predicate(predicate);
+        }
+    }
+    let scan_data = scan_builder
+        .build()
+        .scan_data(extern_table_client.table_client().as_ref())?;
+    let data = KernelScanDataIterator {
+        data: Box::new(scan_data),
+        table_client: extern_table_client,
+    };
+    Ok(data.into_handle())
+}
+
+/// # Safety
+///
+/// The iterator must be valid (returned by [kernel_scan_data_init]) and not yet freed by
+/// [kernel_scan_data_free]. The visitor function pointer must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn kernel_scan_data_next(
+    data: &mut KernelScanDataIterator,
+    engine_context: *mut c_void,
+    engine_visitor: extern "C" fn(engine_context: *mut c_void, engine_data: *mut c_void, selection_vector: &KernelBoolSlice),
+) -> ExternResult<bool> {
+    kernel_scan_data_next_impl(data, engine_context, engine_visitor)
+        .into_extern_result(data.table_client.error_allocator())
+}
+fn kernel_scan_data_next_impl(
+    data: &mut KernelScanDataIterator,
+    engine_context: *mut c_void,
+    engine_visitor: extern "C" fn(engine_context: *mut c_void, engine_data: *mut c_void, selection_vector: &KernelBoolSlice),
+) -> DeltaResult<bool> {
+    if let Some((data, sel_vec)) = data.data.next().transpose()? {
+        let bool_slice: KernelBoolSlice = sel_vec.into();
+        let data_ptr = Box::into_raw(data);
+        (engine_visitor)(engine_context, data_ptr.cast(), &bool_slice);
+        // ensure we free the data
+        let _ = unsafe { Box::from_raw(data_ptr) };
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// # Safety
+///
+/// Caller is responsible to (at most once) pass a valid pointer returned by a call to
+/// [kernel_scan_files_init].
+// we should probably be consistent with drop vs. free on engine side (probably the latter is more
+// intuitive to non-rust code)
+#[no_mangle]
+pub unsafe extern "C" fn kernel_scan_data_free(data: *mut KernelScanDataIterator) {
+    BoxHandle::drop_handle(data);
 }
 
 // Intentionally opaque to the engine.

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "read-table-multi-threaded"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+arrow = { version = "^49.0", features = ["prettyprint"] }
+clap = { version = "^4.4", features = ["derive"] }
+deltakernel = { path = "../../../kernel", features = [
+  "default-client",
+  "tokio",
+  "developer-visibility",
+] }
+env_logger = "0.11.3"
+itertools = "0.12.1"
+url = "2"
+

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -14,5 +14,6 @@ deltakernel = { path = "../../../kernel", features = [
 ] }
 env_logger = "0.11.3"
 itertools = "0.12.1"
+spmc = "0.3.0"
 url = "2"
 

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 arrow = { version = "^49.0", features = ["prettyprint"] }
 clap = { version = "^4.4", features = ["derive"] }
-deltakernel = { path = "../../../kernel", features = [
+delta_kernel = { path = "../../../kernel", features = [
   "default-client",
   "tokio",
   "developer-visibility",

--- a/kernel/examples/read-table-multi-threaded/README.md
+++ b/kernel/examples/read-table-multi-threaded/README.md
@@ -1,0 +1,20 @@
+Read Table Multi-Threaded
+=========================
+
+This example shows a program that reads a table using multiple threads. This shows the use of the
+`scan_files` and `scan_state` methods on a Scan, that can be used to partition work to either
+multiple threads, or workers (in the case of a distributed engine).
+
+We use a single-producer-multi-consumer channel to send each file and its metadata (in the form of a
+[`ScanFile`]) that needs to be read out to a pool of threads. Each thread reads from the channel,
+and then processes any files it receives. The results are sent back as Arrow `RecordBatch`s on a
+mutli-producer-single-consumer channel.
+
+Once the main thread has sent all the files out, we close the `ScanFile` sender, which means that
+once the last `ScanFile` has been received by a thread, subsequent `recv` calls in any thread will
+start to return errors. The threads take this as a signal to shut down.
+
+We also ensure that _only_ the threads have copies of the `Sender`s used to send the `RecordBatch`s,
+by closing the copy that the main thread has once all the threads have been created. This means that
+we can simply loop over our `RecordBatch` receiver, because it will return results until the last
+thread has exited (which closes that last sender).

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -192,15 +192,15 @@ fn do_work(
                 // meta-data was passed to each thread to correctly apply the selection vector
 
                 // build the required metadata and ask our parquet handler to read it.
-                let meta = &[FileMeta {
+                let meta = FileMeta {
                     last_modified: 0,
                     size: scan_file.size,
                     location: scan_file.location().unwrap(),
-                }];
+                };
                 // could push selection_vector into the read here if desired
                 let read_results = engine_interface
                     .get_parquet_handler()
-                    .read_parquet_files(meta, scan_state.read_schema(), None)
+                    .read_parquet_files(&[meta], scan_state.read_schema(), None)
                     .unwrap();
 
                 for read_result in read_results {

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -4,19 +4,23 @@ use std::sync::mpsc::Sender;
 use std::sync::{mpsc, Arc};
 use std::thread;
 
+use arrow::array::{Array, AsArray, MapArray};
 use arrow::compute::filter_record_batch;
+use arrow::datatypes::{Int32Type, Int64Type};
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::print_batches;
+use delta_kernel::actions::deletion_vector::DeletionVectorDescriptor;
 use delta_kernel::client::arrow_data::ArrowEngineData;
 use delta_kernel::client::default::executor::tokio::TokioBackgroundExecutor;
 use delta_kernel::client::default::DefaultEngineInterface;
 use delta_kernel::client::sync::SyncEngineInterface;
-use delta_kernel::scan::ScanFile;
-use delta_kernel::scan::{state::ScanState, transform_to_logical, ScanBuilder};
+use delta_kernel::scan::state::GlobalScanState;
+use delta_kernel::scan::{transform_to_logical, ScanBuilder};
 use delta_kernel::schema::Schema;
-use delta_kernel::{DeltaResult, EngineInterface, FileMeta, Table};
+use delta_kernel::{DeltaResult, EngineData, EngineInterface, FileMeta, Table};
 
 use clap::{Parser, ValueEnum};
+use url::Url;
 
 /// An example program that reads a table using multiple threads. This shows the use of the
 /// scan_files and scan_state methods on a Scan, that can be used to partition work to either
@@ -28,9 +32,9 @@ struct Cli {
     /// Path to the table to inspect
     path: String,
 
-    /// how many threads to read with
-    #[arg(short, long, default_value_t = 2)]
-    thread_count: usize,
+    /// how many threads to read with (1 - 2048)
+    #[arg(short, long, default_value_t = 2, value_parser = 1..=2048)]
+    thread_count: i64,
 
     /// Which EngineInterface to use
     #[arg(short, long, value_enum, default_value_t = Interface::Default)]
@@ -58,6 +62,97 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+// package up dv info as primitive types
+struct DvInfo {
+    storage_type: String,
+    path_or_inline_dv: String,
+    offset: Option<i32>,
+    size_in_bytes: i32,
+    cardinality: i64,
+}
+
+// the way we as a connector represent data to scan. this is computed from the raw data returned
+// from the scan, and could be any format the engine chooses to use to facilitate distributing work.
+struct ScanFile {
+    path: String,
+    size: usize,
+    partition_values: HashMap<String, String>,
+    dv_info: Option<DvInfo>,
+}
+
+// TODO(nick): Maybe move all the arrow support code into a module so it looks less scary
+
+// we know we're using arrow under the hood, so cast an EngineData into something we can work with
+fn to_arrow(data: Box<dyn EngineData>) -> DeltaResult<RecordBatch> {
+    Ok(data
+        .into_any()
+        .downcast::<ArrowEngineData>()
+        .map_err(|_| delta_kernel::Error::EngineDataType("ArrowEngineData".to_string()))?
+        .into())
+}
+
+// turn an entry in a MapArray into a HashMap
+fn materialize(arry: &MapArray, row_index: usize) -> HashMap<String, String> {
+    let mut ret = HashMap::new();
+    let map_val = arry.value(row_index);
+    let keys = map_val.column(0).as_string::<i32>();
+    let values = map_val.column(1).as_string::<i32>();
+    for (key, value) in keys.iter().zip(values.iter()) {
+        if let (Some(key), Some(value)) = (key, value) {
+            ret.insert(key.into(), value.into());
+        }
+    }
+    ret
+}
+
+// turn our record batch iteratively into ScanFiles. This looks messy, but it's really just
+// iterating the RecordBatch and pulling out the required information
+fn get_scan_files(
+    batch: RecordBatch,
+    selection_vector: Vec<bool>,
+) -> DeltaResult<impl Iterator<Item = ScanFile>> {
+    Ok((0..batch.num_rows()).filter_map(move |row_index| {
+        if selection_vector[row_index] {
+            let path_col = batch.column(0).as_string::<i32>();
+            let size_col = batch.column(1).as_primitive::<Int64Type>();
+
+            let dv_col = batch.column(3).as_struct();
+            let storage_col = dv_col.column(0).as_string::<i32>();
+            let dv_info = if storage_col.is_valid(row_index) {
+                let dv_path_col = dv_col.column(1).as_string::<i32>();
+                let offset_col = dv_col.column(2).as_primitive::<Int32Type>();
+                let size_in_bytes_col = dv_col.column(3).as_primitive::<Int32Type>();
+                let cardinality_col = dv_col.column(4).as_primitive::<Int64Type>();
+                Some(DvInfo {
+                    storage_type: storage_col.value(row_index).to_string(),
+                    path_or_inline_dv: dv_path_col.value(row_index).to_string(),
+                    offset: if offset_col.is_valid(row_index) {
+                        Some(offset_col.value(row_index))
+                    } else {
+                        None
+                    },
+                    size_in_bytes: size_in_bytes_col.value(row_index),
+                    cardinality: cardinality_col.value(row_index),
+                })
+            } else {
+                None
+            };
+
+            let constant_vals = batch.column(4).as_struct();
+            let partition_col = constant_vals.column(0).as_map();
+            let partition_values = materialize(partition_col, row_index);
+            Some(ScanFile {
+                path: path_col.value(row_index).to_string(),
+                size: size_col.value(row_index) as usize,
+                partition_values,
+                dv_info,
+            })
+        } else {
+            None
+        }
+    }))
 }
 
 fn try_main() -> DeltaResult<()> {
@@ -106,9 +201,12 @@ fn try_main() -> DeltaResult<()> {
         .with_schema_opt(read_schema_opt)
         .build();
 
-    // this gives us an iterator of `ScanFile`s, which are just paths and metadata for the files
-    // that make up the table
-    let scan_files = scan.scan_files(engine_interface.as_ref())?;
+    // this gives us an iterator of (our engine data, selection vector). our engine data is just
+    // arrow data. The schema is (TODO link to schema)
+    let scan_data = scan.scan_data(engine_interface.as_ref())?;
+
+    // get any global state associated with this scan
+    let global_state = scan.global_scan_state();
 
     // create the channels we'll use. record_batch_[t/r]x are used for the threads to send back the
     // processed RecordBatches to themain thread
@@ -125,7 +223,7 @@ fn try_main() -> DeltaResult<()> {
         .map(|_| {
             // items that we need to send to the other thread
             //let interface = cli.interface.clone();
-            let scan_state = scan.get_scan_state().into_owned();
+            let scan_state = global_state.clone();
             let rb_tx = record_batch_tx.clone();
             let scan_file_rx = scan_file_rx.clone();
             let interface = engine_interface.clone();
@@ -140,9 +238,12 @@ fn try_main() -> DeltaResult<()> {
     drop(record_batch_tx);
 
     // send out each scan file
-    for scan_file in scan_files {
-        let scan_file = scan_file?;
-        scan_file_tx.send(scan_file).unwrap();
+    for res in scan_data {
+        let (data, vector) = res?;
+        let batch = to_arrow(data)?;
+        for scan_file in get_scan_files(batch, vector)? {
+            scan_file_tx.send(scan_file).unwrap();
+        }
     }
 
     // have sent all scan files, drop this so threads will exit when there's no more work
@@ -157,39 +258,53 @@ fn try_main() -> DeltaResult<()> {
 // this is the work each thread does
 fn do_work(
     engine_interface: Arc<Box<dyn EngineInterface>>,
-    scan_state: ScanState<'_>,
+    scan_state: GlobalScanState,
     record_batch_tx: Sender<RecordBatch>,
     scan_file_rx: spmc::Receiver<ScanFile>,
 ) {
     // get the type for the function calls
     let engine_interface: &dyn EngineInterface = engine_interface.as_ref().as_ref();
+    let read_schema = Arc::new(scan_state.read_schema.clone());
     loop {
         // in a loop, try and get a ScanFile
         match scan_file_rx.recv() {
             Ok(scan_file) => {
                 // we got a scan file, let's process it
 
+                let root_url = Url::parse(&scan_state.table_root).unwrap();
+
                 // get the selection vector (i.e. deletion vector)
-                let mut selection_vector = scan_file
-                    .selection_vector(engine_interface)
-                    .unwrap();
+                let mut selection_vector = scan_file.dv_info.map(|info| {
+                    let descriptor = DeletionVectorDescriptor::new(
+                        info.storage_type,
+                        info.path_or_inline_dv,
+                        info.offset,
+                        info.size_in_bytes,
+                        info.cardinality,
+                    );
+                    delta_kernel::scan::selection_vector(engine_interface, &descriptor, &root_url)
+                        .unwrap()
+                });
 
-                // this example uses the parquet_handler from the engine_client, but an engine could
-                // choose to use whatever method it might want to read a parquet file. further
-                // parallelism would be possible here as we could read the parquet file in chunks
-                // where each thread reads one chunk. The engine would need to ensure enough
-                // meta-data was passed to each thread to correctly apply the selection vector
-
-                // build the required metadata and ask our parquet handler to read it.
+                // build the required metadata for our parquet handler to read this file
+                let location = root_url.join(&scan_file.path).unwrap();
                 let meta = FileMeta {
                     last_modified: 0,
                     size: scan_file.size,
-                    location: scan_file.location().unwrap(),
+                    location,
                 };
-                // could push selection_vector into the read here if desired
+
+                // this example uses the parquet_handler from the engine_client, but an engine could
+                // choose to use whatever method it might want to read a parquet file. The reader
+                // could, for example, fill in the parition columns, or apply deletion vectors. Here
+                // we assume a more naive parquet reader and fix the data up after the fact.
+                // further parallelism would also be possible here as we could read the parquet file
+                // in chunks where each thread reads one chunk. The engine would need to ensure
+                // enough meta-data was passed to each thread to correctly apply the selection
+                // vector
                 let read_results = engine_interface
                     .get_parquet_handler()
-                    .read_parquet_files(&[meta], scan_state.read_schema(), None)
+                    .read_parquet_files(&[meta], read_schema.clone(), None)
                     .unwrap();
 
                 for read_result in read_results {
@@ -199,25 +314,16 @@ fn do_work(
                         0
                     };
 
-                    // ask the kernel to transform the physical data into the correct logical form
+                    // // ask the kernel to transform the physical data into the correct logical form
                     let logical = transform_to_logical(
                         engine_interface,
                         read_result.unwrap(),
                         &scan_state,
-                        &scan_file,
+                        &scan_file.partition_values,
                     )
                     .unwrap();
 
-                    // we know we're using arrow under the hood, so cast this into something we can
-                    // work with
-                    let record_batch: RecordBatch = logical
-                        .into_any()
-                        .downcast::<ArrowEngineData>()
-                        .map_err(|_| {
-                            delta_kernel::Error::EngineDataType("ArrowEngineData".to_string())
-                        })
-                        .unwrap()
-                        .into();
+                    let record_batch = to_arrow(logical).unwrap();
 
                     // need to split the dv_mask. what's left in dv_mask covers this result, and rest
                     // will cover the following results
@@ -229,6 +335,7 @@ fn do_work(
                         record_batch
                     };
                     selection_vector = rest;
+
                     // send back the processed result
                     record_batch_tx.send(batch).unwrap();
                 }

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -1,0 +1,145 @@
+use std::collections::HashMap;
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use arrow::compute::filter_record_batch;
+use arrow::record_batch::RecordBatch;
+use arrow::util::pretty::print_batches;
+use deltakernel::client::arrow_data::ArrowEngineData;
+use deltakernel::client::default::executor::tokio::TokioBackgroundExecutor;
+use deltakernel::client::default::DefaultEngineInterface;
+use deltakernel::client::sync::SyncEngineInterface;
+use deltakernel::scan::{ScanBuilder, transform_to_logical};
+use deltakernel::schema::Schema;
+use deltakernel::{DeltaResult, EngineInterface, FileMeta, Table};
+
+use clap::{Parser, ValueEnum};
+
+/// An example program that dumps out the data of a delta table. Struct and Map types are not
+/// supported.
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+struct Cli {
+    /// Path to the table to inspect
+    path: String,
+
+    /// how many threads to read with
+    #[arg(short, long, default_value_t = 2)]
+    thread_count: usize,
+
+    /// Which EngineInterface to use
+    #[arg(short, long, value_enum, default_value_t = Interface::Default)]
+    interface: Interface,
+
+    /// Comma separated list of columns to select
+    #[arg(long, value_delimiter=',', num_args(0..))]
+    columns: Option<Vec<String>>,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum Interface {
+    /// Use the default, async engine interface
+    Default,
+    /// Use the sync engine interface (local files only)
+    Sync,
+}
+
+fn main() -> ExitCode {
+    env_logger::init();
+    match try_main() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            println!("{e:#?}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn try_main() -> DeltaResult<()> {
+    let cli = Cli::parse();
+    let url = url::Url::parse(&cli.path)?;
+
+    println!("Reading {url}");
+    let engine_interface: Box<dyn EngineInterface> = match cli.interface {
+        Interface::Default => Box::new(DefaultEngineInterface::try_new(
+            &url,
+            HashMap::<String, String>::new(),
+            Arc::new(TokioBackgroundExecutor::new()),
+        )?),
+        Interface::Sync => Box::new(SyncEngineInterface::new()),
+    };
+
+    let table = Table::new(url);
+    let snapshot = table.snapshot(engine_interface.as_ref(), None)?;
+
+    let read_schema_opt = cli
+        .columns
+        .map(|cols| {
+            use itertools::Itertools;
+            let table_schema = snapshot.schema();
+            let selected_fields = cols
+                .iter()
+                .map(|col| {
+                    table_schema
+                        .field(col)
+                        .cloned()
+                        .ok_or(deltakernel::Error::Generic(format!(
+                            "Table has no such column: {col}"
+                        )))
+                })
+                .try_collect();
+            selected_fields.map(|selected_fields| Arc::new(Schema::new(selected_fields)))
+        })
+        .transpose()?;
+    let scan = ScanBuilder::new(snapshot)
+        .with_schema_opt(read_schema_opt)
+        .build();
+
+    let scan_state = scan.get_scan_state();
+    let scan_files = scan.scan_files(engine_interface.as_ref())?;
+    let parquet_handler = engine_interface.get_parquet_handler();
+
+    let mut batches = vec![];
+    for scan_file in scan_files {
+        let scan_file = scan_file?;
+        let meta = &[
+            FileMeta {
+                last_modified: 0,
+                size: scan_file.size,
+                location: scan_file.location.clone(),
+            }
+        ];
+        let read_results = parquet_handler.read_parquet_files(
+            meta, scan_state.read_schema(), None
+        )?;
+
+        for read_result in read_results {
+            let len = if let Ok(ref res) = read_result {
+                res.length()
+            } else {
+                0
+            };
+            let logical = transform_to_logical(
+                engine_interface.as_ref(),
+                read_result?,
+                &scan_state,
+                &scan_file
+            )?;
+
+            let record_batch: RecordBatch = logical
+                .into_any()
+                .downcast::<ArrowEngineData>()
+                .map_err(|_| deltakernel::Error::EngineDataType("ArrowEngineData".to_string()))?
+                .into();
+            // let batch = if let Some(mask) = res.mask {
+            //     filter_record_batch(&record_batch, &mask.into())?
+            // } else {
+            //     record_batch
+            // };
+            batches.push(record_batch);
+        }
+    }
+    print_batches(&batches)?;
+    Ok(())
+}

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -7,14 +7,14 @@ use std::thread;
 use arrow::compute::filter_record_batch;
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::print_batches;
-use deltakernel::client::arrow_data::ArrowEngineData;
-use deltakernel::client::default::executor::tokio::TokioBackgroundExecutor;
-use deltakernel::client::default::DefaultEngineInterface;
-use deltakernel::client::sync::SyncEngineInterface;
-use deltakernel::scan::ScanFile;
-use deltakernel::scan::{state::ScanState, transform_to_logical, ScanBuilder};
-use deltakernel::schema::Schema;
-use deltakernel::{DeltaResult, EngineInterface, FileMeta, Table};
+use delta_kernel::client::arrow_data::ArrowEngineData;
+use delta_kernel::client::default::executor::tokio::TokioBackgroundExecutor;
+use delta_kernel::client::default::DefaultEngineInterface;
+use delta_kernel::client::sync::SyncEngineInterface;
+use delta_kernel::scan::ScanFile;
+use delta_kernel::scan::{state::ScanState, transform_to_logical, ScanBuilder};
+use delta_kernel::schema::Schema;
+use delta_kernel::{DeltaResult, EngineInterface, FileMeta, Table};
 
 use clap::{Parser, ValueEnum};
 use url::Url;
@@ -93,7 +93,7 @@ fn try_main() -> DeltaResult<()> {
                     table_schema
                         .field(col)
                         .cloned()
-                        .ok_or(deltakernel::Error::Generic(format!(
+                        .ok_or(delta_kernel::Error::Generic(format!(
                             "Table has no such column: {col}"
                         )))
                 })
@@ -147,10 +147,7 @@ fn try_main() -> DeltaResult<()> {
     drop(scan_file_tx);
 
     // simply gather up each batch and print them
-    let mut batches = vec![];
-    for received in record_batch_rx {
-        batches.push(received);
-    }
+    let batches: Vec<_> = record_batch_rx.iter().collect();
     print_batches(&batches)?;
     Ok(())
 }
@@ -228,7 +225,7 @@ fn do_work(
                         .into_any()
                         .downcast::<ArrowEngineData>()
                         .map_err(|_| {
-                            deltakernel::Error::EngineDataType("ArrowEngineData".to_string())
+                            delta_kernel::Error::EngineDataType("ArrowEngineData".to_string())
                         })
                         .unwrap()
                         .into();

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -162,7 +162,8 @@ fn do_work(
     url: Url,
     record_batch_tx: Sender<RecordBatch>,
     scan_file_rx: spmc::Receiver<ScanFile>,
-) { // todo: return a result and don't unwrap everywhere
+) {
+    // todo: return a result and don't unwrap everywhere
     // each thread needs its own copy since engine_interface isn't Clone, Send, or Sync
     let engine_interface: Box<dyn EngineInterface> = match interface {
         Interface::Default => Box::new(
@@ -204,7 +205,6 @@ fn do_work(
                     .get_parquet_handler()
                     .read_parquet_files(meta, scan_state.read_schema(), None)
                     .unwrap();
-
 
                 for read_result in read_results {
                     let len = if let Ok(ref res) = read_result {

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::process::ExitCode;
-use std::sync::Arc;
+use std::sync::mpsc::Sender;
+use std::sync::{mpsc, Arc};
+use std::thread;
 
 use arrow::compute::filter_record_batch;
 use arrow::record_batch::RecordBatch;
@@ -9,14 +11,17 @@ use deltakernel::client::arrow_data::ArrowEngineData;
 use deltakernel::client::default::executor::tokio::TokioBackgroundExecutor;
 use deltakernel::client::default::DefaultEngineInterface;
 use deltakernel::client::sync::SyncEngineInterface;
-use deltakernel::scan::{ScanBuilder, transform_to_logical};
+use deltakernel::scan::ScanFile;
+use deltakernel::scan::{state::ScanState, transform_to_logical, ScanBuilder};
 use deltakernel::schema::Schema;
 use deltakernel::{DeltaResult, EngineInterface, FileMeta, Table};
 
 use clap::{Parser, ValueEnum};
+use url::Url;
 
-/// An example program that dumps out the data of a delta table. Struct and Map types are not
-/// supported.
+/// An example program that reads a table using multiple threads. This shows the use of the
+/// scan_files and scan_state methods on a Scan, that can be used to partition work to either
+/// multiple threads, or workers (in the case of a distributed engine).
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -61,6 +66,8 @@ fn try_main() -> DeltaResult<()> {
     let url = url::Url::parse(&cli.path)?;
 
     println!("Reading {url}");
+
+    // create the requested interface
     let engine_interface: Box<dyn EngineInterface> = match cli.interface {
         Interface::Default => Box::new(DefaultEngineInterface::try_new(
             &url,
@@ -70,9 +77,11 @@ fn try_main() -> DeltaResult<()> {
         Interface::Sync => Box::new(SyncEngineInterface::new()),
     };
 
-    let table = Table::new(url);
+    // build a table and get the lastest snapshot from it
+    let table = Table::new(url.clone());
     let snapshot = table.snapshot(engine_interface.as_ref(), None)?;
 
+    // process the columns requested and build a schema from them
     let read_schema_opt = cli
         .columns
         .map(|cols| {
@@ -92,61 +101,156 @@ fn try_main() -> DeltaResult<()> {
             selected_fields.map(|selected_fields| Arc::new(Schema::new(selected_fields)))
         })
         .transpose()?;
+
+    // build a scan with the specified schema
     let scan = ScanBuilder::new(snapshot)
         .with_schema_opt(read_schema_opt)
         .build();
 
-    let scan_state = scan.get_scan_state();
+    // this gives us an iterator of `ScanFile`s, which are just paths and metadata for the files
+    // that make up the table
     let scan_files = scan.scan_files(engine_interface.as_ref())?;
-    let parquet_handler = engine_interface.get_parquet_handler();
 
-    let mut batches = vec![];
+    // create the channels we'll use. record_batch_[t/r]x are used for the threads to send back the
+    // processed RecordBatches to themain thread
+    let (record_batch_tx, record_batch_rx) = mpsc::channel();
+    // scan_file_[t/r]x are used to send each scan file from the iterator out to the waiting threads
+    let (mut scan_file_tx, scan_file_rx) = spmc::channel();
+
+    // fire up each thread. we don't need the handles as we rely on the channels to indicate when
+    // things are done
+    let _handles: Vec<_> = (0..cli.thread_count)
+        .map(|_| {
+            // items that we need to send to the other thread
+            let interface = cli.interface.clone();
+            let scan_state = scan.get_scan_state().into_owned();
+            let url = url.clone();
+            let rb_tx = record_batch_tx.clone();
+            let scan_file_rx = scan_file_rx.clone();
+            thread::spawn(move || {
+                do_work(interface, scan_state, url, rb_tx, scan_file_rx);
+            })
+        })
+        .collect();
+
+    // have handed out all copies needed, drop so record_batch_rx will exit when the last thread is
+    // done sending
+    drop(record_batch_tx);
+
+    // send out each scan file
     for scan_file in scan_files {
         let scan_file = scan_file?;
-        let meta = &[
-            FileMeta {
-                last_modified: 0,
-                size: scan_file.size,
-                location: scan_file.location()?,
-            }
-        ];
-        let mut selection_vector = scan_file.selection_vector(engine_interface.as_ref())?;
-        // could push selection_vector into the read here if desired
-        let read_results = parquet_handler.read_parquet_files(
-            meta, scan_state.read_schema(), None
-        )?;
+        scan_file_tx.send(scan_file).unwrap();
+    }
 
-        for read_result in read_results {
-            let len = if let Ok(ref res) = read_result {
-                res.length()
-            } else {
-                0
-            };
-            let logical = transform_to_logical(
-                engine_interface.as_ref(),
-                read_result?,
-                &scan_state,
-                &scan_file
-            )?;
+    // have sent all scan files, drop this so threads will exit when there's no more work
+    drop(scan_file_tx);
 
-            let record_batch: RecordBatch = logical
-                .into_any()
-                .downcast::<ArrowEngineData>()
-                .map_err(|_| deltakernel::Error::EngineDataType("ArrowEngineData".to_string()))?
-                .into();
-
-            // need to split the dv_mask. what's left in dv_mask covers this result, and rest
-            // will cover the following results
-            let rest = selection_vector.as_mut().map(|mask| mask.split_off(len));
-            let batch = if let Some(mask) = selection_vector.clone() {
-                filter_record_batch(&record_batch, &mask.into())?
-            } else {
-                record_batch
-            };
-            selection_vector = rest;
-            batches.push(batch);
-        }
+    // simply gather up each batch and print them
+    let mut batches = vec![];
+    for received in record_batch_rx {
+        batches.push(received);
     }
     print_batches(&batches)?;
     Ok(())
+}
+
+// this is the work each thread does
+fn do_work(
+    interface: Interface, // what type of engine_interface was requested
+    scan_state: ScanState<'_>,
+    url: Url,
+    record_batch_tx: Sender<RecordBatch>,
+    scan_file_rx: spmc::Receiver<ScanFile>,
+) { // todo: return a result and don't unwrap everywhere
+    // each thread needs its own copy since engine_interface isn't Clone, Send, or Sync
+    let engine_interface: Box<dyn EngineInterface> = match interface {
+        Interface::Default => Box::new(
+            DefaultEngineInterface::try_new(
+                &url,
+                HashMap::<String, String>::new(),
+                Arc::new(TokioBackgroundExecutor::new()),
+            )
+            .unwrap(),
+        ),
+        Interface::Sync => Box::new(SyncEngineInterface::new()),
+    };
+
+    loop {
+        // in a loop, try and get a ScanFile
+        match scan_file_rx.recv() {
+            Ok(scan_file) => {
+                // we got a scan file, let's process it
+
+                // get the selection vector (i.e. deletion vector)
+                let mut selection_vector = scan_file
+                    .selection_vector(engine_interface.as_ref())
+                    .unwrap();
+
+                // this example uses the parquet_handler from the engine_client, but an engine could
+                // choose to use whatever method it might want to read a parquet file. further
+                // parallelism would be possible here as we could read the parquet file in chunks
+                // where each thread reads one chunk. The engine would need to ensure enough
+                // meta-data was passed to each thread to correctly apply the selection vector
+
+                // build the required metadata and ask our parquet handler to read it.
+                let meta = &[FileMeta {
+                    last_modified: 0,
+                    size: scan_file.size,
+                    location: scan_file.location().unwrap(),
+                }];
+                // could push selection_vector into the read here if desired
+                let read_results = engine_interface
+                    .get_parquet_handler()
+                    .read_parquet_files(meta, scan_state.read_schema(), None)
+                    .unwrap();
+
+
+                for read_result in read_results {
+                    let len = if let Ok(ref res) = read_result {
+                        res.length()
+                    } else {
+                        0
+                    };
+
+                    // ask the kernel to transform the physical data into the correct logical form
+                    let logical = transform_to_logical(
+                        engine_interface.as_ref(),
+                        read_result.unwrap(),
+                        &scan_state,
+                        &scan_file,
+                    )
+                    .unwrap();
+
+                    // we know we're using arrow under the hood, so cast this into something we can
+                    // work with
+                    let record_batch: RecordBatch = logical
+                        .into_any()
+                        .downcast::<ArrowEngineData>()
+                        .map_err(|_| {
+                            deltakernel::Error::EngineDataType("ArrowEngineData".to_string())
+                        })
+                        .unwrap()
+                        .into();
+
+                    // need to split the dv_mask. what's left in dv_mask covers this result, and rest
+                    // will cover the following results
+                    let rest = selection_vector.as_mut().map(|mask| mask.split_off(len));
+                    let batch = if let Some(mask) = selection_vector.clone() {
+                        // apply the selection vector
+                        filter_record_batch(&record_batch, &mask.into()).unwrap()
+                    } else {
+                        record_batch
+                    };
+                    selection_vector = rest;
+                    // send back the processed result
+                    record_batch_tx.send(batch).unwrap();
+                }
+            }
+            Err(_) => {
+                // failed to read, so there's no more work, just exit
+                break;
+            }
+        }
+    }
 }

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -270,7 +270,6 @@ fn do_work(
         match scan_file_rx.recv() {
             Ok(scan_file) => {
                 // we got a scan file, let's process it
-
                 let root_url = Url::parse(&scan_state.table_root).unwrap();
 
                 // get the selection vector (i.e. deletion vector)
@@ -314,7 +313,7 @@ fn do_work(
                         0
                     };
 
-                    // // ask the kernel to transform the physical data into the correct logical form
+                    // ask the kernel to transform the physical data into the correct logical form
                     let logical = transform_to_logical(
                         engine_interface,
                         read_result.unwrap(),

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -43,6 +43,22 @@ pub struct DeletionVectorDescriptor {
 }
 
 impl DeletionVectorDescriptor {
+    pub fn new(
+        storage_type: String,
+        path_or_inline_dv: String,
+        offset: Option<i32>,
+        size_in_bytes: i32,
+        cardinality: i64,
+    ) -> Self {
+        DeletionVectorDescriptor {
+            storage_type,
+            path_or_inline_dv,
+            offset,
+            size_in_bytes,
+            cardinality,
+        }
+    }
+
     pub fn unique_id(&self) -> String {
         if let Some(offset) = self.offset {
             format!("{}{}@{offset}", self.storage_type, self.path_or_inline_dv)

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -113,9 +113,9 @@ impl DeletionVectorDescriptor {
     pub fn read(
         &self,
         fs_client: Arc<dyn FileSystemClient>,
-        parent: Url,
+        parent: &Url,
     ) -> DeltaResult<RoaringTreemap> {
-        match self.absolute_path(&parent)? {
+        match self.absolute_path(parent)? {
             None => {
                 let bytes = z85::decode(&self.path_or_inline_dv)
                     .map_err(|_| Error::deletion_vector("Failed to decode DV"))?;
@@ -308,7 +308,7 @@ mod tests {
         let fs_client = sync_interface.get_file_system_client();
 
         let example = dv_example();
-        let tree_map = example.read(fs_client, parent).unwrap();
+        let tree_map = example.read(fs_client, &parent).unwrap();
 
         let expected: Vec<u64> = vec![0, 9];
         let found = tree_map.iter().collect::<Vec<_>>();

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -43,22 +43,6 @@ pub struct DeletionVectorDescriptor {
 }
 
 impl DeletionVectorDescriptor {
-    pub fn new(
-        storage_type: String,
-        path_or_inline_dv: String,
-        offset: Option<i32>,
-        size_in_bytes: i32,
-        cardinality: i64,
-    ) -> Self {
-        DeletionVectorDescriptor {
-            storage_type,
-            path_or_inline_dv,
-            offset,
-            size_in_bytes,
-            cardinality,
-        }
-    }
-
     pub fn unique_id(&self) -> String {
         if let Some(offset) = self.offset {
             format!("{}{}@{offset}", self.storage_type, self.path_or_inline_dv)

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -1,5 +1,5 @@
 /// Code to parse and handle actions from the delta log
-pub(crate) mod deletion_vector;
+pub mod deletion_vector;
 pub(crate) mod schemas;
 pub(crate) mod visitors;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -90,7 +90,7 @@ pub struct FileMeta {
 /// It contains one Expression which can be evaluated on multiple ColumnarBatches.
 /// Connectors can implement this interface to optimize the evaluation using the
 /// connector specific capabilities.
-pub trait ExpressionEvaluator {
+pub trait ExpressionEvaluator: Send + Sync {
     /// Evaluate the expression on a given EngineData.
     ///
     /// Contains one value for each row of the input.
@@ -145,7 +145,7 @@ pub trait FileSystemClient: Send + Sync {
 /// Delta Kernel can use this client to parse JSON strings into Row or read content from JSON files.
 /// Connectors can leverage this interface to provide their best implementation of the JSON parsing
 /// capability to Delta Kernel.
-pub trait JsonHandler {
+pub trait JsonHandler: Send + Sync {
     /// Parse the given json strings and return the fields requested by output schema as columns in [`EngineData`].
     /// json_strings MUST be a single column batch of engine data, and the column type must be string
     fn parse_json(
@@ -195,7 +195,7 @@ pub trait ParquetHandler: Send + Sync {
 /// Interface encapsulating all clients needed by the Delta Kernel in order to read the Delta table.
 ///
 /// Connectors are expected to pass an implementation of this interface when reading a Delta table.
-pub trait EngineInterface {
+pub trait EngineInterface: Send + Sync {
     /// Get the connector provided [`ExpressionHandler`].
     fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler>;
 

--- a/kernel/src/scan/file_stream.rs
+++ b/kernel/src/scan/file_stream.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use either::Either;
+use lazy_static::lazy_static;
 use tracing::debug;
 
 use super::data_skipping::DataSkippingFilter;
@@ -8,8 +9,8 @@ use crate::actions::{get_log_schema, ADD_NAME, REMOVE_NAME};
 use crate::actions::{visitors::AddVisitor, visitors::RemoveVisitor, Add, Remove};
 use crate::engine_data::{GetData, TypedGetData};
 use crate::expressions::Expression;
-use crate::schema::SchemaRef;
-use crate::{DataVisitor, DeltaResult, EngineData, EngineInterface};
+use crate::schema::{DataType, MapType, SchemaRef, StructField, StructType};
+use crate::{DataVisitor, DeltaResult, EngineData, EngineInterface, ExpressionHandler};
 
 struct LogReplayScanner {
     filter: Option<DataSkippingFilter>,
@@ -22,7 +23,7 @@ struct LogReplayScanner {
 
 #[derive(Default)]
 struct AddRemoveVisitor {
-    adds: Vec<Add>,
+    adds: Vec<(Add, usize)>,
     removes: Vec<Remove>,
     selection_vector: Option<Vec<bool>>,
     // whether or not we are visiting commit json (=true) or checkpoint (=false)
@@ -52,8 +53,10 @@ impl DataVisitor for AddRemoveVisitor {
                     .as_ref()
                     .is_some_and(|selection| !selection[i])
                 {
-                    self.adds
-                        .push(AddVisitor::visit_add(i, path, &getters[..ADD_FIELD_COUNT])?)
+                    self.adds.push((
+                        AddVisitor::visit_add(i, path, &getters[..ADD_FIELD_COUNT])?,
+                        i,
+                    ))
                 }
             }
             // Remove will have a path at index 15 if it is valid
@@ -70,6 +73,34 @@ impl DataVisitor for AddRemoveVisitor {
         }
         Ok(())
     }
+}
+
+lazy_static! {
+    static ref SCAN_ROW_SCHEMA: DataType = DataType::Struct(Box::new(StructType::new(vec!(
+        StructField::new("path", DataType::STRING, true),
+        StructField::new("size", DataType::LONG, true),
+        StructField::new("modificationTime", DataType::LONG, true),
+        StructField::new(
+            "deletionVector",
+            StructType::new(vec![
+                StructField::new("storageType", DataType::STRING, false),
+                StructField::new("pathOrInlineDv", DataType::STRING, false),
+                StructField::new("offset", DataType::INTEGER, true),
+                StructField::new("sizeInBytes", DataType::INTEGER, false),
+                StructField::new("cardinality", DataType::LONG, false),
+            ]),
+            true
+        ),
+        StructField::new(
+            "fileConstantValues",
+            StructType::new(vec![StructField::new(
+                "partitionValues",
+                MapType::new(DataType::STRING, DataType::STRING, false),
+                true,
+            )]),
+            true
+        ),
+    ))));
 }
 
 impl LogReplayScanner {
@@ -122,7 +153,7 @@ impl LogReplayScanner {
         visitor
             .adds
             .into_iter()
-            .filter_map(|add| {
+            .filter_map(|(add, _)| {
                 // Note: each (add.path + add.dv_unique_id()) pair has a
                 // unique Add + Remove pair in the log. For example:
                 // https://github.com/delta-io/delta/blob/master/spark/src/test/resources/delta/table-with-dv-large/_delta_log/00000000000000000001.json
@@ -142,9 +173,91 @@ impl LogReplayScanner {
             })
             .collect()
     }
+
+    fn get_add_transform_expr(&self) -> Expression {
+        Expression::Struct(vec![
+            Expression::column("add.path"),
+            Expression::column("add.size"),
+            Expression::column("add.modificationTime"),
+            Expression::column("add.deletionVector"),
+            Expression::Struct(vec![Expression::column("add.partitionValues")]),
+        ])
+    }
+
+    fn process_scan_batch(
+        &mut self,
+        expression_handler: &dyn ExpressionHandler,
+        actions: &dyn EngineData,
+        is_log_batch: bool,
+    ) -> DeltaResult<(Box<dyn EngineData>, Vec<bool>)> {
+        // apply data skipping to get back a selection vector for actions that passed skipping
+        // note: None implies all files passed data skipping.
+        let filter_vector = self
+            .filter
+            .as_ref()
+            .map(|filter| filter.apply(actions))
+            .transpose()?;
+
+        let mut selection_vector = match filter_vector {
+            Some(ref filter_vector) => filter_vector.clone(),
+            None => vec![false; actions.length()],
+        };
+
+        let schema_to_use = if is_log_batch {
+            // NB: We _must_ pass these in the order `ADD_NAME, REMOVE_NAME` as the visitor assumes
+            // the Add action comes first. The [`project`] method honors this order, so this works
+            // as long as we keep this order here.
+            get_log_schema().project(&[ADD_NAME, REMOVE_NAME])?
+        } else {
+            // All checkpoint actions are already reconciled and Remove actions in checkpoint files
+            // only serve as tombstones for vacuum jobs. So no need to load them here.
+            get_log_schema().project(&[ADD_NAME])?
+        };
+        let mut visitor = AddRemoveVisitor::new(filter_vector, is_log_batch);
+        actions.extract(schema_to_use, &mut visitor)?;
+
+        for remove in visitor.removes.into_iter() {
+            let dv_id = remove.dv_unique_id();
+            self.seen.insert((remove.path, dv_id));
+        }
+
+        for (add, index) in visitor.adds.into_iter() {
+            // Note: each (add.path + add.dv_unique_id()) pair has a
+            // unique Add + Remove pair in the log. For example:
+            // https://github.com/delta-io/delta/blob/master/spark/src/test/resources/delta/table-with-dv-large/_delta_log/00000000000000000001.json
+            if !self.seen.contains(&(add.path.clone(), add.dv_unique_id())) {
+                debug!(
+                    "Including file in scan: {}, is log {is_log_batch}",
+                    add.path
+                );
+                if is_log_batch {
+                    // Remember file actions from this batch so we can ignore duplicates
+                    // as we process batches from older commit and/or checkpoint files. We
+                    // don't need to track checkpoint batches because they are already the
+                    // oldest actions and can never replace anything.
+                    self.seen.insert((add.path.clone(), add.dv_unique_id()));
+                }
+                selection_vector[index] = true;
+            } else {
+                debug!(
+                    "Filtering out add due to it being removed {}, is log {is_log_batch}",
+                    add.path
+                );
+            }
+        }
+
+        let result = expression_handler
+            .get_evaluator(
+                get_log_schema().project(&[ADD_NAME])?,
+                self.get_add_transform_expr(),
+                SCAN_ROW_SCHEMA.clone(),
+            )
+            .evaluate(actions)?;
+        Ok((result, selection_vector))
+    }
 }
 
-/// Given an iterator of (record batch, bool) tuples and a predicate, returns an iterator of `Adds`.
+/// Given an iterator of (engine_data, bool) tuples and a predicate, returns an iterator of `Adds`.
 /// The boolean flag indicates whether the record batch is a log or checkpoint batch.
 pub fn log_replay_iter(
     engine_client: &dyn EngineInterface,
@@ -163,4 +276,94 @@ pub fn log_replay_iter(
         }
         Err(err) => Either::Right(std::iter::once(Err(err))),
     })
+}
+
+/// Given an iterator of (engine_data, bool) tuples and a predicate, returns an iterator of
+/// `(engine_data, selection_vec)`. Each row that is selected in the returned `engine_data` _must_
+/// be processed to complete the scan. Non-selected rows _must_ be ignored. The boolean flag
+/// indicates whether the record batch is a log or checkpoint batch.
+pub fn scan_action_iter(
+    engine_interface: &dyn EngineInterface,
+    action_iter: impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>>,
+    table_schema: &SchemaRef,
+    predicate: &Option<Expression>,
+) -> impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, Vec<bool>)>> {
+    let mut log_scanner = LogReplayScanner::new(engine_interface, table_schema, predicate);
+    let expression_handler = engine_interface.get_expression_handler();
+    action_iter.map(move |action_res| {
+        action_res.and_then(|(batch, is_log_batch)| {
+            log_scanner.process_scan_batch(
+                expression_handler.as_ref(),
+                batch.as_ref(),
+                is_log_batch,
+            )
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+
+    use super::*;
+    use crate::{
+        client::arrow_data::ArrowEngineData,
+        client::sync::{json::SyncJsonHandler, SyncEngineInterface},
+        EngineData, JsonHandler,
+    };
+
+    // TODO(nick): Merge all copies of this into one "test utils" thing
+    fn string_array_to_engine_data(string_array: StringArray) -> Box<dyn EngineData> {
+        let string_field = Arc::new(Field::new("a", DataType::Utf8, true));
+        let schema = Arc::new(ArrowSchema::new(vec![string_field]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(string_array)])
+            .expect("Can't convert to record batch");
+        Box::new(ArrowEngineData::new(batch))
+    }
+
+    fn add_batch() -> Box<ArrowEngineData> {
+        let handler = SyncJsonHandler {};
+        let json_strings: StringArray = vec![
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"}"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
+            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
+        ]
+        .into();
+        let output_schema = Arc::new(get_log_schema().clone());
+        let parsed = handler
+            .parse_json(string_array_to_engine_data(json_strings), output_schema)
+            .unwrap();
+        ArrowEngineData::try_from_engine_data(parsed).unwrap()
+    }
+
+    #[test]
+    fn test_scan_action_iter() {
+        let batch = vec![add_batch()];
+        let interface = SyncEngineInterface::new();
+        // doesn't matter here
+        let table_schema = Arc::new(StructType::new(vec![StructField::new(
+            "foo",
+            crate::schema::DataType::STRING,
+            false,
+        )]));
+        let iter = scan_action_iter(
+            &interface,
+            batch.into_iter().map(|batch| Ok((batch as _, false))),
+            &table_schema,
+            &None,
+        );
+        for res in iter {
+            let (batch, sel) = res.unwrap();
+            let record_batch: RecordBatch = batch
+                .into_any()
+                .downcast::<ArrowEngineData>()
+                .map_err(|_| delta_kernel::Error::EngineDataType("ArrowEngineData".to_string()))
+                .unwrap()
+                .into();
+            println!("{:#?}", record_batch);
+            println!("{:#?}", sel);
+        }
+    }
 }

--- a/kernel/src/scan/file_stream.rs
+++ b/kernel/src/scan/file_stream.rs
@@ -102,8 +102,7 @@ lazy_static! {
             true
         ),
     )));
-    static ref SCAN_ROW_DATATYPE: DataType =
-        DataType::Struct(Box::new(SCAN_ROW_SCHEMA.as_ref().clone()));
+    static ref SCAN_ROW_DATATYPE: DataType = SCAN_ROW_SCHEMA.as_ref().clone().into();
 }
 
 impl LogReplayScanner {

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -5,12 +5,12 @@ use itertools::Itertools;
 use tracing::debug;
 use url::Url;
 
-use self::file_stream::log_replay_iter;
-use self::state::ScanState;
+use self::file_stream::{log_replay_iter, scan_action_iter};
+use self::state::{GlobalScanState, ScanState};
 use crate::actions::deletion_vector::{treemap_to_bools, DeletionVectorDescriptor};
 use crate::actions::{get_log_schema, Add, ADD_NAME, REMOVE_NAME};
 use crate::expressions::{Expression, Scalar};
-use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::schema::{DataType, Schema, SchemaRef, StructField, StructType};
 use crate::snapshot::Snapshot;
 use crate::{DeltaResult, EngineData, EngineInterface, Error, FileMeta};
 
@@ -221,6 +221,30 @@ impl Scan {
         ))
     }
 
+    /// Get an iterator of [`EngineData`]s that should be included in scan for a query. This handles
+    /// log-replay, reconciling Add and Remove actions, and applying data skipping (if possible).
+    pub fn scan_data(
+        &self,
+        engine_interface: &dyn EngineInterface,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, Vec<bool>)>>> {
+        let commit_read_schema = get_log_schema().project(&[ADD_NAME, REMOVE_NAME])?;
+        let checkpoint_read_schema = get_log_schema().project(&[ADD_NAME])?;
+
+        let log_iter = self.snapshot.log_segment.replay(
+            engine_interface,
+            commit_read_schema,
+            checkpoint_read_schema,
+            self.predicate.clone(),
+        )?;
+
+        Ok(scan_action_iter(
+            engine_interface,
+            log_iter,
+            &self.read_schema,
+            &self.predicate,
+        ))
+    }
+
     /// Get an iterator of [`ScanFile`]s that should be included in scan for a query. This handles
     /// log-replay, reconciling Add and Remove actions, and applying data skipping (if possible).
     pub fn scan_files(
@@ -233,44 +257,11 @@ impl Scan {
             .map(move |add_res| add_res.map(|add| ScanFile::from_add(add, &table_root))))
     }
 
-    /// Get the state needed to process this scan. In particular this returns a triple of
-    /// (all_fields_in_query, fields_to_read_from_parquet, have_partition_cols) where:
-    /// - all_fields_in_query - all fields in the query as [`ColumnType`] enums
-    /// - fields_to_read_from_parquet - Which fields should be read from the raw parquet files
-    /// - have_partition_cols - boolean indicating if we have partition columns in this query
-    fn get_state_info<'a>(
-        &'a self,
-        partition_columns: &[String],
-    ) -> (Vec<ColumnType<'a>>, Vec<StructField>, bool) {
-        let mut have_partition_cols = false;
-        let mut read_fields = Vec::with_capacity(self.schema().fields.len());
-        // Loop over all selected fields and note if they are columns that will be read from the
-        // parquet file ([`ColumnType::Selected`]) or if they are partition columns and will need to
-        // be filled in by evaluating an expression ([`ColumnType::Partition`])
-        let column_types = self
-            .schema()
-            .fields()
-            .map(|field| {
-                if partition_columns.contains(field.name()) {
-                    // todo: this is slow(ish)
-                    // Store the raw field, we will turn it into an expression in the inner loop
-                    // since the expression could be different for each add file
-                    have_partition_cols = true;
-                    ColumnType::Partition(Cow::Borrowed(field))
-                } else {
-                    // Add to read schema, store field so we can build a `Column` expression later
-                    // if needed (i.e. if we have partition columns)
-                    read_fields.push(field.clone());
-                    ColumnType::Selected(Cow::Borrowed(field))
-                }
-            })
-            .collect();
-        (column_types, read_fields, have_partition_cols)
-    }
-
-    pub fn get_scan_state(&self) -> ScanState<'_> {
+    // will probably go away
+    pub fn scan_state(&self) -> ScanState<'_> {
         let partition_columns = &self.snapshot.metadata().partition_columns;
-        let (all_fields, read_fields, have_partition_cols) = self.get_state_info(partition_columns);
+        let (all_fields, read_fields, have_partition_cols) =
+            get_state_info(self.schema().as_ref(), partition_columns);
         let read_schema = Arc::new(StructType::new(read_fields));
         ScanState::new(
             all_fields,
@@ -278,6 +269,22 @@ impl Scan {
             self.schema().clone(),
             read_schema,
         )
+    }
+
+    /// Get global state that is valid for the entire scan. This is somewhat expensive so should
+    /// only be called once per scan.
+    pub fn global_scan_state(&self) -> GlobalScanState {
+        let partition_columns = &self.snapshot.metadata().partition_columns;
+        let (_all_fields, read_fields, _have_partition_cols) =
+            get_state_info(self.schema().as_ref(), partition_columns);
+        let read_schema = StructType::new(read_fields);
+        let logical_schema = self.schema().as_ref().clone();
+        GlobalScanState {
+            table_root: self.snapshot.table_root.to_string(),
+            partition_columns: partition_columns.clone(),
+            logical_schema,
+            read_schema,
+        }
     }
 
     /// This is the main method to 'materialize' the scan. It returns a [`Result`] of
@@ -288,7 +295,8 @@ impl Scan {
     /// more details.
     pub fn execute(&self, engine_interface: &dyn EngineInterface) -> DeltaResult<Vec<ScanResult>> {
         let partition_columns = &self.snapshot.metadata().partition_columns;
-        let (all_fields, read_fields, have_partition_cols) = self.get_state_info(partition_columns);
+        let (all_fields, read_fields, have_partition_cols) =
+            get_state_info(self.schema().as_ref(), partition_columns);
         let read_schema = Arc::new(StructType::new(read_fields));
         debug!("Executing scan with read schema {read_schema:#?}");
         let output_schema = DataType::Struct(Box::new(self.schema().as_ref().clone()));
@@ -389,22 +397,69 @@ fn parse_partition_value(raw: Option<&String>, data_type: &DataType) -> DeltaRes
     }
 }
 
-/// Turn raw physical parquet data into the logical format based on a scan state
+/// Get the state needed to process a scan. In particular this returns a triple of
+/// (all_fields_in_query, fields_to_read_from_parquet, have_partition_cols) where:
+/// - all_fields_in_query - all fields in the query as [`ColumnType`] enums
+/// - fields_to_read_from_parquet - Which fields should be read from the raw parquet files
+/// - have_partition_cols - boolean indicating if we have partition columns in this query
+fn get_state_info<'a>(
+    schema: &'a Schema,
+    partition_columns: &[String],
+) -> (Vec<ColumnType<'a>>, Vec<StructField>, bool) {
+    let mut have_partition_cols = false;
+    let mut read_fields = Vec::with_capacity(schema.fields.len());
+    // Loop over all selected fields and note if they are columns that will be read from the
+    // parquet file ([`ColumnType::Selected`]) or if they are partition columns and will need to
+    // be filled in by evaluating an expression ([`ColumnType::Partition`])
+    let column_types = schema
+        .fields()
+        .map(|field| {
+            if partition_columns.contains(field.name()) {
+                // todo: this is slow(ish)
+                // Store the raw field, we will turn it into an expression in the inner loop
+                // since the expression could be different for each add file
+                have_partition_cols = true;
+                ColumnType::Partition(Cow::Borrowed(field))
+            } else {
+                // Add to read schema, store field so we can build a `Column` expression later
+                // if needed (i.e. if we have partition columns)
+                read_fields.push(field.clone());
+                ColumnType::Selected(Cow::Borrowed(field))
+            }
+        })
+        .collect();
+    (column_types, read_fields, have_partition_cols)
+}
+
+pub fn selection_vector(
+    engine_interface: &dyn EngineInterface,
+    descriptor: &DeletionVectorDescriptor,
+    table_root: &Url,
+) -> DeltaResult<Vec<bool>> {
+    let fs_client = engine_interface.get_file_system_client();
+    let dv_treemap = descriptor.read(fs_client, table_root.clone())?;
+    Ok(treemap_to_bools(dv_treemap))
+}
+
 pub fn transform_to_logical(
     engine_interface: &dyn EngineInterface,
     data: Box<dyn EngineData>,
-    scan_state: &ScanState<'_>,
-    scan_file: &ScanFile,
+    global_state: &GlobalScanState,
+    partition_values: &std::collections::HashMap<String, String>,
 ) -> DeltaResult<Box<dyn EngineData>> {
-    if scan_state.have_partition_cols {
+    let (all_fields, _read_fields, have_partition_cols) = get_state_info(
+        &global_state.logical_schema,
+        &global_state.partition_columns,
+    );
+    let read_schema = Arc::new(global_state.read_schema.clone());
+    if have_partition_cols {
         // need to add back partition cols
-        let all_fields: Vec<Expression> = scan_state
-            .column_types
+        let all_fields: Vec<Expression> = all_fields
             .iter()
             .map(|field| match field {
                 ColumnType::Partition(field) => {
                     let value_expression = parse_partition_value(
-                        scan_file.partition_values.get(field.name()),
+                        partition_values.get(field.name()),
                         field.data_type(),
                     )?;
                     Ok::<Expression, Error>(Expression::Literal(value_expression))
@@ -416,9 +471,9 @@ pub fn transform_to_logical(
         let result = engine_interface
             .get_expression_handler()
             .get_evaluator(
-                scan_state.read_schema.clone(),
+                read_schema.clone(),
                 read_expression.clone(),
-                DataType::Struct(Box::new(scan_state.logical_schema.as_ref().clone())),
+                DataType::Struct(Box::new(global_state.logical_schema.clone())),
             )
             .evaluate(data.as_ref())?;
         Ok(result)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use self::file_stream::log_replay_iter;
 use self::state::ScanState;
-use crate::actions::deletion_vector::{DeletionVectorDescriptor, treemap_to_bools};
+use crate::actions::deletion_vector::{treemap_to_bools, DeletionVectorDescriptor};
 use crate::actions::{get_log_schema, Add, ADD_NAME, REMOVE_NAME};
 use crate::expressions::{Expression, Scalar};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
@@ -16,7 +16,7 @@ use crate::{DeltaResult, EngineData, EngineInterface, Error, FileMeta};
 
 mod data_skipping;
 pub mod file_stream;
-mod state;
+pub mod state;
 
 /// Builder to scan a snapshot of a table.
 pub struct ScanBuilder {
@@ -113,6 +113,20 @@ pub enum ColumnType<'a> {
     Partition(Cow<'a, StructField>),
 }
 
+impl<'a> ColumnType<'a> {
+    pub(crate) fn into_owned(self) -> ColumnType<'static> {
+        match self {
+            ColumnType::Selected(field) => {
+                let field = field.into_owned();
+                ColumnType::Selected(Cow::Owned(field))
+            }
+            ColumnType::Partition(field) => {
+                let field = field.into_owned();
+                ColumnType::Partition(Cow::Owned(field))
+            }
+        }
+    }
+}
 /// One file to scan, plus associated metadata
 pub struct ScanFile {
     table_root: Url,
@@ -137,7 +151,10 @@ impl ScanFile {
         Ok(self.table_root.join(self.path.as_str())?)
     }
 
-    pub fn selection_vector(&self, engine_interface: &dyn EngineInterface) -> DeltaResult<Option<Vec<bool>>> {
+    pub fn selection_vector(
+        &self,
+        engine_interface: &dyn EngineInterface,
+    ) -> DeltaResult<Option<Vec<bool>>> {
         let dv_treemap = self
             .deletion_vector_descriptor
             .as_ref()
@@ -211,13 +228,16 @@ impl Scan {
         engine_interface: &dyn EngineInterface,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanFile>>> {
         let table_root = self.snapshot.table_root.clone();
-        Ok(self.files(engine_interface)?.map(move |add_res| {
-            add_res.map(|add| ScanFile::from_add(add, &table_root))
-        }))
+        Ok(self
+            .files(engine_interface)?
+            .map(move |add_res| add_res.map(|add| ScanFile::from_add(add, &table_root))))
     }
 
     /// get some stuff
-    fn get_state_info<'a>(&'a self, partition_columns: &Vec<String>) -> (Vec<ColumnType<'a>>, Vec<StructField>, bool) {
+    fn get_state_info<'a>(
+        &'a self,
+        partition_columns: &[String],
+    ) -> (Vec<ColumnType<'a>>, Vec<StructField>, bool) {
         let mut have_partition_cols = false;
         let mut read_fields = Vec::with_capacity(self.schema().fields.len());
         let column_types = self
@@ -245,7 +265,12 @@ impl Scan {
         let partition_columns = &self.snapshot.metadata().partition_columns;
         let (all_fields, read_fields, have_partition_cols) = self.get_state_info(partition_columns);
         let read_schema = Arc::new(StructType::new(read_fields));
-        ScanState::new(all_fields, have_partition_cols, self.schema().clone(), read_schema)
+        ScanState::new(
+            all_fields,
+            have_partition_cols,
+            self.schema().clone(),
+            read_schema,
+        )
     }
 
     /// This is the main method to 'materialize' the scan. It returns a [`Result`] of
@@ -366,7 +391,8 @@ pub fn transform_to_logical(
 ) -> DeltaResult<Box<dyn EngineData>> {
     if scan_state.have_partition_cols {
         // need to add back partition cols
-        let all_fields: Vec<Expression> = scan_state.column_types
+        let all_fields: Vec<Expression> = scan_state
+            .column_types
             .iter()
             .map(|field| match field {
                 ColumnType::Partition(field) => {
@@ -385,9 +411,7 @@ pub fn transform_to_logical(
             .get_evaluator(
                 scan_state.read_schema.clone(),
                 read_expression.clone(),
-                DataType::Struct(Box::new(
-                    scan_state.logical_schema.as_ref().clone()
-                ))
+                DataType::Struct(Box::new(scan_state.logical_schema.as_ref().clone())),
             )
             .evaluate(data.as_ref())?;
         Ok(result)

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -1,7 +1,7 @@
 //! This module encapsulates the state of a scan
 
-use crate::schema::SchemaRef;
 use super::ColumnType;
+use crate::schema::SchemaRef;
 
 pub struct ScanState<'a> {
     pub(crate) column_types: Vec<ColumnType<'a>>,
@@ -27,5 +27,18 @@ impl<'a> ScanState<'a> {
 
     pub fn read_schema(&self) -> SchemaRef {
         self.read_schema.clone()
+    }
+
+    pub fn into_owned(self) -> ScanState<'static> {
+        ScanState {
+            column_types: self
+                .column_types
+                .into_iter()
+                .map(|ct| ct.into_owned())
+                .collect(),
+            have_partition_cols: self.have_partition_cols,
+            logical_schema: self.logical_schema.clone(),
+            read_schema: self.read_schema.clone(),
+        }
     }
 }

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -1,0 +1,31 @@
+//! This module encapsulates the state of a scan
+
+use crate::schema::SchemaRef;
+use super::ColumnType;
+
+pub struct ScanState<'a> {
+    pub(crate) column_types: Vec<ColumnType<'a>>,
+    pub(crate) have_partition_cols: bool,
+    pub(crate) logical_schema: SchemaRef,
+    pub(crate) read_schema: SchemaRef,
+}
+
+impl<'a> ScanState<'a> {
+    pub fn new(
+        column_types: Vec<ColumnType<'a>>,
+        have_partition_cols: bool,
+        logical_schema: SchemaRef,
+        read_schema: SchemaRef,
+    ) -> Self {
+        Self {
+            column_types,
+            have_partition_cols,
+            logical_schema,
+            read_schema,
+        }
+    }
+
+    pub fn read_schema(&self) -> SchemaRef {
+        self.read_schema.clone()
+    }
+}

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -3,7 +3,10 @@
 use std::collections::HashMap;
 
 use crate::{
-    actions::{deletion_vector::{treemap_to_bools, DeletionVectorDescriptor}, visitors::visit_deletion_vector_at},
+    actions::{
+        deletion_vector::{treemap_to_bools, DeletionVectorDescriptor},
+        visitors::visit_deletion_vector_at,
+    },
     engine_data::{GetData, TypedGetData},
     schema::Schema,
     DataVisitor, DeltaResult, EngineData, EngineInterface,

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -1,51 +1,14 @@
 //! This module encapsulates the state of a scan
 
-use super::ColumnType;
-use crate::schema::{Schema, SchemaRef};
+use std::collections::HashMap;
 
+use crate::{
+    actions::deletion_vector::{treemap_to_bools, DeletionVectorDescriptor},
+    engine_data::{GetData, TypedGetData},
+    schema::Schema,
+    DataVisitor, DeltaResult, EngineData, EngineInterface,
+};
 use serde::{Deserialize, Serialize};
-
-pub struct ScanState<'a> {
-    pub(crate) column_types: Vec<ColumnType<'a>>,
-    pub(crate) have_partition_cols: bool,
-    pub(crate) logical_schema: SchemaRef,
-    pub(crate) read_schema: SchemaRef,
-}
-
-impl<'a> ScanState<'a> {
-    pub fn new(
-        column_types: Vec<ColumnType<'a>>,
-        have_partition_cols: bool,
-        logical_schema: SchemaRef,
-        read_schema: SchemaRef,
-    ) -> Self {
-        Self {
-            column_types,
-            have_partition_cols,
-            logical_schema,
-            read_schema,
-        }
-    }
-
-    pub fn read_schema(&self) -> SchemaRef {
-        self.read_schema.clone()
-    }
-
-    pub fn into_owned(self) -> ScanState<'static> {
-        ScanState {
-            column_types: self
-                .column_types
-                .into_iter()
-                .map(|ct| ct.into_owned())
-                .collect(),
-            have_partition_cols: self.have_partition_cols,
-            logical_schema: self.logical_schema.clone(),
-            read_schema: self.read_schema.clone(),
-        }
-    }
-}
-
-// will probably actually use this one
 
 /// State that doesn't change beween scans
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -54,4 +17,123 @@ pub struct GlobalScanState {
     pub partition_columns: Vec<String>,
     pub logical_schema: Schema,
     pub read_schema: Schema,
+}
+
+/// this struct can be used by an engine to materialize a selection vector
+#[derive(Debug)]
+pub struct DvInfo {
+    deletion_vector: Option<DeletionVectorDescriptor>,
+}
+
+impl DvInfo {
+    pub fn get_selection_vector(
+        &self,
+        engine_interface: &dyn EngineInterface,
+        table_root: &url::Url,
+    ) -> DeltaResult<Option<Vec<bool>>> {
+        let dv_treemap = self
+            .deletion_vector
+            .as_ref()
+            .map(|dv_descriptor| {
+                let fs_client = engine_interface.get_file_system_client();
+                dv_descriptor.read(fs_client, table_root)
+            })
+            .transpose()?;
+        Ok(dv_treemap.map(treemap_to_bools))
+    }
+}
+
+/// Request that the kernel call a callback on each valid file that needs to be read for the
+/// scan.
+///
+/// The arguments to the callback are:
+/// * `context`: an `&mut context` argument. this can be anything that engine needs to pass through to each call
+/// * `path`: a `&str` which is the path to the file
+/// * `size`: an `i64` which is the size of the file
+/// * `dv_info`: a [`DvInfo`] struct, which allows getting the selection vector for this file
+/// * `partition_values`: a `HashMap<String, String>` which are partition values
+///
+/// ## Context
+/// A note on the `context`. This can be any value the engine wants. This function takes ownership of the passed arg, but then returns it, so the engine can repeatedly call `visit_scan_files` with the same context.
+/// ## Example
+/// ```ignore
+/// let context = [my context];
+/// for res in scan_data { // scan data from scan.get_scan_data()
+///     let (data, vector) = res?;
+///     context = delta_kernel::scan::state::visit_scan_files(
+///        data.as_ref(),
+///        vector,
+///        context,
+///        my_callback,
+///     )?;
+/// }
+/// ```
+pub fn visit_scan_files<T>(
+    data: &dyn EngineData,
+    selection_vector: Vec<bool>,
+    context: T,
+    callback: fn(
+        context: &mut T,
+        path: &str,
+        size: i64,
+        dv_info: DvInfo,
+        partition_values: HashMap<String, String>,
+    ) -> (),
+) -> DeltaResult<T> {
+    let mut visitor = ScanFileVisitor {
+        callback,
+        selection_vector,
+        context,
+    };
+    data.extract(super::file_stream::SCAN_ROW_SCHEMA.clone(), &mut visitor)?;
+    Ok(visitor.context)
+}
+
+// add some visitor magic for clients
+struct ScanFileVisitor<T> {
+    callback: fn(&mut T, &str, i64, DvInfo, HashMap<String, String>) -> (),
+    selection_vector: Vec<bool>,
+    context: T,
+}
+
+impl<T> DataVisitor for ScanFileVisitor<T> {
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        for row_index in 0..row_count {
+            if !self.selection_vector[row_index] {
+                // skip skipped rows
+                continue;
+            }
+            // Since path column is required, use it to detect presence of an Add action
+            if let Some(path) = getters[0].get_opt(row_index, "scanFile.path")? {
+                let size = getters[1].get(row_index, "scanFile.size")?;
+                let deletion_vector = if let Some(storage_type) =
+                    getters[3].get_opt(row_index, "scanFile.deletionVector.storageType")?
+                {
+                    // there is a storageType, so the whole DV must be there
+                    let path_or_inline_dv: String =
+                        getters[4].get(row_index, "scanFile.deletionVector.pathOrInlineDv")?;
+                    let offset: Option<i32> =
+                        getters[5].get_opt(row_index, "scanFile.deletionVector.offset")?;
+                    let size_in_bytes: i32 =
+                        getters[6].get(row_index, "scanFile.deletionVector.sizeInBytes")?;
+                    let cardinality: i64 =
+                        getters[7].get(row_index, "scanFile.deletionVector.cardinality")?;
+                    Some(DeletionVectorDescriptor {
+                        storage_type,
+                        path_or_inline_dv,
+                        offset,
+                        size_in_bytes,
+                        cardinality,
+                    })
+                } else {
+                    None
+                };
+                let dv_info = DvInfo { deletion_vector };
+                let partition_values: HashMap<_, _> =
+                    getters[8].get(row_index, "scanFile.fileConstantValues.partitionValues")?;
+                (self.callback)(&mut self.context, path, size, dv_info, partition_values)
+            }
+        }
+        Ok(())
+    }
 }

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -48,7 +48,6 @@ impl<'a> ScanState<'a> {
 // will probably actually use this one
 
 /// State that doesn't change beween scans
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GlobalScanState {
     pub table_root: String,

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -1,7 +1,9 @@
 //! This module encapsulates the state of a scan
 
 use super::ColumnType;
-use crate::schema::SchemaRef;
+use crate::schema::{Schema, SchemaRef};
+
+use serde::{Deserialize, Serialize};
 
 pub struct ScanState<'a> {
     pub(crate) column_types: Vec<ColumnType<'a>>,
@@ -41,4 +43,16 @@ impl<'a> ScanState<'a> {
             read_schema: self.read_schema.clone(),
         }
     }
+}
+
+// will probably actually use this one
+
+/// State that doesn't change beween scans
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GlobalScanState {
+    pub table_root: String,
+    pub partition_columns: Vec<String>,
+    pub logical_schema: Schema,
+    pub read_schema: Schema,
 }


### PR DESCRIPTION
This PR let's us better model the stages of a scan, so we can be used by an engine that doesn't just want the kernel to do all the reading in whatever thread called `Scan::execute`.

We introduce a method in `Scan` that can return `EngineData` with a known schema and a selection vector. That data will have all the relevant info for performing the scan. The engine can serialize/use that data however it likes to distribute work.

Currently also includes a `GlobalScanState` which is serializable. This is a bit of a shortcut for now, and we may want to generalize it more to not require an engine to use our serialization at all, but in the interest of time I'd like to keep this unless there are serious objections.

DuckDB notes:
- They have a capable parquet reader, so we want to ensure they can get things like partition column info _before_ they read the file, because their reader can insert that info at read time.
- Similar for DVs