### PR TITLE
feat: add struct literal

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -243,6 +243,7 @@ pub enum KernelError {
     InvalidColumnMappingMode,
     InvalidTableLocation,
     InvalidDecimalError,
+    InvalidStructData,
 }
 
 impl From<Error> for KernelError {
@@ -282,6 +283,7 @@ impl From<Error> for KernelError {
             Error::InvalidColumnMappingMode(_) => KernelError::InvalidColumnMappingMode,
             Error::InvalidTableLocation(_) => KernelError::InvalidTableLocation,
             Error::InvalidDecimal(_) => KernelError::InvalidDecimalError,
+            Error::InvalidStructData(_) => KernelError::InvalidStructData,
             Error::Backtraced {
                 source,
                 backtrace: _,

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -79,6 +79,21 @@ impl Scalar {
                 DataType::Map { .. } => unimplemented!(),
                 DataType::Struct { .. } => unimplemented!(),
             },
+            Struct(values, fields) => {
+                let mut columns = Vec::with_capacity(values.len());
+                for val in values {
+                    columns.push(val.to_array(num_rows)?);
+                }
+                Arc::new(StructArray::try_new(
+                    fields
+                        .iter()
+                        .map(TryInto::<ArrowField>::try_into)
+                        .collect::<Result<Vec<_>, _>>()?
+                        .into(),
+                    columns,
+                    None,
+                )?)
+            }
         };
         Ok(arr)
     }

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -11,7 +11,7 @@ use arrow_array::{
 };
 use arrow_ord::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq};
 use arrow_schema::{
-    ArrowError, DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+    ArrowError, DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
 };
 use itertools::Itertools;
 
@@ -80,14 +80,12 @@ impl Scalar {
                 DataType::Struct { .. } => unimplemented!(),
             },
             Struct(values, fields) => {
-let columns = values.iter().map(|val| val.to_array(num_rows)).try_collect()?;
-let fields = fields.iter().map(ArrowField::try_from).try_collect()?;
-Arc::new(StructArray::try_new(
-    fields.into(),
-    columns,
-                    columns,
-                    None,
-                )?)
+                let arrays = values
+                    .iter()
+                    .map(|val| val.to_array(num_rows))
+                    .try_collect()?;
+                let fields: Fields = fields.iter().map(ArrowField::try_from).try_collect()?;
+                Arc::new(StructArray::try_new(fields, arrays, None)?)
             }
         };
         Ok(arr)

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -53,12 +53,17 @@ impl Scalar {
                 Decimal128Array::from_value(*val, num_rows)
                     .with_precision_and_scale(*precision, *scale as i8)?,
             ),
-            Struct(values, fields) => {
-                let arrays = values
+            Struct(data) => {
+                let arrays = data
+                    .values()
                     .iter()
                     .map(|val| val.to_array(num_rows))
                     .try_collect()?;
-                let fields: Fields = fields.iter().map(ArrowField::try_from).try_collect()?;
+                let fields: Fields = data
+                    .fields()
+                    .iter()
+                    .map(ArrowField::try_from)
+                    .try_collect()?;
                 Arc::new(StructArray::try_new(fields, arrays, None)?)
             }
             Null(data_type) => match data_type {

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -80,16 +80,11 @@ impl Scalar {
                 DataType::Struct { .. } => unimplemented!(),
             },
             Struct(values, fields) => {
-                let mut columns = Vec::with_capacity(values.len());
-                for val in values {
-                    columns.push(val.to_array(num_rows)?);
-                }
-                Arc::new(StructArray::try_new(
-                    fields
-                        .iter()
-                        .map(TryInto::<ArrowField>::try_into)
-                        .collect::<Result<Vec<_>, _>>()?
-                        .into(),
+let columns = values.iter().map(|val| val.to_array(num_rows)).try_collect()?;
+let fields = fields.iter().map(ArrowField::try_from).try_collect()?;
+Arc::new(StructArray::try_new(
+    fields.into(),
+    columns,
                     columns,
                     None,
                 )?)

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -143,6 +143,10 @@ pub enum Error {
     /// Precision or scale not compliant with delta specification
     #[error("Inavlid decimal: {0}")]
     InvalidDecimal(String),
+
+    /// Incosistent data passed to struct scalar
+    #[error("Invalid struct data: {0}")]
+    InvalidStructData(String),
 }
 
 // Convenience constructors for Error types that take a String argument
@@ -184,6 +188,9 @@ impl Error {
     }
     pub fn invalid_decimal(msg: impl ToString) -> Self {
         Self::InvalidDecimal(msg.to_string())
+    }
+    pub fn invalid_struct_data(msg: impl ToString) -> Self {
+        Self::InvalidStructData(msg.to_string())
     }
 
     // Capture a backtrace when the error is constructed.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 
 use itertools::Itertools;
 
-pub use self::scalars::Scalar;
+pub use self::scalars::{Scalar, StructData};
 
 mod scalars;
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -111,11 +111,10 @@ impl Display for Scalar {
             Self::Null(_) => write!(f, "null"),
             Self::Struct(values, fields) => {
                 write!(f, "{{")?;
-                for (i, (value, field)) in values.iter().zip(fields.iter()).enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{}: {}", field.name, value)?;
+                let mut delim = "";
+                for (value, field) in values.iter().zip(fields.iter()) {
+                    write!(f, "{delim}{}: {value}", field.name)?;
+                    delim = ", ";
                 }
                 write!(f, "}}")
             }

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -41,16 +41,14 @@ impl StructData {
                 ))
             );
 
-            if !f.is_nullable() {
-                require!(
-                    !a.is_null(),
-                    Error::invalid_struct_data(format!(
-                        "Value for non-nullable field {:?} cannto be null, got {}",
-                        f.name(),
-                        a
-                    ))
-                );
-            }
+            require!(
+                f.is_nullable() || !a.is_null(),
+                Error::invalid_struct_data(format!(
+                    "Value for non-nullable field {:?} cannto be null, got {}",
+                    f.name(),
+                    a
+                ))
+            );
         }
 
         Ok(Self { fields, values })

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -476,6 +476,10 @@ impl DataType {
     pub fn decimal_unchecked(precision: u8, scale: u8) -> Self {
         Self::decimal(precision, scale).unwrap()
     }
+
+    pub fn struct_type(fields: Vec<StructField>) -> Self {
+        DataType::Struct(Box::new(StructType::new(fields)))
+    }
 }
 
 impl Display for DataType {


### PR DESCRIPTION
Add a `Struct` literal type. The short term use is to use it when integrating with delta-rs. Assumption would be it might also come in handy as we develop the write path and need to express partition values.

Looked through the code if we needed to so some additional handling w.r.t. `fileConstantValues`, but that seems to be all in "raw" form as we find in the actions?