### PR TITLE
don't fully enforce matching schema

### DIFF
--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -72,9 +72,10 @@ static SKIPPED_TESTS: &[&str; 2] = &[
     "multi_partitioned_2",
 ];
 
-// Ensure that two schema have the same field names, data types, nullability, and
-// dict_id/ordering. Basically just ignore the metadata because that diverges from the real data to
-// the golden tabled data
+// Ensure that two schema have the same field names, data types, and dict_id/ordering.
+// We ignore:
+//  - nullability: parquet marks many things as nullable that we don't in our schema
+//  - metadata: because that diverges from the real data to the golden tabled data
 fn assert_schema_fields_match(schema: &Schema, golden: &Schema) {
     for (schema_field, golden_field) in schema.fields.iter().zip(golden.fields.iter()) {
         assert!(
@@ -84,10 +85,6 @@ fn assert_schema_fields_match(schema: &Schema, golden: &Schema) {
         assert!(
             schema_field.data_type() == golden_field.data_type(),
             "Field data types don't match"
-        );
-        assert!(
-            schema_field.is_nullable() == golden_field.is_nullable(),
-            "Field nullability doesn't match"
         );
         assert!(
             schema_field.dict_id() == golden_field.dict_id(),

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -154,22 +154,20 @@ fn ensure_data_types(
             // strings aren't primitive in arrow
             match arrow_type {
                 string_type @ ArrowDataType::Utf8 => Ok(string_type.clone()),
-                _ => {
-                    return Err(make_arrow_error(format!(
-                        "Incorrect datatype. Expected Utf8, got {}",
-                        arrow_type
-                    )))
-                }
+                _ => Err(make_arrow_error(format!(
+                    "Incorrect datatype. Expected Utf8, got {}",
+                    arrow_type
+                ))),
             }
         }
         DataType::Primitive(_) => {
             if arrow_type.is_primitive() {
                 Ok(arrow_type.clone())
             } else {
-                return Err(make_arrow_error(format!(
+                Err(make_arrow_error(format!(
                     "Incorrect datatype. Expected primitive, got {}",
                     arrow_type
-                )));
+                )))
             }
         }
         DataType::Array(inner_type) => match arrow_type {
@@ -179,12 +177,10 @@ fn ensure_data_types(
                 let _ = ensure_data_types(kernel_array_type, arrow_list_type)?;
                 Ok(list_type.clone())
             }
-            _ => {
-                return Err(make_arrow_error(format!(
-                    "Incorrect datatype. Expected List, got {}",
-                    arrow_type
-                )))
-            }
+            _ => Err(make_arrow_error(format!(
+                "Incorrect datatype. Expected List, got {}",
+                arrow_type
+            ))),
         },
         DataType::Map(kernel_map_type) => match arrow_type {
             map_type @ ArrowDataType::Map(arrow_map_type, _) => {
@@ -212,14 +208,12 @@ fn ensure_data_types(
                 }
                 Ok(map_type.clone())
             }
-            _ => {
-                return Err(Error::Arrow(
-                    arrow_schema::ArrowError::InvalidArgumentError(format!(
-                        "Incorrect datatype. Expected Map, got {}",
-                        arrow_type
-                    )),
-                ))
-            }
+            _ => Err(Error::Arrow(
+                arrow_schema::ArrowError::InvalidArgumentError(format!(
+                    "Incorrect datatype. Expected Map, got {}",
+                    arrow_type
+                )),
+            )),
         },
         DataType::Struct(kernel_fields) => match arrow_type {
             struct_type @ ArrowDataType::Struct(arrow_fields) => {
@@ -228,12 +222,10 @@ fn ensure_data_types(
                 }
                 Ok(struct_type.clone())
             }
-            _ => {
-                return Err(make_arrow_error(format!(
-                    "Incorrect datatype. Expected Struct, got {}",
-                    arrow_type
-                )))
-            }
+            _ => Err(make_arrow_error(format!(
+                "Incorrect datatype. Expected Struct, got {}",
+                arrow_type
+            ))),
         },
     }
 }

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -195,12 +195,12 @@ fn ensure_data_types(
                         "Arrow map struct didn't have a value type".to_string(),
                     ));
                 }
+                Ok(arrow_type.clone())
             } else {
-                return Err(make_arrow_error(
+                Err(make_arrow_error(
                     "Arrow map type wasn't a struct.".to_string(),
-                ));
+                ))
             }
-            Ok(arrow_type.clone())
         }
         (DataType::Struct(kernel_fields), ArrowDataType::Struct(arrow_fields)) => {
             for (kernel_field, arrow_field) in kernel_fields.fields().zip(arrow_fields.iter()) {

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -144,7 +144,7 @@ fn make_arrow_error(s: String) -> Error {
     Error::Arrow(arrow_schema::ArrowError::InvalidArgumentError(s))
 }
 
-/// Ensure a kernel data type matches an arrow data type. This only ensures that the actually "type"
+/// Ensure a kernel data type matches an arrow data type. This only ensures that the actual "type"
 /// is the same, but does so recursively into structs, and ensures lists and maps have the correct
 /// associated types as well. This returns an `Ok(())` if the types are compatible, or an error if
 /// the types do not match.

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -160,6 +160,16 @@ fn ensure_data_types(
                 ))),
             }
         }
