### PR TITLE
Add compilation failure tests for Handle

### DIFF
--- a/ffi-proc-macros/src/lib.rs
+++ b/ffi-proc-macros/src/lib.rs
@@ -84,6 +84,18 @@ fn bool_to_boolean(b: bool) -> TokenStream2 {
 }
 
 /// Macro for conveniently deriving a `delta_kernel_ffi::handle::HandleDescriptor`.
+///
+/// When targeting a struct, it is invoked with three arguments:
+/// ```ignore
+/// #[handle_descriptor(target = Foo, mutable = false. sized = true)]
+/// pub struct SharedFoo;
+/// ```
+///
+/// When targeting a trait, two arguments suffice (`sized = false` is implied):
+/// ```ignore
+/// #[handle_descriptor(target = dyn Bar, mutable = true)]
+/// pub struct MutableBar;
+/// ```
 #[proc_macro_attribute]
 pub fn handle_descriptor(attr: TokenStream, item: TokenStream) -> TokenStream {
     let descriptor_params = parse_macro_input!(attr as HandleDescriptorParams);

--- a/ffi-proc-macros/src/lib.rs
+++ b/ffi-proc-macros/src/lib.rs
@@ -80,7 +80,7 @@ fn bool_to_boolean(b: bool) -> TokenStream2 {
     } else {
         quote! { False }
     };
-    quote! { crate::handle::#name }
+    quote! { delta_kernel_ffi::handle::#name }
 }
 
 /// Macro for conveniently deriving a `delta_kernel_ffi::handle::HandleDescriptor`.
@@ -105,7 +105,7 @@ pub fn handle_descriptor(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Inject a single unconstructible member to produce a NZST
     let ident = &st.ident;
-    let new_struct = quote! { struct #ident(crate::handle::Unconstructable); };
+    let new_struct = quote! { struct #ident(delta_kernel_ffi::handle::Unconstructable); };
     let new_struct = new_struct.into();
     let new_struct = parse_macro_input!(new_struct as ItemStruct);
     st.fields = new_struct.fields;
@@ -116,7 +116,7 @@ pub fn handle_descriptor(attr: TokenStream, item: TokenStream) -> TokenStream {
     let target = &descriptor_params.target;
     let descriptor_impl = quote! {
         #[automatically_derived]
-        impl crate::handle::HandleDescriptor for #ident {
+        impl delta_kernel_ffi::handle::HandleDescriptor for #ident {
             type Target = #target;
             type Mutable = #mutable;
             type Sized = #sized;

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -40,4 +40,4 @@ default-engine = [
   "arrow-schema"
 ]
 sync-engine = ["delta_kernel/sync-engine"]
-doc-tests = []
+developer-visibility = []

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 version.workspace = true
-build = "build.rs"
+build = false#"build.rs"
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 tracing = "0.1"
@@ -29,6 +29,7 @@ libc = "0.2.147"
 
 [dev-dependencies]
 rand = "0.8.5"
+trybuild = "1.0"
 
 [features]
 default = ["default-engine"]
@@ -39,3 +40,4 @@ default-engine = [
   "arrow-schema"
 ]
 sync-engine = ["delta_kernel/sync-engine"]
+doc-tests = []

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -35,7 +35,7 @@
 /// #[handle_descriptor(target = Foo, mutable = true, sized = true)]
 /// pub struct MutableFoo;
 ///
-/// pub trait Bar {}
+/// pub trait Bar: Send {}
 ///
 /// #[handle_descriptor(target = dyn Bar, mutable = false)]
 /// pub struct SharedBar;
@@ -538,7 +538,10 @@ mod tests {
     #[handle_descriptor(target=NotSync, mutable=true, sized=true)]
     pub struct MutNotSync;
 
+    // Because tests compile as binaries against packages, this test can only run correctly if we
+    // use developer-visibility to make mod handle public. Otherwise it's inaccessible for testing.
     #[test]
+    #[cfg(feature="developer-visibility")]
     fn invalid_handle_code() {
         let t = trybuild::TestCases::new();
         t.compile_fail("tests/invalid-handle-code/*.rs");

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -16,9 +16,9 @@ use delta_kernel::snapshot::Snapshot;
 use delta_kernel::{DeltaResult, Engine, Error, Table};
 use delta_kernel_ffi_macros::handle_descriptor;
 
-#[cfg(feature="doc-tests")]
+#[cfg(feature="developer-visibility")]
 pub mod handle;
-#[cfg(not(feature="doc-tests"))]
+#[cfg(not(feature="developer-visibility"))]
 pub(crate) mod handle;
 
 use handle::Handle;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -16,8 +16,17 @@ use delta_kernel::snapshot::Snapshot;
 use delta_kernel::{DeltaResult, Engine, Error, Table};
 use delta_kernel_ffi_macros::handle_descriptor;
 
+#[cfg(feature="doc-tests")]
+pub mod handle;
+#[cfg(not(feature="doc-tests"))]
 pub(crate) mod handle;
+
 use handle::Handle;
+
+// The handle_descriptor macro needs this, because it needs to emit fully qualified type names. THe
+// actual prod code could use `crate::`, but doc tests can't because they're not "inside" the crate.
+// relies on `crate::`
+extern crate self as delta_kernel_ffi;
 
 pub mod scan;
 
@@ -66,9 +75,10 @@ impl Iterator for EngineIterator {
 /// references to the slice or its data that could outlive the function call.
 ///
 /// ```
-/// fn wants_slice(slice: KernelStringSlice) { ... }
-/// let msg = String::from(...);
-/// wants_slice(msg.as_ref().into());
+/// # use delta_kernel_ffi::KernelStringSlice;
+/// fn wants_slice(slice: KernelStringSlice) { }
+/// let msg = String::from("hello");
+/// wants_slice(msg.into());
 /// ```
 #[repr(C)]
 pub struct KernelStringSlice {

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -295,10 +295,11 @@ pub unsafe extern "C" fn get_from_map(
     key: KernelStringSlice,
     allocate_fn: AllocateStringFn,
 ) -> NullableCvoid {
-    let string_key = String::try_from_slice(key);
+    // TODO: Return ExternResult to caller instead of panicking?
+    let string_key = unsafe { String::try_from_slice(key) };
     map.values
-        .get(&string_key)
-        .and_then(|v| allocate_fn(v.as_str().into()))
+        .get(&string_key.unwrap())
+        .and_then(|v| allocate_fn(v.into()))
 }
 
 /// Get a selection vector out of a [`DvInfo`] struct

--- a/ffi/tests/invalid-handle-code/double-mut-reference.rs
+++ b/ffi/tests/invalid-handle-code/double-mut-reference.rs
@@ -1,0 +1,16 @@
+use delta_kernel_ffi_macros::handle_descriptor;
+use delta_kernel_ffi::handle::Handle;
+
+pub struct Foo(u32);
+
+#[handle_descriptor(target=Foo, mutable=true, sized=true)]
+pub struct MutFoo;
+
+fn main() {
+    let s = Foo(0);
+    let mut h: Handle<MutFoo> = Box::new(s).into();
+    let r = unsafe { h.as_mut() };
+    let _ = unsafe { h.as_mut() };
+    let _ = unsafe { h.as_ref() };
+    r.0 = 1;
+}

--- a/ffi/tests/invalid-handle-code/double-mut-reference.stderr
+++ b/ffi/tests/invalid-handle-code/double-mut-reference.stderr
@@ -1,0 +1,21 @@
+error[E0499]: cannot borrow `h` as mutable more than once at a time
+  --> tests/invalid-handle-code/double-mut-reference.rs:13:22
+   |
+12 |     let r = unsafe { h.as_mut() };
+   |                      - first mutable borrow occurs here
+13 |     let _ = unsafe { h.as_mut() };
+   |                      ^ second mutable borrow occurs here
+14 |     let _ = unsafe { h.as_ref() };
+15 |     r.0 = 1;
+   |     ------- first borrow later used here
+
+error[E0502]: cannot borrow `h` as immutable because it is also borrowed as mutable
+  --> tests/invalid-handle-code/double-mut-reference.rs:14:22
+   |
+12 |     let r = unsafe { h.as_mut() };
+   |                      - mutable borrow occurs here
+13 |     let _ = unsafe { h.as_mut() };
+14 |     let _ = unsafe { h.as_ref() };
+   |                      ^ immutable borrow occurs here
+15 |     r.0 = 1;
+   |     ------- mutable borrow later used here

--- a/ffi/tests/invalid-handle-code/moved-from-handle.rs
+++ b/ffi/tests/invalid-handle-code/moved-from-handle.rs
@@ -1,0 +1,15 @@
+use delta_kernel_ffi_macros::handle_descriptor;
+use delta_kernel_ffi::handle::Handle;
+
+pub struct Foo(u32);
+
+#[handle_descriptor(target=Foo, mutable=true, sized=true)]
+pub struct MutFoo;
+
+fn main() {
+    let s = Foo(0);
+    let mut h: Handle<MutFoo> = Box::new(s).into();
+    unsafe { h.drop_handle() };
+    let _ = unsafe { h.into_inner() };
+    let _ = unsafe { h.as_mut() };
+}

--- a/ffi/tests/invalid-handle-code/moved-from-handle.stderr
+++ b/ffi/tests/invalid-handle-code/moved-from-handle.stderr
@@ -1,0 +1,32 @@
+error[E0382]: use of moved value: `h`
+  --> tests/invalid-handle-code/moved-from-handle.rs:13:22
+   |
+11 |     let mut h: Handle<MutFoo> = Box::new(s).into();
+   |         ----- move occurs because `h` has type `Handle<MutFoo>`, which does not implement the `Copy` trait
+12 |     unsafe { h.drop_handle() };
+   |                ------------- `h` moved due to this method call
+13 |     let _ = unsafe { h.into_inner() };
+   |                      ^ value used here after move
+   |
+note: `Handle::<H>::drop_handle` takes ownership of the receiver `self`, which moves `h`
+  --> src/handle.rs
+   |
+   |         pub unsafe fn drop_handle(self) {
+   |                                   ^^^^
+
+error[E0382]: borrow of moved value: `h`
+  --> tests/invalid-handle-code/moved-from-handle.rs:14:22
+   |
+11 |     let mut h: Handle<MutFoo> = Box::new(s).into();
+   |         ----- move occurs because `h` has type `Handle<MutFoo>`, which does not implement the `Copy` trait
+12 |     unsafe { h.drop_handle() };
+13 |     let _ = unsafe { h.into_inner() };
+   |                        ------------ `h` moved due to this method call
+14 |     let _ = unsafe { h.as_mut() };
+   |                      ^ value borrowed here after move
+   |
+note: `Handle::<H>::into_inner` takes ownership of the receiver `self`, which moves `h`
+  --> src/handle.rs
+   |
+   |         pub unsafe fn into_inner(self) -> H::From {
+   |                                  ^^^^

--- a/ffi/tests/invalid-handle-code/mut-clone-handle.rs
+++ b/ffi/tests/invalid-handle-code/mut-clone-handle.rs
@@ -1,0 +1,15 @@
+use delta_kernel_ffi_macros::handle_descriptor;
+use delta_kernel_ffi::handle::Handle;
+use std::sync::Arc;
+
+pub struct Foo(u32);
+
+#[handle_descriptor(target=Foo, mutable=true, sized=true)]
+pub struct MutFoo;
+
+fn main() {
+    let s = Foo(0);
+    let h: Handle<MutFoo> = Arc::new(s).into();
+    let r = h.clone_as_arc();
+    let h = h.clone_handle();
+}

--- a/ffi/tests/invalid-handle-code/mut-clone-handle.stderr
+++ b/ffi/tests/invalid-handle-code/mut-clone-handle.stderr
@@ -1,0 +1,66 @@
+error[E0599]: the method `clone_as_arc` exists for struct `Handle<MutFoo>`, but its trait bounds were not satisfied
+  --> tests/invalid-handle-code/mut-clone-handle.rs:13:15
+   |
+8  | pub struct MutFoo;
+   | ----------------- doesn't satisfy 5 bounds
+...
+13 |     let r = h.clone_as_arc();
+   |               ^^^^^^^^^^^^ method cannot be called on `Handle<MutFoo>` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `<MutFoo as HandleDescriptor>::Mutable = False`
+           `<MutFoo as handle::private::HandleOps<_, False, _>>::From = Arc<_>`
+           `MutFoo: handle::private::SharedHandleOps<_, _>`
+           `MutFoo: handle::private::SharedHandle`
+           which is required by `MutFoo: handle::private::SharedHandleOps<_, _>`
+           `MutFoo: handle::private::HandleOps<_, False, _>`
+           which is required by `MutFoo: handle::private::SharedHandleOps<_, _>`
+note: the traits `handle::private::SharedHandle`, `handle::private::HandleOps`,  and `handle::private::SharedHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait SharedHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait HandleOps<T: ?Sized, M, S> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait SharedHandleOps<T: ?Sized, S>: HandleOps<T, False, S> + SharedHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0271]: type mismatch resolving `<MutFoo as HandleDescriptor>::Mutable == False`
+  --> tests/invalid-handle-code/mut-clone-handle.rs:12:41
+   |
+12 |     let h: Handle<MutFoo> = Arc::new(s).into();
+   |                                         ^^^^ expected `False`, found `True`
+   |
+   = note: required for `Handle<MutFoo>` to implement `From<Arc<Foo>>`
+   = note: required for `Arc<Foo>` to implement `Into<Handle<MutFoo>>`
+
+error[E0599]: the method `clone_handle` exists for struct `Handle<MutFoo>`, but its trait bounds were not satisfied
+  --> tests/invalid-handle-code/mut-clone-handle.rs:14:15
+   |
+8  | pub struct MutFoo;
+   | ----------------- doesn't satisfy 5 bounds
+...
+14 |     let h = h.clone_handle();
+   |               ^^^^^^^^^^^^
+   |
+   = note: the following trait bounds were not satisfied:
+           `<MutFoo as HandleDescriptor>::Mutable = False`
+           `<MutFoo as handle::private::HandleOps<_, False, _>>::From = Arc<_>`
+           `MutFoo: handle::private::SharedHandleOps<_, _>`
+           `MutFoo: handle::private::SharedHandle`
+           which is required by `MutFoo: handle::private::SharedHandleOps<_, _>`
+           `MutFoo: handle::private::HandleOps<_, False, _>`
+           which is required by `MutFoo: handle::private::SharedHandleOps<_, _>`
+note: the traits `handle::private::SharedHandle`, `handle::private::HandleOps`,  and `handle::private::SharedHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait SharedHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait HandleOps<T: ?Sized, M, S> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait SharedHandleOps<T: ?Sized, S>: HandleOps<T, False, S> + SharedHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ffi/tests/invalid-handle-code/not-send.rs
+++ b/ffi/tests/invalid-handle-code/not-send.rs
@@ -1,0 +1,11 @@
+use delta_kernel_ffi_macros::handle_descriptor;
+
+pub struct NotSend(*mut u32);
+
+#[handle_descriptor(target=NotSend, mutable=false, sized=true)]
+pub struct SharedNotSend;
+
+#[handle_descriptor(target=NotSend, mutable=true, sized=true)]
+pub struct MutNotSend;
+
+fn main() {}

--- a/ffi/tests/invalid-handle-code/not-send.stderr
+++ b/ffi/tests/invalid-handle-code/not-send.stderr
@@ -1,0 +1,35 @@
+error[E0277]: `*mut u32` cannot be sent between threads safely
+ --> tests/invalid-handle-code/not-send.rs:5:28
+  |
+5 | #[handle_descriptor(target=NotSend, mutable=false, sized=true)]
+  |                            ^^^^^^^ `*mut u32` cannot be sent between threads safely
+  |
+  = help: within `NotSend`, the trait `Send` is not implemented for `*mut u32`, which is required by `NotSend: Send`
+note: required because it appears within the type `NotSend`
+ --> tests/invalid-handle-code/not-send.rs:3:12
+  |
+3 | pub struct NotSend(*mut u32);
+  |            ^^^^^^^
+note: required by a bound in `delta_kernel_ffi::handle::HandleDescriptor::Target`
+ --> src/handle.rs
+  |
+  |     type Target: ?Sized + Send;
+  |                           ^^^^ required by this bound in `HandleDescriptor::Target`
+
+error[E0277]: `*mut u32` cannot be sent between threads safely
+ --> tests/invalid-handle-code/not-send.rs:8:28
+  |
+8 | #[handle_descriptor(target=NotSend, mutable=true, sized=true)]
+  |                            ^^^^^^^ `*mut u32` cannot be sent between threads safely
+  |
+  = help: within `NotSend`, the trait `Send` is not implemented for `*mut u32`, which is required by `NotSend: Send`
+note: required because it appears within the type `NotSend`
+ --> tests/invalid-handle-code/not-send.rs:3:12
+  |
+3 | pub struct NotSend(*mut u32);
+  |            ^^^^^^^
+note: required by a bound in `delta_kernel_ffi::handle::HandleDescriptor::Target`
+ --> src/handle.rs
+  |
+  |     type Target: ?Sized + Send;
+  |                           ^^^^ required by this bound in `HandleDescriptor::Target`

--- a/ffi/tests/invalid-handle-code/private-constructor.rs
+++ b/ffi/tests/invalid-handle-code/private-constructor.rs
@@ -1,0 +1,11 @@
+use delta_kernel_ffi_macros::handle_descriptor;
+use delta_kernel_ffi::handle::Handle;
+
+pub struct Foo(u32);
+
+#[handle_descriptor(target=Foo, mutable=false, sized=true)]
+pub struct SharedFoo;
+
+fn main() {
+    let _: Handle<SharedFoo> = Handle { ptr: std::ptr::NonNull::dangling() };
+}

--- a/ffi/tests/invalid-handle-code/private-constructor.stderr
+++ b/ffi/tests/invalid-handle-code/private-constructor.stderr
@@ -1,0 +1,5 @@
+error[E0451]: field `ptr` of struct `Handle` is private
+  --> tests/invalid-handle-code/private-constructor.rs:10:41
+   |
+10 |     let _: Handle<SharedFoo> = Handle { ptr: std::ptr::NonNull::dangling() };
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private field

--- a/ffi/tests/invalid-handle-code/shared-as-mut.rs
+++ b/ffi/tests/invalid-handle-code/shared-as-mut.rs
@@ -1,0 +1,13 @@
+use delta_kernel_ffi_macros::handle_descriptor;
+use delta_kernel_ffi::handle::Handle;
+
+pub struct Foo(u32);
+
+#[handle_descriptor(target=Foo, mutable=false, sized=true)]
+pub struct SharedFoo;
+
+fn main() {
+    let s = Foo(0);
+    let h: Handle<SharedFoo> = Box::new(s).into();
+    let r = h.as_mut();
+}

--- a/ffi/tests/invalid-handle-code/shared-as-mut.stderr
+++ b/ffi/tests/invalid-handle-code/shared-as-mut.stderr
@@ -1,0 +1,36 @@
+error[E0599]: the method `as_mut` exists for struct `Handle<SharedFoo>`, but its trait bounds were not satisfied
+  --> tests/invalid-handle-code/shared-as-mut.rs:12:15
+   |
+7  | pub struct SharedFoo;
+   | -------------------- doesn't satisfy `<SharedFoo as HandleDescriptor>::Mutable = True`, `SharedFoo: handle::private::HandleOps<_, True, _>`, `SharedFoo: handle::private::MutableHandleOps<_, _>` or `SharedFoo: handle::private::MutableHandle`
+...
+12 |     let r = h.as_mut();
+   |               ^^^^^^ method cannot be called on `Handle<SharedFoo>` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `<SharedFoo as HandleDescriptor>::Mutable = True`
+           `SharedFoo: handle::private::MutableHandleOps<_, _>`
+           `SharedFoo: handle::private::MutableHandle`
+           which is required by `SharedFoo: handle::private::MutableHandleOps<_, _>`
+           `SharedFoo: handle::private::HandleOps<_, True, _>`
+           which is required by `SharedFoo: handle::private::MutableHandleOps<_, _>`
+note: the traits `handle::private::MutableHandle`, `handle::private::HandleOps`,  and `handle::private::MutableHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait MutableHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait HandleOps<T: ?Sized, M, S> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait MutableHandleOps<T: ?Sized, S>: HandleOps<T, True, S> + MutableHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0271]: type mismatch resolving `<SharedFoo as HandleDescriptor>::Mutable == True`
+  --> tests/invalid-handle-code/shared-as-mut.rs:11:44
+   |
+11 |     let h: Handle<SharedFoo> = Box::new(s).into();
+   |                                            ^^^^ expected `True`, found `False`
+   |
+   = note: required for `Handle<SharedFoo>` to implement `From<Box<Foo>>`
+   = note: required for `Box<Foo>` to implement `Into<Handle<SharedFoo>>`

--- a/ffi/tests/invalid-handle-code/shared-not-sync.rs
+++ b/ffi/tests/invalid-handle-code/shared-not-sync.rs
@@ -2,16 +2,16 @@ use delta_kernel_ffi_macros::handle_descriptor;
 use delta_kernel_ffi::handle::Handle;
 use std::sync::Arc;
 
-pub struct NotSync {
-    pub ptr: *mut u32,
-}
+pub struct NotSync(*mut u32);
+
 unsafe impl Send for NotSync {}
 
 #[handle_descriptor(target=NotSync, mutable=false, sized=true)]
 pub struct SharedNotSync;
 
 fn main() {
-    let s = NotSync { ptr: std::ptr::null_mut() };
+    let s = NotSync(std::ptr::null_mut());
     let h: Handle<SharedNotSync> = Arc::new(s).into();
-    unsafe { h.drop_handle() };
+    let r = h.clone_as_arc();
+    let h = h.clone_handle();
 }

--- a/ffi/tests/invalid-handle-code/shared-not-sync.rs
+++ b/ffi/tests/invalid-handle-code/shared-not-sync.rs
@@ -1,0 +1,17 @@
+use delta_kernel_ffi_macros::handle_descriptor;
+use delta_kernel_ffi::handle::Handle;
+use std::sync::Arc;
+
+pub struct NotSync {
+    pub ptr: *mut u32,
+}
+unsafe impl Send for NotSync {}
+
+#[handle_descriptor(target=NotSync, mutable=false, sized=true)]
+pub struct SharedNotSync;
+
+fn main() {
+    let s = NotSync { ptr: std::ptr::null_mut() };
+    let h: Handle<SharedNotSync> = Arc::new(s).into();
+    unsafe { h.drop_handle() };
+}

--- a/ffi/tests/invalid-handle-code/shared-not-sync.stderr
+++ b/ffi/tests/invalid-handle-code/shared-not-sync.stderr
@@ -1,0 +1,15 @@
+error[E0277]: `*mut u32` cannot be shared between threads safely
+  --> tests/invalid-handle-code/shared-not-sync.rs:15:48
+   |
+15 |     let h: Handle<SharedNotSync> = Arc::new(s).into();
+   |                                                ^^^^ `*mut u32` cannot be shared between threads safely
+   |
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut u32`, which is required by `Arc<NotSync>: Into<_>`
+note: required because it appears within the type `NotSync`
+  --> tests/invalid-handle-code/shared-not-sync.rs:5:12
+   |
+5  | pub struct NotSync {
+   |            ^^^^^^^
+   = note: required for `SharedNotSync` to implement `handle::private::SharedHandleOps<NotSync, True>`
+   = note: required for `Handle<SharedNotSync>` to implement `From<Arc<NotSync>>`
+   = note: required for `Arc<NotSync>` to implement `Into<Handle<SharedNotSync>>`

--- a/ffi/tests/invalid-handle-code/shared-not-sync.stderr
+++ b/ffi/tests/invalid-handle-code/shared-not-sync.stderr
@@ -1,15 +1,59 @@
-error[E0277]: `*mut u32` cannot be shared between threads safely
-  --> tests/invalid-handle-code/shared-not-sync.rs:15:48
+error[E0599]: the method `clone_as_arc` exists for struct `Handle<SharedNotSync>`, but its trait bounds were not satisfied
+  --> tests/invalid-handle-code/shared-not-sync.rs:15:15
    |
-15 |     let h: Handle<SharedNotSync> = Arc::new(s).into();
+10 | pub struct SharedNotSync;
+   | ------------------------ doesn't satisfy `SharedNotSync: handle::private::SharedHandle` or `_: SharedHandleOps<_, _>`
+...
+15 |     let r = h.clone_as_arc();
+   |               ^^^^^^^^^^^^ method cannot be called on `Handle<SharedNotSync>` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `SharedNotSync: handle::private::SharedHandleOps<_, _>`
+           `SharedNotSync: handle::private::SharedHandle`
+           which is required by `SharedNotSync: handle::private::SharedHandleOps<_, _>`
+note: the traits `handle::private::SharedHandle` and `handle::private::SharedHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait SharedHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait SharedHandleOps<T: ?Sized, S>: HandleOps<T, False, S> + SharedHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: `*mut u32` cannot be shared between threads safely
+  --> tests/invalid-handle-code/shared-not-sync.rs:14:48
+   |
+14 |     let h: Handle<SharedNotSync> = Arc::new(s).into();
    |                                                ^^^^ `*mut u32` cannot be shared between threads safely
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut u32`, which is required by `Arc<NotSync>: Into<_>`
 note: required because it appears within the type `NotSync`
   --> tests/invalid-handle-code/shared-not-sync.rs:5:12
    |
-5  | pub struct NotSync {
+5  | pub struct NotSync(*mut u32);
    |            ^^^^^^^
    = note: required for `SharedNotSync` to implement `handle::private::SharedHandleOps<NotSync, True>`
    = note: required for `Handle<SharedNotSync>` to implement `From<Arc<NotSync>>`
    = note: required for `Arc<NotSync>` to implement `Into<Handle<SharedNotSync>>`
+
+error[E0599]: the method `clone_handle` exists for struct `Handle<SharedNotSync>`, but its trait bounds were not satisfied
+  --> tests/invalid-handle-code/shared-not-sync.rs:16:15
+   |
+10 | pub struct SharedNotSync;
+   | ------------------------ doesn't satisfy `SharedNotSync: handle::private::SharedHandle` or `_: SharedHandleOps<_, _>`
+...
+16 |     let h = h.clone_handle();
+   |               ^^^^^^^^^^^^
+   |
+   = note: the following trait bounds were not satisfied:
+           `SharedNotSync: handle::private::SharedHandleOps<_, _>`
+           `SharedNotSync: handle::private::SharedHandle`
+           which is required by `SharedNotSync: handle::private::SharedHandleOps<_, _>`
+note: the traits `handle::private::SharedHandle` and `handle::private::SharedHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait SharedHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait SharedHandleOps<T: ?Sized, S>: HandleOps<T, False, S> + SharedHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -3,6 +3,7 @@ use rustc_version::{version_meta, Channel};
 fn main() {
     // note if we're on the nightly channel so we can enable doc_auto_cfg if so
     if let Channel::Nightly = version_meta().unwrap().channel {
+        println!("cargo::rustc-check-cfg=cfg(NIGHTLY_CHANNEL)");
         println!("cargo:rustc-cfg=NIGHTLY_CHANNEL");
     }
 }

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -1,5 +1,5 @@
 //! This module defines visitors that can be used to extract the various delta actions from
-//! [`EngineData`] types.
+//! [`crate::engine_data::EngineData`] types.
 
 use std::collections::HashMap;
 

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -62,10 +62,8 @@ pub(crate) fn generate_mask(
     }
 }
 
-/// Reorder a RecordBatch to match `requested_ordering`. This method takes `mask_indicies` as
-/// computed by [`get_requested_indicies`] as an optimization. If the indicies are in order, then we
-/// don't need to do any re-ordering. Otherwise, for each non-zero value in `requested_ordering`,
-/// the column at that index will be added in order to returned batch
+/// Reorder a RecordBatch to match `requested_ordering`. For each non-zero value in
+/// `requested_ordering`, the column at that index will be added in order to returned batch
 pub(crate) fn reorder_record_batch(
     input_data: RecordBatch,
     requested_ordering: &[usize],

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -9,7 +9,7 @@ use crate::expressions::{BinaryOperator, Expression as Expr, VariadicOperator};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::{Engine, EngineData, ExpressionEvaluator, JsonHandler};
 
-/// Returns <op2> (if any) such that B <op2> A is equivalent to A <op> B.
+/// Returns `<op2>` (if any) such that `B <op2> A` is equivalent to `A <op> B`.
 fn commute(op: &BinaryOperator) -> Option<BinaryOperator> {
     use BinaryOperator::*;
     match op {


### PR DESCRIPTION
The FFI `Handle` class relies on several invariants that should cause compilation failures when somebody attempts to misuse a handle. This PR adds such negative test coverage with help from the `trybuild` crate. To run those tests, do:
```
$ cargo test --features developer-visibility --package delta_kernel_ffi -- invalid_handle_code
```
The newly added `developer-visibility` feature is similar to the one already present in the kernel crate, and makes extra classes and modules public. This is important for testing, because doc tests and compilation failure tests are not "inside" the crate and thus cannot otherwise access `pub(crate) mod handle`. The same mechanism also allows generating internal docs that include classes relevant to those building or extending the kernel FFI.