### PR TITLE
Make the README for the example make more sense

### DIFF
--- a/kernel/examples/read-table-multi-threaded/README.md
+++ b/kernel/examples/read-table-multi-threaded/README.md
@@ -37,11 +37,11 @@ All paths must start with `file://` and be absolute.
 
 - Use the sync engine to read `kernel/tests/data/basic_partitioned/`
 
-`cargo run -- -i sync file:///[path-to-kernel-repo]/delta-kernel-rs/kernel/tests/data/basic_partitioned/`
+`cargo run -- -i sync file://[path-to-kernel-repo]/delta-kernel-rs/kernel/tests/data/basic_partitioned/`
 
 - Read some giant table using 100 threads:
 
-`cargo run -- -t 100 file://path/to/my/giant/table`
+`cargo run -- -t 100 file:///path/to/my/giant/table`
 
 ## selecting specific columns
 
@@ -49,4 +49,4 @@ To select specific columns you need a `--` after the column list specification.
 
 - Read `letter` and `data` columns from the `multi_partitioned` dat table:
 
-`cargo run -- --columns letter,data -- file:///[path-to-kernel-repo]/delta-kernel-rs/acceptance/tests/dat/out/reader_tests/generated/multi_partitioned/delta/`
+`cargo run -- --columns letter,data -- file://[path-to-kernel-repo]/delta-kernel-rs/acceptance/tests/dat/out/reader_tests/generated/multi_partitioned/delta/`

--- a/kernel/examples/read-table-multi-threaded/README.md
+++ b/kernel/examples/read-table-multi-threaded/README.md
@@ -29,7 +29,7 @@ All paths must start with `file://` and be absolute.
 
 - Read and print the table in `kernel/tests/data/table-with-dv-small/`:
 
-`cargo run -- file:///[path-to-kernel-repo]/delta-kernel-rs/kernel/tests/data/table-with-dv-small/`
+`cargo run -- file://[path-to-kernel-repo]/delta-kernel-rs/kernel/tests/data/table-with-dv-small/`
 
 - Get usage info:
 

--- a/kernel/examples/read-table-multi-threaded/README.md
+++ b/kernel/examples/read-table-multi-threaded/README.md
@@ -1,14 +1,18 @@
 Read Table Multi-Threaded
 =========================
 
+# About
 This example shows a program that reads a table using multiple threads. This shows the use of the
-`scan_files` and `scan_state` methods on a Scan, that can be used to partition work to either
-multiple threads, or workers (in the case of a distributed engine).
+`scan_data`, `global_scan_state`, and `visit_scan_files` methods, that can be used to partition work
+to either multiple threads, or workers (in the case of a distributed engine).
 
-We use a single-producer-multi-consumer channel to send each file and its metadata (in the form of a
-[`ScanFile`]) that needs to be read out to a pool of threads. Each thread reads from the channel,
-and then processes any files it receives. The results are sent back as Arrow `RecordBatch`s on a
-mutli-producer-single-consumer channel.
+You can run this from the same directory as this `README.md` by running `cargo run -- [args]`.
+
+We use a single-producer-multi-consumer channel to send each file and its metadata that needs to be
+read out to a pool of threads. The data is sent as a [`ScanFile`], a struct we define that holds all
+the metadata needed to read a file. Each thread reads from the channel, and then processes any files
+it receives. The results are sent back as Arrow `RecordBatch`s on a mutli-producer-single-consumer
+channel.
 
 Once the main thread has sent all the files out, we close the `ScanFile` sender, which means that
 once the last `ScanFile` has been received by a thread, subsequent `recv` calls in any thread will
@@ -18,3 +22,31 @@ We also ensure that _only_ the threads have copies of the `Sender`s used to send
 by closing the copy that the main thread has once all the threads have been created. This means that
 we can simply loop over our `RecordBatch` receiver, because it will return results until the last
 thread has exited (which closes that last sender).
+
+# Examples
+
+All paths must start with `file://` and be absolute.
+
+- Read and print the table in `kernel/tests/data/table-with-dv-small/`:
+
+`cargo run -- file:///[path-to-kernel-repo]/delta-kernel-rs/kernel/tests/data/table-with-dv-small/`
+
+- Get usage info:
+
+`cargo run -- --help`
+
+- Use the sync engine to read `kernel/tests/data/basic_partitioned/`
+
+`cargo run -- -i sync file:///[path-to-kernel-repo]/delta-kernel-rs/kernel/tests/data/basic_partitioned/`
+
+- Read some giant table using 100 threads:
+
+`cargo run -- -t 100 file://path/to/my/giant/table`
+
+## selecting specific columns
+
+To select specific columns you need a `--` after the column list specification.
+
+- Read `letter` and `data` columns from the `multi_partitioned` dat table:
+
+`cargo run -- --columns letter,data -- file:///[path-to-kernel-repo]/delta-kernel-rs/acceptance/tests/dat/out/reader_tests/generated/multi_partitioned/delta/`

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -20,7 +20,7 @@ use clap::{Parser, ValueEnum};
 use url::Url;
 
 /// An example program that reads a table using multiple threads. This shows the use of the
-/// scan_files and scan_state methods on a Scan, that can be used to partition work to either
+/// scan_data and global_scan_state methods on a Scan, that can be used to partition work to either
 /// multiple threads, or workers (in the case of a distributed engine).
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -83,7 +83,7 @@ pub enum Expression {
     Literal(Scalar),
     /// A column reference by name.
     Column(String),
-    ///
+    /// A struct computed from a Vec of expressions
     Struct(Vec<Expression>),
     /// A binary operation.
     BinaryOperation {


### PR DESCRIPTION
Add examples and more details the to `README.md` for `read-table-multi-threaded`.

Rust version got updated, so clippy started warning about two new things that I also fixed:
1. An empty doc comment
2. That the `loop` in this example could  be written as a `while let`. This fix changed a lot of indentation, but no actual logic.