+        DataType::Primitive(PrimitiveType::Binary) => {
+            // binary isn't primitive in arrow
+            match arrow_type {
+                string_type @ ArrowDataType::Binary => Ok(string_type.clone()),
+                _ => Err(make_arrow_error(format!(
+                    "Incorrect datatype. Expected Binary, got {}",
+                    arrow_type
+                ))),
+            }
+        }
         DataType::Primitive(_) => {
             if arrow_type.is_primitive() {
                 Ok(arrow_type.clone())

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -203,10 +203,17 @@ fn ensure_data_types(
             }
         }
         (DataType::Struct(kernel_fields), ArrowDataType::Struct(arrow_fields)) => {
-            for (kernel_field, arrow_field) in kernel_fields.fields().zip(arrow_fields.iter()) {
-                let _ = ensure_data_types(&kernel_field.data_type, arrow_field.data_type())?;
+            if kernel_fields.fields.len() == arrow_fields.len() {
+                for (kernel_field, arrow_field) in kernel_fields.fields().zip(arrow_fields.iter()) {
+                    let _ = ensure_data_types(&kernel_field.data_type, arrow_field.data_type())?;
+                }
+                Ok(arrow_type.clone())
+            } else {
+                Err(make_arrow_error(format!(
+                    "Struct types have different numbers of fields. Expected {}, got {}",
+                    kernel_fields.fields.len(), arrow_fields.len()
+                )))
             }
-            Ok(arrow_type.clone())
         }
         _ => Err(make_arrow_error(format!(
             "Incorrect datatype. Expected {}, got {}",

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -159,8 +159,8 @@ fn ensure_data_types(kernel_type: &DataType, arrow_type: &ArrowDataType) -> Delt
         (
             DataType::Primitive(PrimitiveType::Decimal(kernel_prec, kernel_scale)),
             ArrowDataType::Decimal128(arrow_prec, arrow_scale),
-        ) if arrow_prec == kernel_prec && arrow_scale == kernel_scale => {
-            // decimal isn't primitive in arrow
+        ) if arrow_prec == kernel_prec && *arrow_scale == *kernel_scale as i8 => {
+            // decimal isn't primitive in arrow. cast above is okay as we limit range
             Ok(())
         }
         (DataType::Array(inner_type), ArrowDataType::List(arrow_list_type)) => {


### PR DESCRIPTION
When we read from a checkpoint, there can be disagreement about the schema we think we've read, and what was actually in the parquet.  This can cause issues when we try and interact with engine data via expressions. For example [here](https://github.com/delta-incubator/delta-kernel-rs/blob/main/kernel/src/scan/log_replay.rs#L219), where we use the "correct" schema and do not mark dvs as nullable. Also, in our arrow_conversions we make assumptions about the names of the fields that mark map keys and values (see [here](https://github.com/delta-incubator/delta-kernel-rs/blob/main/kernel/src/engine/arrow_conversion.rs#L128)), which also causes issues when the actual materialized names are different.

An example error trying to work with a checkpoint file:
```
Arrow(
    InvalidArgumentError(
        "Incorrect datatype for StructArray field \"deletionVector\", expected Struct([Field { name: \"storageType\", data_type: Utf8, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"pathOrInlineDv\", data_type: Utf8, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"offset\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"sizeInBytes\", data_type: Int32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"cardinality\", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }]) got Struct([Field { name: \"storageType\", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"pathOrInlineDv\", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"offset\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"sizeInBytes\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"cardinality\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"maxRowIndex\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }])",
    ),
)
```

This arises for two reasons:

1. To avoid "parquet corruption", spark will write a nullable struct as having _all_ fields nullable. Thus, for example, since DVs are nullable, all fields of the DV struct are marked nullable. This means the "nullability" of fields will not be the same as the specified read schema
2. We can't guarantee exactly what names the "meta" fields for maps/lists will have in the raw schema

This PR does as much validation as possible, but doesn't check things we can't control. So for each named field in the output schema it ensures the types are the same, and does so recursively into structs, maps, and lists.

Then it simply uses the schema that the parquet/json reader had already associated with the data. 

This "works". Major issues:
1. The schema you ask for might not be exactly the schema you get. Although differences in nullability are the only "observable" difference from kernel perspective
2. A bigger issue is that this complicates the writing of expression evaluators for engines, as we'll have to carefully document and explain potential schema mismatches.

After some discussion, we will go with this for the time being.
