### PR TITLE
Clean up some more old table client references (replace with engine)

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -3,5 +3,5 @@
 This directory contains acceptance tests for the Delta Kernel (Rust) project.
 These tests have been implemented as a separate sub-project in the workspace to
 ensure that they are acting as a "connector" for the kernel APIs, thereby
-allowing us to test the exact same client interfaces that any connector
+allowing us to test the exact same engine interfaces that any connector
 implemented on top of delta-kernel-rs would be using.

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 version.workspace = true
-build = "build.rs"
+build = false#"build.rs"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
@@ -17,7 +17,7 @@ tracing = "0.1"
 url = "2"
 delta_kernel = { path = "../kernel", features = ["developer-visibility"] }
 
-# used if we use the default client to be able to move arrow data into the c-ffi format
+# used if we use the default engine to be able to move arrow data into the c-ffi format
 arrow-schema = { version = "^49.0", default-features = false, features = ["ffi"], optional = true }
 arrow-data = { version = "^49.0", default-features = false, features = ["ffi"], optional = true }
 arrow-array = { version = "^49.0", default-features = false, optional = true }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 version.workspace = true
-build = false#"build.rs"
+build = "build.rs"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/ffi/cffi-test.c
+++ b/ffi/cffi-test.c
@@ -26,9 +26,9 @@ int main(int argc, char* argv[]) {
   KernelStringSlice table_path_slice = {table_path, strlen(table_path)};
 
   ExternResultExternEngineHandle engine_res =
-    get_default_client(table_path_slice, NULL);
+    get_default_engine(table_path_slice, NULL);
   if (engine_res.tag != OkExternEngineHandle) {
-    printf("Failed to get client\n");
+    printf("Failed to get engine\n");
     return -1;
   }
 

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -123,10 +123,10 @@ int main(int argc, char* argv[]) {
 
   // alternately if we don't care to set any options on the builder:
   // ExternResultExternEngineHandle engine_res =
-  //   get_default_client(table_path_slice, NULL);
+  //   get_default_engine(table_path_slice, NULL);
 
   if (engine_res.tag != OkExternEngineHandle) {
-    printf("Failed to get client\n");
+    printf("Failed to get engine\n");
     print_error("  ", (Error*)engine_builder_res.err);
     free_error((Error*)engine_builder_res.err);
     return -1;

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -54,7 +54,7 @@ pub struct ArrowFFIData {
 ///
 /// # Safety
 /// data_handle must be a valid EngineDataHandle as read by the [`DefaultEngine`] obtained
-/// from `get_default_client`.
+/// from `get_default_engine`.
 #[cfg(feature = "default-engine")]
 pub unsafe extern "C" fn get_raw_arrow_data(
     data_handle: *mut EngineDataHandle,
@@ -141,9 +141,9 @@ pub struct KernelScanDataIterator {
     // Item = Box<dyn EngineData>, see above, Vec<bool> -> can become a KernelBoolSlice
     data: Box<dyn Iterator<Item = DeltaResult<ScanData>>>,
 
-    // Also keep a reference to the external client for its error allocator.
+    // Also keep a reference to the external engine for its error allocator.
     // Parquet and Json handlers don't hold any reference to the tokio reactor, so the iterator
-    // terminates early if the last table client goes out of scope.
+    // terminates early if the last engine goes out of scope.
     engine: Arc<dyn ExternEngine>,
 }
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -36,7 +36,7 @@ delta_kernel_derive = { path = "../derive-macros", version = "0.0.1" }
 # used for developer-visibility
 visibility = "0.1.0"
 
-# Used in default client
+# Used in default engine
 arrow-array = { version = "^49.0", optional = true }
 arrow-select = { version = "^49.0", optional = true }
 arrow-arith = { version = "^49.0", optional = true }
@@ -45,12 +45,12 @@ arrow-ord = { version = "^49.0", optional = true }
 arrow-schema = { version = "^49.0", optional = true }
 futures = { version = "0.3", optional = true }
 object_store = { version = "^0.8.0", optional = true }
-# Used in default and sync client
+# Used in default and sync engine
 parquet = { version = "^49.0", optional = true }
 # Used for fetching direct urls (like pre-signed urls)
 reqwest = { version = "^0.11.0", optional = true }
 
-# optionally used with default client (though not required)
+# optionally used with default engine (though not required)
 tokio = { version = "1", optional = true, features = ["rt-multi-thread"] }
 
 [features]

--- a/kernel/examples/inspect-table/src/main.rs
+++ b/kernel/examples/inspect-table/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
     );
     let Ok(engine) = engine else {
         println!(
-            "Failed to construct table client: {}",
+            "Failed to construct engine: {}",
             engine.err().unwrap()
         );
         return;

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -226,7 +226,7 @@ fn do_work(
             location,
         };
 
-        // this example uses the parquet_handler from the engine_client, but an engine could
+        // this example uses the parquet_handler from the engine, but an engine could
         // choose to use whatever method it might want to read a parquet file. The reader
         // could, for example, fill in the parition columns, or apply deletion vectors. Here
         // we assume a more naive parquet reader and fix the data up after the fact.

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -403,8 +403,8 @@ mod tests {
 
     #[test]
     fn test_parse_add_partitioned() {
-        let client = SyncEngine::new();
-        let json_handler = client.get_json_handler();
+        let engine = SyncEngine::new();
+        let json_handler = engine.get_json_handler();
         let json_strings: StringArray = vec![
             r#"{"commitInfo":{"timestamp":1670892998177,"operation":"WRITE","operationParameters":{"mode":"Append","partitionBy":"[\"c1\",\"c2\"]"},"isolationLevel":"Serializable","isBlindAppend":true,"operationMetrics":{"numFiles":"3","numOutputRows":"3","numOutputBytes":"1356"},"engineInfo":"Apache-Spark/3.3.1 Delta-Lake/2.2.0","txnId":"046a258f-45e3-4657-b0bf-abfb0f76681c"}}"#,
             r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#,
@@ -467,8 +467,8 @@ mod tests {
 
     #[test]
     fn test_parse_txn() {
-        let client = SyncEngine::new();
-        let json_handler = client.get_json_handler();
+        let engine = SyncEngine::new();
+        let json_handler = engine.get_json_handler();
         let json_strings: StringArray = vec![
             r#"{"commitInfo":{"timestamp":1670892998177,"operation":"WRITE","operationParameters":{"mode":"Append","partitionBy":"[\"c1\",\"c2\"]"},"isolationLevel":"Serializable","isBlindAppend":true,"operationMetrics":{"numFiles":"3","numOutputRows":"3","numOutputBytes":"1356"},"engineInfo":"Apache-Spark/3.3.1 Delta-Lake/2.2.0","txnId":"046a258f-45e3-4657-b0bf-abfb0f76681c"}}"#,
             r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#,

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -355,8 +355,8 @@ mod tests {
 
     #[test]
     fn test_md_extract() -> DeltaResult<()> {
-        let client = SyncEngine::new();
-        let handler = client.get_json_handler();
+        let engine = SyncEngine::new();
+        let handler = engine.get_json_handler();
         let json_strings: StringArray = vec![
             r#"{"metaData":{"id":"aff5cb91-8cd9-4195-aef9-446908507302","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"c1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c3\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["c1","c2"],"configuration":{},"createdTime":1670892997849}}"#,
         ]
@@ -374,8 +374,8 @@ mod tests {
 
     #[test]
     fn test_nullable_struct() -> DeltaResult<()> {
-        let client = SyncEngine::new();
-        let handler = client.get_json_handler();
+        let engine = SyncEngine::new();
+        let handler = engine.get_json_handler();
         let json_strings: StringArray = vec![
             r#"{"metaData":{"id":"aff5cb91-8cd9-4195-aef9-446908507302","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"c1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c3\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["c1","c2"],"configuration":{},"createdTime":1670892997849}}"#,
         ]

--- a/kernel/src/engine/default/executor.rs
+++ b/kernel/src/engine/default/executor.rs
@@ -1,4 +1,4 @@
-//! The default client uses Async IO to read files, but the kernel APIs are all
+//! The default engine uses Async IO to read files, but the kernel APIs are all
 //! synchronous. Therefore, we need an executor to run the async IO on in the
 //! background.
 //!

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -62,7 +62,7 @@ impl JsonHandler for SyncJsonHandler {
         json_strings: Box<dyn EngineData>,
         output_schema: SchemaRef,
     ) -> DeltaResult<Box<dyn EngineData>> {
-        // TODO: This is taken from the default client as it's the same. We should share an
+        // TODO: This is taken from the default engine as it's the same. We should share an
         // implementation at some point
         let json_strings: RecordBatch = ArrowEngineData::try_from_engine_data(json_strings)?.into();
         if json_strings.num_columns() != 1 {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -3,18 +3,18 @@
 //! Delta-kernel-rs is an experimental [Delta](https://github.com/delta-io/delta/) implementation
 //! focused on interoperability with a wide range of query engines. It currently only supports
 //! reads. This library defines a number of traits which must be implemented to provide a
-//! working "delta reader". The are detailed below. There is a provided "default client" that
+//! working "delta reader". The are detailed below. There is a provided "default engine" that
 //! implenents all these traits and can be used to ease integration work. See
-//! [`DefaultEngine`](client/default/index.html) for more information.
+//! [`DefaultEngine`](engine/default/index.html) for more information.
 //!
-//! A full `rust` example for reading table data using the default client can be found
+//! A full `rust` example for reading table data using the default engine can be found
 //! [here](https://github.com/delta-incubator/delta-kernel-rs/blob/main/kernel/examples/dump-table/src/main.rs)
 //!
 //! # Engine traits
 //!
 //! The [`Engine`] trait allow connectors to bring their own implementation of functionality such as
 //! reading parquet files, listing files in a file system, parsing a JSON string etc.  This trait
-//! exposes methods to get sub-clients which expose the core functionalities customizable by
+//! exposes methods to get sub-engines which expose the core functionalities customizable by
 //! connectors.
 //!
 //! ## Expression handling
@@ -116,7 +116,7 @@ pub trait ExpressionEvaluator: Send + Sync {
 
 /// Provides expression evaluation capability to Delta Kernel.
 ///
-/// Delta Kernel can use this client to evaluate predicate on partition filters,
+/// Delta Kernel can use this handler to evaluate predicate on partition filters,
 /// fill up partition column values and any computation on data using Expressions.
 pub trait ExpressionHandler {
     /// Create an [`ExpressionEvaluator`] that can evaluate the given [`Expression`]

--- a/kernel/src/scan/file_stream.rs
+++ b/kernel/src/scan/file_stream.rs
@@ -258,12 +258,12 @@ impl LogReplayScanner {
 /// Given an iterator of (engine_data, bool) tuples and a predicate, returns an iterator of `Adds`.
 /// The boolean flag indicates whether the record batch is a log or checkpoint batch.
 pub fn log_replay_iter(
-    engine_client: &dyn Engine,
+    engine: &dyn Engine,
     action_iter: impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>>,
     table_schema: &SchemaRef,
     predicate: &Option<Expression>,
 ) -> impl Iterator<Item = DeltaResult<Add>> {
-    let mut log_scanner = LogReplayScanner::new(engine_client, table_schema, predicate);
+    let mut log_scanner = LogReplayScanner::new(engine, table_schema, predicate);
 
     action_iter.flat_map(move |actions| match actions {
         Ok((batch, is_log_batch)) => {

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -97,7 +97,7 @@ pub fn visit_scan_files<T>(
     Ok(visitor.context)
 }
 
-// add some visitor magic for clients
+// add some visitor magic for engines
 struct ScanFileVisitor<T> {
     callback: fn(&mut T, &str, i64, DvInfo, HashMap<String, String>),
     selection_vector: Vec<bool>,

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -380,8 +380,8 @@ mod tests {
             std::fs::canonicalize(PathBuf::from("./tests/data/table-with-dv-small/")).unwrap();
         let url = url::Url::from_directory_path(path).unwrap();
 
-        let client = SyncEngine::new();
-        let snapshot = Snapshot::try_new(url, &client, Some(1)).unwrap();
+        let engine = SyncEngine::new();
+        let snapshot = Snapshot::try_new(url, &engine, Some(1)).unwrap();
 
         let expected = Protocol {
             min_reader_version: 3,
@@ -402,8 +402,8 @@ mod tests {
             std::fs::canonicalize(PathBuf::from("./tests/data/table-with-dv-small/")).unwrap();
         let url = url::Url::from_directory_path(path).unwrap();
 
-        let client = SyncEngine::new();
-        let snapshot = Snapshot::try_new(url, &client, None).unwrap();
+        let engine = SyncEngine::new();
+        let snapshot = Snapshot::try_new(url, &engine, None).unwrap();
 
         let expected = Protocol {
             min_reader_version: 3,


### PR DESCRIPTION
Renames straggler [table] client references in the code, that escaped https://github.com/delta-incubator/delta-kernel-rs/pull/191.