### PR TITLE
Allow FFI to compile with neither default nor sync engine

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 tracing = "0.1"
 url = "2"
-delta_kernel = { path = "../kernel", default-features=false, features = ["developer-visibility"] }
+delta_kernel = { path = "../kernel", default-features = false, features = ["developer-visibility"] }
 
 # used if we use the default engine to be able to move arrow data into the c-ffi format
 arrow-schema = { version = "^49.0", default-features = false, features = ["ffi"], optional = true }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 tracing = "0.1"
 url = "2"
-delta_kernel = { path = "../kernel", features = ["developer-visibility"] }
+delta_kernel = { path = "../kernel", default-features=false, features = ["developer-visibility"] }
 
 # used if we use the default client to be able to move arrow data into the c-ffi format
 arrow-schema = { version = "^49.0", default-features = false, features = ["ffi"], optional = true }
@@ -34,3 +34,4 @@ default-engine = [
   "arrow-data",
   "arrow-schema"
 ]
+sync-engine = ["delta_kernel/sync-engine"]

--- a/ffi/cbindgen.toml
+++ b/ffi/cbindgen.toml
@@ -9,6 +9,7 @@ namespace = "ffi"
 
 [defines]
 "feature = default-engine" = "DEFINE_DEFAULT_ENGINE"
+"feature = sync-engine" = "DEFINE_SYNC_ENGINE"
 
 [export.mangle]
 remove_underscores = true

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,6 +1,7 @@
 /// FFI interface for the delta kernel
 ///
 /// Exposes that an engine needs to call from C/C++ to interface with kernel
+#[cfg(any(feature = "default-engine", feature = "sync-engine"))]
 use std::collections::HashMap;
 use std::default::Default;
 use std::os::raw::{c_char, c_void};
@@ -157,11 +158,13 @@ pub unsafe extern "C" fn drop_bool_slice(slice: *mut KernelBoolSlice) {
 pub enum KernelError {
     UnknownError, // catch-all for unrecognized kernel Error types
     FFIError,     // errors encountered in the code layer that supports FFI
+    #[cfg(any(feature = "default-engine", feature = "sync-engine"))]
     ArrowError,
     EngineDataTypeError,
     ExtractError,
     GenericError,
     IOErrorError,
+    #[cfg(any(feature = "default-engine", feature = "sync-engine"))]
     ParquetError,
     #[cfg(feature = "default-engine")]
     ObjectStoreError,
@@ -190,12 +193,14 @@ impl From<Error> for KernelError {
     fn from(e: Error) -> Self {
         match e {
             // NOTE: By definition, no kernel Error maps to FFIError
+            #[cfg(any(feature = "default-engine", feature = "sync-engine"))]
             Error::Arrow(_) => KernelError::ArrowError,
             Error::EngineDataType(_) => KernelError::EngineDataTypeError,
             Error::Extract(..) => KernelError::ExtractError,
             Error::Generic(_) => KernelError::GenericError,
             Error::GenericError { .. } => KernelError::GenericError,
             Error::IOError(_) => KernelError::IOErrorError,
+            #[cfg(any(feature = "default-engine", feature = "sync-engine"))]
             Error::Parquet(_) => KernelError::ParquetError,
             #[cfg(feature = "default-engine")]
             Error::ObjectStore(_) => KernelError::ObjectStoreError,
@@ -389,12 +394,14 @@ unsafe fn unwrap_and_parse_path_as_url(path: KernelStringSlice) -> DeltaResult<U
 }
 
 // A client builder allows setting options before building an actual client
+#[cfg(any(feature = "default-engine", feature = "sync-engine"))]
 pub struct EngineBuilder {
     url: Url,
     allocate_fn: AllocateErrorFn,
     options: HashMap<String, String>,
 }
 
+#[cfg(any(feature = "default-engine", feature = "sync-engine"))]
 impl EngineBuilder {
     fn set_option(&mut self, key: String, val: String) {
         self.options.insert(key, val);

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -422,6 +422,7 @@ impl From<ArrayType> for DataType {
     }
 }
 
+/// cbindgen:ignore
 impl DataType {
     pub const STRING: Self = DataType::Primitive(PrimitiveType::String);
     pub const LONG: Self = DataType::Primitive(PrimitiveType::Long);


### PR DESCRIPTION
The main kernel crate can compile without any engine implementations, but the FFI crate was missing some cfg and toml magic.

While we're at it, add a `cbindgen:ignore` directive to kernel's `impl DataType`, in order to suppress cbindgen warnings about the constants defined there.
