### PR TITLE
fix: timestamp ntz and decimal conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 acceptance/tests/dat/
 .vscode
 ffi/examples/read-table/build
+/build

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -228,6 +228,7 @@ pub enum KernelError {
     ParseIntError,
     InvalidColumnMappingMode,
     InvalidTableLocation,
+    InvalidDecimalError,
 }
 
 impl From<Error> for KernelError {
@@ -266,6 +267,7 @@ impl From<Error> for KernelError {
             Error::ParseIntError(_) => KernelError::ParseIntError,
             Error::InvalidColumnMappingMode(_) => KernelError::InvalidColumnMappingMode,
             Error::InvalidTableLocation(_) => KernelError::InvalidTableLocation,
+            Error::InvalidDecimal(_) => KernelError::InvalidDecimalError,
             Error::Backtraced {
                 source,
                 backtrace: _,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -688,7 +688,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         precision: u8,
-        scale: i8,
+        scale: u8,
     ),
 
     /// Visit a `string` belonging to the list identified by `sibling_list_id`.

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -203,7 +203,7 @@ impl TryFrom<&ArrowDataType> for DataType {
             ArrowDataType::FixedSizeBinary(_) => Ok(DataType::Primitive(PrimitiveType::Binary)),
             ArrowDataType::LargeBinary => Ok(DataType::Primitive(PrimitiveType::Binary)),
             ArrowDataType::Decimal128(p, s) => {
-                if s < &0 {
+                if *s < 0 {
                     return Err(ArrowError::from_external_error(
                         Error::invalid_decimal("Negative scales are not supported in Delta").into(),
                     ));

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -107,6 +107,7 @@ impl TryFrom<&DataType> for ArrowDataType {
                         // timezone. Stored as 4 bytes integer representing days since 1970-01-01
                         Ok(ArrowDataType::Date32)
                     }
+                    // TODO: https://github.com/delta-io/delta/issues/643
                     PrimitiveType::Timestamp => Ok(ArrowDataType::Timestamp(
                         TimeUnit::Microsecond,
                         Some("UTC".into()),

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -92,15 +92,9 @@ impl TryFrom<&DataType> for ArrowDataType {
                     PrimitiveType::Boolean => Ok(ArrowDataType::Boolean),
                     PrimitiveType::Binary => Ok(ArrowDataType::Binary),
                     PrimitiveType::Decimal(precision, scale) => {
-                        if precision <= &38 {
-                            Ok(ArrowDataType::Decimal128(*precision, *scale))
-                        } else {
-                            // NOTE: since we are converting from delta, we should never get here.
-                            Err(ArrowError::SchemaError(format!(
-                                "Precision too large to be represented as Delta type: {} > 38",
-                                precision
-                            )))
-                        }
+                        PrimitiveType::check_decimal(*precision, *scale)
+                            .map_err(|e| ArrowError::from_external_error(e.into()))?;
+                        Ok(ArrowDataType::Decimal128(*precision, *scale))
                     }
                     PrimitiveType::Date => {
                         // A calendar date, represented as a year-month-day triple without a

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -50,7 +50,7 @@ impl Scalar {
             Binary(val) => Arc::new(BinaryArray::from(vec![val.as_slice(); num_rows])),
             Decimal(val, precision, scale) => Arc::new(
                 Decimal128Array::from_value(*val, num_rows)
-                    .with_precision_and_scale(*precision, *scale)?,
+                    .with_precision_and_scale(*precision, *scale as i8)?,
             ),
             Null(data_type) => match data_type {
                 DataType::Primitive(primitive) => match primitive {
@@ -72,7 +72,7 @@ impl Scalar {
                     PrimitiveType::Binary => Arc::new(BinaryArray::new_null(num_rows)),
                     PrimitiveType::Decimal(precision, scale) => Arc::new(
                         Decimal128Array::new_null(num_rows)
-                            .with_precision_and_scale(*precision, *scale)?,
+                            .with_precision_and_scale(*precision, *scale as i8)?,
                     ),
                 },
                 DataType::Array(_) => unimplemented!(),

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -42,8 +42,9 @@ impl Scalar {
             Double(val) => Arc::new(Float64Array::from_value(*val, num_rows)),
             String(val) => Arc::new(StringArray::from(vec![val.clone(); num_rows])),
             Boolean(val) => Arc::new(BooleanArray::from(vec![*val; num_rows])),
-            Timestamp(val) => Arc::new(TimestampMicrosecondArray::from_value(*val, num_rows)),
-            // TODO: Is this correct?
+            Timestamp(val) => {
+                Arc::new(TimestampMicrosecondArray::from_value(*val, num_rows).with_timezone_utc())
+            }
             TimestampNtz(val) => Arc::new(TimestampMicrosecondArray::from_value(*val, num_rows)),
             Date(val) => Arc::new(Date32Array::from_value(*val, num_rows)),
             Binary(val) => Arc::new(BinaryArray::from(vec![val.as_slice(); num_rows])),
@@ -61,7 +62,10 @@ impl Scalar {
                     PrimitiveType::Double => Arc::new(Float64Array::new_null(num_rows)),
                     PrimitiveType::String => Arc::new(StringArray::new_null(num_rows)),
                     PrimitiveType::Boolean => Arc::new(BooleanArray::new_null(num_rows)),
-                    PrimitiveType::Timestamp | PrimitiveType::TimestampNtz => {
+                    PrimitiveType::Timestamp => {
+                        Arc::new(TimestampMicrosecondArray::new_null(num_rows).with_timezone_utc())
+                    }
+                    PrimitiveType::TimestampNtz => {
                         Arc::new(TimestampMicrosecondArray::new_null(num_rows))
                     }
                     PrimitiveType::Date => Arc::new(Date32Array::new_null(num_rows)),

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -139,6 +139,10 @@ pub enum Error {
     /// Asked for a table at an invalid location
     #[error("Invalid table location: {0}.")]
     InvalidTableLocation(String),
+
+    /// Precision or scale not compliant with delta specification
+    #[error("Inavlid decimal: {0}")]
+    InvalidDecimal(String),
 }
 
 // Convenience constructors for Error types that take a String argument
@@ -175,9 +179,11 @@ impl Error {
     pub fn invalid_table_location(location: impl ToString) -> Self {
         Self::InvalidTableLocation(location.to_string())
     }
-
     pub fn invalid_column_mapping_mode(mode: impl ToString) -> Self {
         Self::InvalidColumnMappingMode(mode.to_string())
+    }
+    pub fn invalid_decimal(msg: impl ToString) -> Self {
+        Self::InvalidDecimal(msg.to_string())
     }
 
     // Capture a backtrace when the error is constructed.

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -144,7 +144,7 @@ impl PrimitiveType {
     /// Check if the given precision and scale are valid for a decimal type.
     pub fn check_decimal(precision: u8, scale: u8) -> DeltaResult<()> {
         require!(
-            precision > 0 && precision <= 38,
+            0 < precision && precision <= 38,
             Error::invalid_decimal(format!(
                 "precision must in range 1..38 inclusive, found: {}.",
                 precision

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -145,10 +145,13 @@ impl PrimitiveType {
     pub fn check_decimal(precision: u8, scale: i8) -> DeltaResult<()> {
         require!(
             precision > 0 && precision <= 38,
-            Error::invalid_decimal("precision must in range 1..38 inclusive.")
+            Error::invalid_decimal(format!(
+                "precision must in range 1..38 inclusive, found: {}.",
+                precision
+            ))
         );
         require!(
-            scale >= 0 && scale <= precision as i8,
+            scale.abs() <= 38,
             Error::invalid_decimal("scale must be in range 0..precision inclusive.")
         );
         Ok(())
@@ -318,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_parse_decimal() -> Result<(), Box<dyn std::error::Error>> {
-        assert_decimal("0", 0, 0, 0)?;
+        assert_decimal("0", 0, 1, 0)?;
         assert_decimal("0.00", 0, 3, 2)?;
         assert_decimal("123", 123, 3, 0)?;
         assert_decimal("-123", -123, 3, 0)?;
@@ -331,8 +334,8 @@ mod tests {
         assert_decimal("0.00123", 123, 5, 5)?;
         assert_decimal("-1.23E-12", -123, 3, 14)?;
         assert_decimal("1234.5E-4", 12345, 5, 5)?;
-        assert_decimal("0E+7", 0, 0, -7)?;
-        assert_decimal("-0", 0, 0, 0)?;
+        assert_decimal("0E+7", 0, 1, -7)?;
+        assert_decimal("-0", 0, 1, 0)?;
         assert_decimal("12.000000000000000000", 12000000000000000000, 38, 18)?;
         Ok(())
     }

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 
 use crate::schema::{DataType, PrimitiveType};
 use crate::utils::require;
-use crate::Error;
+use crate::{DeltaResult, Error};
 
 /// A single value, which can be null. Used for representing literal values
 /// in [Expressions][crate::expressions::Expression].
@@ -33,8 +33,8 @@ pub enum Scalar {
 }
 
 impl Scalar {
-    pub fn data_type(&self) -> DataType {
-        match self {
+    pub fn data_type(&self) -> DeltaResult<DataType> {
+        let data_type = match self {
             Self::Integer(_) => DataType::INTEGER,
             Self::Long(_) => DataType::LONG,
             Self::Short(_) => DataType::SHORT,
@@ -47,9 +47,10 @@ impl Scalar {
             Self::TimestampNtz(_) => DataType::TIMESTAMP_NTZ,
             Self::Date(_) => DataType::DATE,
             Self::Binary(_) => DataType::BINARY,
-            Self::Decimal(_, precision, scale) => DataType::decimal(*precision, *scale),
+            Self::Decimal(_, precision, scale) => DataType::decimal(*precision, *scale)?,
             Self::Null(data_type) => data_type.clone(),
-        }
+        };
+        Ok(data_type)
     }
 }
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -85,7 +85,7 @@ impl Display for Scalar {
                 }
                 Ordering::Less => {
                     write!(f, "{}", value)?;
-                    for _ in 0..(*scale) {
+                    for _ in 0..*scale {
                         write!(f, "0")?;
                     }
                     Ok(())

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -356,18 +356,18 @@ pub enum PrimitiveType {
         deserialize_with = "deserialize_decimal",
         untagged
     )]
-    Decimal(u8, i8),
+    Decimal(u8, u8),
 }
 
 fn serialize_decimal<S: serde::Serializer>(
     precision: &u8,
-    scale: &i8,
+    scale: &u8,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     serializer.serialize_str(&format!("decimal({},{})", precision, scale))
 }
 
-fn deserialize_decimal<'de, D>(deserializer: D) -> Result<(u8, i8), D::Error>
+fn deserialize_decimal<'de, D>(deserializer: D) -> Result<(u8, u8), D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -386,7 +386,7 @@ where
         })?;
     let scale = parts
         .next()
-        .and_then(|part| part.trim().parse::<i8>().ok())
+        .and_then(|part| part.trim().parse::<u8>().ok())
         .ok_or_else(|| {
             serde::de::Error::custom(format!("Invalid scale in decimal: {}", str_value))
         })?;
@@ -464,7 +464,7 @@ impl DataType {
     pub const TIMESTAMP: Self = DataType::Primitive(PrimitiveType::Timestamp);
     pub const TIMESTAMP_NTZ: Self = DataType::Primitive(PrimitiveType::TimestampNtz);
 
-    pub fn decimal(precision: u8, scale: i8) -> DeltaResult<Self> {
+    pub fn decimal(precision: u8, scale: u8) -> DeltaResult<Self> {
         PrimitiveType::check_decimal(precision, scale)?;
         Ok(DataType::Primitive(PrimitiveType::Decimal(
             precision, scale,
@@ -473,7 +473,7 @@ impl DataType {
 
     // This function assumes that the caller has already checked the precision and scale
     // and that they are valid. Will panic if they are not.
-    pub fn decimal_unchecked(precision: u8, scale: i8) -> Self {
+    pub fn decimal_unchecked(precision: u8, scale: u8) -> Self {
         Self::decimal(precision, scale).unwrap()
     }
 }

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -390,7 +390,7 @@ where
         .ok_or_else(|| {
             serde::de::Error::custom(format!("Invalid scale in decimal: {}", str_value))
         })?;
-    PrimitiveType::check_decimal(precision, scale).map_err(|e| serde::de::Error::custom(e))?;
+    PrimitiveType::check_decimal(precision, scale).map_err(serde::de::Error::custom)?;
     Ok((precision, scale))
 }
 

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -672,10 +672,7 @@ mod tests {
             "metadata": {}
         }
         "#;
-        assert!(matches!(
-            serde_json::from_str::<StructField>(data).unwrap_err(),
-            _
-        ));
+        assert!(serde_json::from_str::<StructField>(data).is_err());
 
         let data = r#"
         {
@@ -685,9 +682,6 @@ mod tests {
             "metadata": {}
         }
         "#;
-        assert!(matches!(
-            serde_json::from_str::<StructField>(data).unwrap_err(),
-            _
-        ));
+        assert!(serde_json::from_str::<StructField>(data).is_err());
     }
 }


### PR DESCRIPTION
This PR fixes some inconsistencies when handling Timestamp NTZ types and adds some checks, that bounds for devimal128 type are enforced.

maybe in a follow up we may need to investigate how we can best ensure the `timestampNTZ` feature is enabled when the type is encountered.