### PR TITLE
Add support for presigned-url reading to the default client

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -125,6 +125,8 @@ pub enum KernelError {
     ObjectStoreError,
     #[cfg(feature = "default-client")]
     ObjectStorePathError,
+    #[cfg(feature = "default-client")]
+    Reqwest,
     FileNotFoundError,
     MissingColumnError,
     UnexpectedColumnTypeError,
@@ -157,6 +159,8 @@ impl From<Error> for KernelError {
             Error::ObjectStore(_) => KernelError::ObjectStoreError,
             #[cfg(feature = "default-client")]
             Error::ObjectStorePath(_) => KernelError::ObjectStorePathError,
+            #[cfg(feature = "default-client")]
+            Error::Reqwest(_) => KernelError::Reqwest,
             Error::FileNotFound(_) => KernelError::FileNotFoundError,
             Error::MissingColumn(_) => KernelError::MissingColumnError,
             Error::UnexpectedColumnType(_) => KernelError::UnexpectedColumnTypeError,

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -48,6 +48,8 @@ futures = { version = "0.3", optional = true }
 object_store = { version = "^0.8.0", optional = true }
 # Used in default and sync client
 parquet = { version = "^49.0", optional = true }
+# Used for fetching direct urls (like pre-signed urls)
+reqwest = { version = "^0.11.0", optional = true }
 
 # optionally used with default client (though not required)
 tokio = { version = "1", optional = true, features = ["rt-multi-thread"] }
@@ -67,7 +69,8 @@ default-client = [
   "object_store",
   "parquet/async",
   "parquet/object_store",
-  "tokio"
+  "reqwest",
+  "tokio",
 ]
 
 developer-visibility = []

--- a/kernel/src/client/default/parquet.rs
+++ b/kernel/src/client/default/parquet.rs
@@ -57,7 +57,8 @@ impl<E: TaskExecutor> ParquetHandler for DefaultParquetHandler<E> {
         }
 
         let arrow_schema: ArrowSchemaRef = Arc::new(physical_schema.as_ref().try_into()?);
-        // get the first FileMeta to decide how to fetch the file
+        // get the first FileMeta to decide how to fetch the file.
+        // NB: This means that every file in `FileMeta` _must_ have the same scheme or things will break
         // s3://    -> aws   (ParquetOpener)
         // nothing  -> local (ParquetOpener)
         // https:// -> assume presigned URL (and fetch without object_store)

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -69,6 +69,10 @@ pub enum Error {
     #[error("Object store path error: {0}")]
     ObjectStorePath(#[from] object_store::path::Error),
 
+    #[cfg(feature = "default-client")]
+    #[error("Reqwest Error: {0}")]
+    Reqwest(#[from] reqwest::Error),
+
     /// A specified file could not be found
     #[error("File not found: {0}")]
     FileNotFound(String),


### PR DESCRIPTION
This is most non-testing code from hackathon. Most code taken from #144. It supports:
1. Reading parquet files from http/https
2. Reading via the `filesystem` interface from http/https

Currently working on how best to test this since we can't have stable urls to read from