### PR TITLE
add a bunch of docs + nightly detection

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -76,6 +76,9 @@ sync-client = [
   "parquet"
 ]
 
+[build-dependencies]
+rustc_version = "0.4.0"
+
 [dev-dependencies]
 arrow = { version = "^49.0", features = ["json", "prettyprint"] }
 delta_kernel = { path = ".", features = ["default-client", "sync-client"] }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "delta_kernel"
 description = "Core crate providing a Delta/Deltalake implementation focused on interoperability with a wide range of query engines."
+documentation = "https://docs.rs/delta_kernel"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
 version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 bytes = "1.4"

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -1,0 +1,8 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // note if we're on the nightly channel so we can enable doc_auto_cfg if so
+    if let Channel::Nightly = version_meta().unwrap().channel {
+        println!("cargo:rustc-cfg=NIGHTLY_CHANNEL");
+    }
+}

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -1,4 +1,4 @@
-/// Code to parse and handle actions from the delta log
+//! Provides parsing and manipulation of the various actions defined in the [Delta specification](https://github.com/delta-io/delta/blob/master/PROTOCOL.md)
 pub(crate) mod deletion_vector;
 pub(crate) mod schemas;
 pub(crate) mod visitors;

--- a/kernel/src/client/default/mod.rs
+++ b/kernel/src/client/default/mod.rs
@@ -1,6 +1,6 @@
 //! # Default Engineinterface
 //!
-//! The default implementation of [`Engineinterface`] is [`DefaultEngineInterface`].
+//! The default implementation of [`EngineInterface`] is [`DefaultEngineInterface`].
 //!
 //! The underlying implementations use asynchronous IO. Async tasks are run on
 //! a separate thread pool, provided by the [`TaskExecutor`] trait. Read more in

--- a/kernel/src/client/mod.rs
+++ b/kernel/src/client/mod.rs
@@ -1,4 +1,4 @@
-//! Provices clients that implement the required interfaces that are optionally built into the
+//! Provides clients that implement the required interfaces that are optionally built into the
 //! kernel
 
 #[cfg(feature = "arrow-conversion")]

--- a/kernel/src/client/mod.rs
+++ b/kernel/src/client/mod.rs
@@ -1,7 +1,8 @@
-//! module for clients that are optionally built into the kernel
+//! Provices clients that implement the required interfaces that are optionally built into the
+//! kernel
 
 #[cfg(feature = "arrow-conversion")]
-pub mod arrow_conversion;
+pub(crate) mod arrow_conversion;
 
 #[cfg(feature = "arrow-expression")]
 pub mod arrow_expression;
@@ -10,10 +11,10 @@ pub mod arrow_expression;
 pub mod arrow_data;
 
 #[cfg(any(feature = "default-client", feature = "sync-client"))]
-pub mod arrow_get_data;
+pub(crate) mod arrow_get_data;
 
 #[cfg(any(feature = "default-client", feature = "sync-client"))]
-pub mod arrow_utils;
+pub(crate) mod arrow_utils;
 
 #[cfg(feature = "default-client")]
 pub mod default;

--- a/kernel/src/client/mod.rs
+++ b/kernel/src/client/mod.rs
@@ -1,5 +1,6 @@
-//! Provides clients that implement the required interfaces that are optionally built into the
-//! kernel
+//! Provides clients that implement the required interfaces. These clients can optionally be built
+//! into the kernel by setting the `default-client` or `sync-client` feature flag. See the related
+//! modules for more information.
 
 #[cfg(feature = "arrow-conversion")]
 pub(crate) mod arrow_conversion;

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1,3 +1,5 @@
+//! Definitions and functions to create and manipulate kernel expressions
+
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,6 +1,18 @@
-//! # Engineinterface interfaces
+//! # Delta Kernel
 //!
-//! The Engineinterface interfaces allow connectors to bring their own implementation of functionality
+//! Delta-kernel-rs is an experimental [Delta](https://github.com/delta-io/delta/) implementation
+//! focused on interoperability with a wide range of query engines. It currently only supports
+//! reads. This library defines a number of interfaces which must be implemented to provide a
+//! working "delta reader". The are detailed below. There is a provided "default client" that
+//! implenents all these interfaces and can be used to ease integration work. See
+//! [`DefaultEngineInterface`](client/default/index.html) for more information.
+//!
+//! A full `rust` example for reading table data using the default client can be found
+//! [here](https://github.com/delta-incubator/delta-kernel-rs/blob/main/kernel/examples/dump-table/src/main.rs)
+//!
+//! # EngineInterface interfaces
+//!
+//! The [`EngineInterface`] interfaces allow connectors to bring their own implementation of functionality
 //! such as reading parquet files, listing files in a file system, parsing a JSON string etc.
 //!
 //! The [`EngineInterface`] trait exposes methods to get sub-clients which expose the core
@@ -26,6 +38,8 @@
 //! methods on the [`FileSystemClient`] trait.
 //!
 
+#![cfg_attr(all(doc, NIGHTLY_CHANNEL), feature(doc_auto_cfg))]
+
 #![warn(
     unreachable_pub,
     trivial_numeric_casts,
@@ -46,7 +60,7 @@ pub mod actions;
 pub mod engine_data;
 pub mod error;
 pub mod expressions;
-pub mod path;
+pub(crate) mod path;
 pub mod scan;
 pub mod schema;
 pub mod snapshot;
@@ -67,10 +81,13 @@ pub mod client;
 /// Delta table version is 8 byte unsigned int
 pub type Version = u64;
 
+/// A specification for a range of bytes to read from a file location
 pub type FileSlice = (Url, Option<Range<usize>>);
 
 /// Data read from a Delta table file and the corresponding scan file information.
 pub type FileDataReadResult = (FileMeta, Box<dyn EngineData>);
+
+/// An iterator of data read from specified files
 pub type FileDataReadResultIterator =
     Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send>;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -39,7 +39,6 @@
 //!
 
 #![cfg_attr(all(doc, NIGHTLY_CHANNEL), feature(doc_auto_cfg))]
-
 #![warn(
     unreachable_pub,
     trivial_numeric_casts,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1,3 +1,5 @@
+//! Functionality to create and execute scans (reads) over data stored in a delta table
+
 use std::sync::Arc;
 
 use itertools::Itertools;

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -1,3 +1,5 @@
+//! Definitions and functions to create and manipulate kernel schema
+
 use std::fmt::Formatter;
 use std::sync::Arc;
 use std::{collections::HashMap, fmt::Display};

--- a/kernel/src/table.rs
+++ b/kernel/src/table.rs
@@ -1,3 +1,6 @@
+//! In-memory representation of a Delta table, which acts as an immutable root entity for reading
+//! the different versions
+
 use std::sync::Arc;
 
 use url::Url;


### PR DESCRIPTION
This:
* ensures that all modules (at least) have module level docs, and cleans up some other docs.
* makes some things `pub(crate)` and not `pub` if they were only internal, so they don't show up in the docs
* also adds a check if we're running on nightly (which docs.rs _is_), and if so sets [`doc_auto_cfg`](https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg), which will give a nice note for which things require certain features to be enabled. e.g:
![image](https://github.com/delta-incubator/delta-kernel-rs/assets/178912/eafa6e0e-4c21-45d5-bf7d-b637305662d4)
It's a bit annoying to have to gate on nightly, but I think it's worth it to make the docs more understandable. 
* tells docs.rs to build our docs with all features enabled
* puts a link to the docs on docs.rs in `Cargo.toml`, which means that'll be linked next time we publish to crates.io

If you'd like to inspect these pretty docs yourself locally you can run:
`cargo +nightly doc --all-features`