### PR TITLE
`get_from_map` shouldn't take a mut map

### DIFF
--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -292,7 +292,7 @@ pub struct CStringMap {
 ///
 /// The engine is responsible for providing a valid [`CStringMap`] pointer and [`KernelStringSlice`]
 pub unsafe extern "C" fn get_from_map(
-    map: &mut CStringMap,
+    map: &CStringMap,
     key: KernelStringSlice,
     allocate_fn: AllocateStringFn,
 ) -> NullableCvoid {


### PR DESCRIPTION
Makes it difficult for engines to use because the visit functions provide a `const`