### PR TITLE
Changed Schema to SchemaRef for state scanning

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -21,7 +21,7 @@ indexmap = "2.2.1"
 itertools = "0.13"
 lazy_static = "1.4"
 roaring = "0.10.1"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 thiserror = "1"
 # only for structured logging

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -224,7 +224,7 @@ fn do_work(
 ) {
     // get the type for the function calls
     let engine: &dyn Engine = engine.as_ref();
-    let read_schema = Arc::new(scan_state.read_schema.clone());
+    let read_schema = scan_state.read_schema.clone();
     // in a loop, try and get a ScanFile. Note that `recv` will return an `Err` when the other side
     // hangs up, which indicates there's no more data to process.
     while let Ok(scan_file) = scan_file_rx.recv() {

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -244,7 +244,7 @@ impl Scan {
             "Executing scan with logical schema {:#?} and physical schema {:#?}",
             self.logical_schema, self.physical_schema
         );
-        let output_schema = DataType::Struct(Box::new(self.schema().as_ref().clone()));
+        let output_schema: DataType = self.schema().clone().into();
         let parquet_handler = engine.get_parquet_handler();
 
         let mut results: Vec<ScanResult> = vec![];
@@ -461,7 +461,7 @@ pub fn transform_to_logical(
             .get_evaluator(
                 read_schema,
                 read_expression.clone(),
-                DataType::Struct(Box::new((*global_state.logical_schema).clone())),
+                global_state.logical_schema.clone().into(),
             )
             .evaluate(data.as_ref())?;
         Ok(result)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -225,8 +225,8 @@ impl Scan {
         GlobalScanState {
             table_root: self.snapshot.table_root.to_string(),
             partition_columns: self.snapshot.metadata().partition_columns.clone(),
-            logical_schema: self.logical_schema.as_ref().clone(),
-            read_schema: self.physical_schema.as_ref().clone(),
+            logical_schema: self.logical_schema.clone(),
+            read_schema: self.physical_schema.clone(),
             column_mapping_mode: self.snapshot.column_mapping_mode,
         }
     }
@@ -432,7 +432,7 @@ pub fn transform_to_logical(
         &global_state.partition_columns,
         global_state.column_mapping_mode,
     )?;
-    let read_schema = Arc::new(global_state.read_schema.clone());
+    let read_schema = global_state.read_schema.clone();
     if have_partition_cols || global_state.column_mapping_mode != ColumnMappingMode::None {
         // need to add back partition cols and/or fix-up mapped columns
         let all_fields = all_fields
@@ -459,9 +459,9 @@ pub fn transform_to_logical(
         let result = engine
             .get_expression_handler()
             .get_evaluator(
-                read_schema.clone(),
+                read_schema,
                 read_expression.clone(),
-                DataType::Struct(Box::new(global_state.logical_schema.clone())),
+                DataType::Struct(Box::new((*global_state.logical_schema).clone())),
             )
             .evaluate(data.as_ref())?;
         Ok(result)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -244,7 +244,7 @@ impl Scan {
             "Executing scan with logical schema {:#?} and physical schema {:#?}",
             self.logical_schema, self.physical_schema
         );
-        let output_schema: DataType = self.schema().clone().into();
+        let output_schema = DataType::from(self.schema().clone());
         let parquet_handler = engine.get_parquet_handler();
 
         let mut results: Vec<ScanResult> = vec![];

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     column_mapping::ColumnMappingMode,
     engine_data::{GetData, TypedGetData},
-    schema::Schema,
+    schema::SchemaRef,
     DataVisitor, DeltaResult, Engine, EngineData, Error,
 };
 use serde::{Deserialize, Serialize};
@@ -21,8 +21,8 @@ use super::log_replay::SCAN_ROW_SCHEMA;
 pub struct GlobalScanState {
     pub table_root: String,
     pub partition_columns: Vec<String>,
-    pub logical_schema: Schema,
-    pub read_schema: Schema,
+    pub logical_schema: SchemaRef,
+    pub read_schema: SchemaRef,
     pub column_mapping_mode: ColumnMappingMode,
 }
 

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -458,7 +458,7 @@ impl From<ArrayType> for DataType {
 
 impl From<SchemaRef> for DataType {
     fn from(schema: SchemaRef) -> Self {
-        DataType::Struct(Box::new(Arc::unwrap_or_clone(schema)))
+        Arc::unwrap_or_clone(schema).into()
     }
 }
 

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -456,6 +456,12 @@ impl From<ArrayType> for DataType {
     }
 }
 
+impl From<SchemaRef> for DataType {
+    fn from(schema: SchemaRef) -> Self {
+        DataType::Struct(Box::new(Arc::unwrap_or_clone(schema)))
+    }
+}
+
 /// cbindgen:ignore
 impl DataType {
     pub const STRING: Self = DataType::Primitive(PrimitiveType::String);


### PR DESCRIPTION
This is a pretty straightforward code-munging PR. Please see the [this comment](https://github.com/delta-incubator/delta-kernel-rs/issues/216#issuecomment-2136621176) where I discuss a shortcoming of this changeset.

We are now using a shared thread-safe pointer to reference schemas in global state instead of cloning.

This addresses #216 .