### PR TITLE
simplify masking and reordering of record batches

### DIFF
--- a/kernel/src/client/default/parquet.rs
+++ b/kernel/src/client/default/parquet.rs
@@ -153,7 +153,7 @@ impl FileOpener for ParquetOpener {
             let stream = stream.map(move |rbr| {
                 // re-order each batch if needed
                 rbr.map_err(Error::Parquet)
-                    .and_then(|rb| reorder_record_batch(rb, &indicies, &requested_ordering))
+                    .and_then(|rb| reorder_record_batch(rb, &requested_ordering))
             });
             Ok(stream.boxed())
         }))

--- a/kernel/src/client/sync/parquet.rs
+++ b/kernel/src/client/sync/parquet.rs
@@ -31,7 +31,6 @@ fn try_create_from_parquet(schema: SchemaRef, location: Url) -> DeltaResult<Arro
         .ok_or_else(|| Error::generic("No data found reading parquet file"))?;
     Ok(ArrowEngineData::new(reorder_record_batch(
         data?,
-        &indicies,
         &requested_ordering,
     )?))
 }


### PR DESCRIPTION
Taking some of the suggestions from https://github.com/delta-incubator/delta-kernel-rs/pull/156/files#r1552305814

This does simplify the generation of the indices and mask. A couple of things I didn't change:

1. still pass  `requested_schema` and `parquet_schema` to `generate_mask`: This is used only as an optimization to determine if we need a mask at all. Since it's a simple length compare, that's faster than building the whole mask when it's not needed
2. Don't use the `requested_schema` as the schema of the new record batch. It appears the way spark writes checkpoints isn't consistent with the protocol spec atm. it marks `minReaderVersion` and `minWriterVersion` as `nullable`, and so we hit a schema miss-match error if we try and do any reordering in metadata queries. I've created #179 as a follow-up to correctly handle things here