### PR TITLE
Support unary NOT and IsNull in data skipping

### DIFF
--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -1,7 +1,7 @@
 //! Expression handling based on arrow-rs compute kernels.
 use std::sync::Arc;
 
-use arrow_arith::boolean::{and, and_kleene, is_null, not, or, or_kleene};
+use arrow_arith::boolean::{and_kleene, is_null, not, or_kleene};
 use arrow_arith::numeric::{add, div, mul, sub};
 use arrow_array::cast::AsArray;
 use arrow_array::{
@@ -314,10 +314,8 @@ fn evaluate_expression(
         (VariadicOperation { op, exprs }, None | Some(&DataType::BOOLEAN)) => {
             type Operation = fn(&BooleanArray, &BooleanArray) -> Result<BooleanArray, ArrowError>;
             let (reducer, default): (Operation, _) = match op {
-                VariadicOperator::And => (and, true),
-                VariadicOperator::Or => (or, false),
-                VariadicOperator::AndKleene => (and_kleene, true),
-                VariadicOperator::OrKleene => (or_kleene, false),
+                VariadicOperator::And => (and_kleene, true),
+                VariadicOperator::Or => (or_kleene, false),
             };
             exprs
                 .iter()

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -1,7 +1,7 @@
 //! Expression handling based on arrow-rs compute kernels.
 use std::sync::Arc;
 
-use arrow_arith::boolean::{and, is_null, not, or};
+use arrow_arith::boolean::{and, and_kleene, is_null, not, or, or_kleene};
 use arrow_arith::numeric::{add, div, mul, sub};
 use arrow_array::cast::AsArray;
 use arrow_array::{
@@ -316,6 +316,8 @@ fn evaluate_expression(
             let (reducer, default): (Operation, _) = match op {
                 VariadicOperator::And => (and, true),
                 VariadicOperator::Or => (or, false),
+                VariadicOperator::AndKleene => (and_kleene, true),
+                VariadicOperator::OrKleene => (or_kleene, false),
             };
             exprs
                 .iter()

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -40,6 +40,8 @@ pub enum BinaryOperator {
 pub enum VariadicOperator {
     And,
     Or,
+    AndKleene,
+    OrKleene,
 }
 
 impl Display for BinaryOperator {
@@ -151,6 +153,20 @@ impl Display for Expression {
                         &exprs.iter().map(|e| format!("{e}")).join(", ")
                     )
                 }
+                VariadicOperator::AndKleene => {
+                    write!(
+                        f,
+                        "ANDKLEENE({})",
+                        &exprs.iter().map(|e| format!("{e}")).join(", ")
+                    )
+                }
+                VariadicOperator::OrKleene => {
+                    write!(
+                        f,
+                        "ORKLEENE({})",
+                        &exprs.iter().map(|e| format!("{e}")).join(", ")
+                    )
+                }
             },
         }
     }
@@ -217,9 +233,19 @@ impl Expression {
         Self::variadic(VariadicOperator::And, exprs)
     }
 
+    /// Creates a new expression ANDKLEENE(exprs...)
+    pub fn and_kleene_from(exprs: impl IntoIterator<Item = Self>) -> Self {
+        Self::variadic(VariadicOperator::AndKleene, exprs)
+    }
+
     /// Creates a new expression OR(exprs...)
     pub fn or_from(exprs: impl IntoIterator<Item = Self>) -> Self {
         Self::variadic(VariadicOperator::Or, exprs)
+    }
+
+    /// Creates a new expression ORKLEENE(exprs...)
+    pub fn or_kleene_from(exprs: impl IntoIterator<Item = Self>) -> Self {
+        Self::variadic(VariadicOperator::OrKleene, exprs)
     }
 
     /// Create a new expression `self IS NULL`
@@ -272,9 +298,19 @@ impl Expression {
         Self::and_from([self, other])
     }
 
+    /// Create a new expression `self ANDKLEENE other`
+    pub fn and_kleene(self, other: Self) -> Self {
+        Self::and_kleene_from([self, other])
+    }
+
     /// Create a new expression `self OR other`
     pub fn or(self, other: Self) -> Self {
         Self::or_from([self, other])
+    }
+
+    /// Create a new expression `self ORKLEENE other`
+    pub fn or_kleene(self, other: Self) -> Self {
+        Self::or_kleene_from([self, other])
     }
 
     /// Create a new expression `DISTINCT(self, other)`

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -40,8 +40,6 @@ pub enum BinaryOperator {
 pub enum VariadicOperator {
     And,
     Or,
-    AndKleene,
-    OrKleene,
 }
 
 impl Display for BinaryOperator {
@@ -153,20 +151,6 @@ impl Display for Expression {
                         &exprs.iter().map(|e| format!("{e}")).join(", ")
                     )
                 }
-                VariadicOperator::AndKleene => {
-                    write!(
-                        f,
-                        "ANDKLEENE({})",
-                        &exprs.iter().map(|e| format!("{e}")).join(", ")
-                    )
-                }
-                VariadicOperator::OrKleene => {
-                    write!(
-                        f,
-                        "ORKLEENE({})",
-                        &exprs.iter().map(|e| format!("{e}")).join(", ")
-                    )
-                }
             },
         }
     }
@@ -233,19 +217,9 @@ impl Expression {
         Self::variadic(VariadicOperator::And, exprs)
     }
 
-    /// Creates a new expression ANDKLEENE(exprs...)
-    pub fn and_kleene_from(exprs: impl IntoIterator<Item = Self>) -> Self {
-        Self::variadic(VariadicOperator::AndKleene, exprs)
-    }
-
     /// Creates a new expression OR(exprs...)
     pub fn or_from(exprs: impl IntoIterator<Item = Self>) -> Self {
         Self::variadic(VariadicOperator::Or, exprs)
-    }
-
-    /// Creates a new expression ORKLEENE(exprs...)
-    pub fn or_kleene_from(exprs: impl IntoIterator<Item = Self>) -> Self {
-        Self::variadic(VariadicOperator::OrKleene, exprs)
     }
 
     /// Create a new expression `self IS NULL`
@@ -298,19 +272,9 @@ impl Expression {
         Self::and_from([self, other])
     }
 
-    /// Create a new expression `self ANDKLEENE other`
-    pub fn and_kleene(self, other: Self) -> Self {
-        Self::and_kleene_from([self, other])
-    }
-
     /// Create a new expression `self OR other`
     pub fn or(self, other: Self) -> Self {
         Self::or_from([self, other])
-    }
-
-    /// Create a new expression `self ORKLEENE other`
-    pub fn or_kleene(self, other: Self) -> Self {
-        Self::or_kleene_from([self, other])
     }
 
     /// Create a new expression `DISTINCT(self, other)`

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -6,9 +6,7 @@ use tracing::debug;
 
 use crate::actions::visitors::SelectionVectorVisitor;
 use crate::error::DeltaResult;
-use crate::expressions::{
-    BinaryOperator, Expression as Expr, Scalar, UnaryOperator, VariadicOperator,
-};
+use crate::expressions::{BinaryOperator, Expression as Expr, UnaryOperator, VariadicOperator};
 use crate::schema::{DataType, PrimitiveType, SchemaRef, StructField, StructType};
 use crate::{Engine, EngineData, ExpressionEvaluator, JsonHandler};
 
@@ -29,10 +27,9 @@ fn commute(op: &BinaryOperator) -> Option<BinaryOperator> {
 /// case a column can contain null if any value > 0 is in the nullCount. This is further complicated
 /// by the default for tightBounds being true, so we have to check if it's EITHER `null` OR `true`
 fn get_tight_null_expr(null_col: String) -> Expr {
-    use Expr::*;
     Expr::and(
         Expr::distinct(Expr::column("tightBounds"), Expr::literal(false)),
-        Expr::gt(Column(null_col), Expr::literal(0i64)),
+        Expr::gt(Expr::column(null_col), Expr::literal(0i64)),
     )
 }
 

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -30,8 +30,8 @@ fn commute(op: &BinaryOperator) -> Option<BinaryOperator> {
 /// by the default for tightBounds being true, so we have to check if it's EITHER `null` OR `true`
 fn get_tight_null_expr(null_col: String) -> Expr {
     use Expr::*;
-    Expr::and_kleene(
-        Expr::or_kleene(
+    Expr::and(
+        Expr::or(
             Column("tightBounds".to_string()).is_null(),
             Expr::eq(
                 Column("tightBounds".to_string()),
@@ -48,7 +48,7 @@ fn get_tight_null_expr(null_col: String) -> Expr {
 /// doesn't help us)
 fn get_not_tight_null_expr(null_col: String) -> Expr {
     use Expr::*;
-    Expr::and_kleene(
+    Expr::and(
         Expr::eq(
             Column("tightBounds".to_string()),
             Literal(Scalar::Boolean(false)),
@@ -117,7 +117,7 @@ fn as_data_skipping_predicate(expr: &Expr) -> Option<Expr> {
                 match expr.as_ref() {
                     Column(col) => {
                         let null_col = format!("nullCount.{col}");
-                        Some(Expr::or_kleene(
+                        Some(Expr::or(
                             get_tight_null_expr(null_col.clone()),
                             get_not_tight_null_expr(null_col),
                         ))

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -32,7 +32,7 @@ fn get_tight_null_expr(null_col: String) -> Expr {
     use Expr::*;
     Expr::and(
         Expr::distinct(Expr::column("tightBounds"), Expr::literal(false)),
-        Expr::gt(Column(null_col), Literal(Scalar::Long(0))),
+        Expr::gt(Column(null_col), Expr::literal(0i64)),
     )
 }
 
@@ -41,13 +41,9 @@ fn get_tight_null_expr(null_col: String) -> Expr {
 /// equal to the null count, since all other values of nullCount must be ignored (except 0, which
 /// doesn't help us)
 fn get_not_tight_null_expr(null_col: String) -> Expr {
-    use Expr::*;
     Expr::and(
-        Expr::eq(
-            Column("tightBounds".to_string()),
-            Literal(Scalar::Boolean(false)),
-        ),
-        Expr::eq(Column("numRecords".to_string()), Column(null_col)),
+        Expr::eq(Expr::column("tightBounds"), Expr::literal(false)),
+        Expr::eq(Expr::column("numRecords"), Expr::column(null_col)),
     )
 }
 
@@ -192,12 +188,8 @@ impl DataSkippingFilter {
         }
 
         let stats_schema = Arc::new(StructType::new(vec![
-            StructField::new("numRecords", DataType::Primitive(PrimitiveType::Long), true),
-            StructField::new(
-                "tightBounds",
-                DataType::Primitive(PrimitiveType::Boolean),
-                true,
-            ),
+            StructField::new("numRecords", DataType::LONG, true),
+            StructField::new("tightBounds", DataType::BOOLEAN, true),
             StructField::new(
                 "nullCount",
                 StructType::new(

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -37,7 +37,7 @@ fn get_tight_null_expr(null_col: String) -> Expr {
 /// case, we can only check if the WHOLE column is null, but checking if the number of records is
 /// equal to the null count, since all other values of nullCount must be ignored (except 0, which
 /// doesn't help us)
-fn get_not_tight_null_expr(null_col: String) -> Expr {
+fn get_wide_null_expr(null_col: String) -> Expr {
     Expr::and(
         Expr::eq(Expr::column("tightBounds"), Expr::literal(false)),
         Expr::eq(Expr::column("numRecords"), Expr::column(null_col)),
@@ -111,7 +111,7 @@ fn as_data_skipping_predicate(expr: &Expr) -> Option<Expr> {
                     let null_col = format!("nullCount.{col}");
                     Some(Expr::or(
                         get_tight_null_expr(null_col.clone()),
-                        get_not_tight_null_expr(null_col),
+                        get_wide_null_expr(null_col),
                     ))
                 }
                 _ => None, // can't check anything other than a col for null

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -31,13 +31,7 @@ fn commute(op: &BinaryOperator) -> Option<BinaryOperator> {
 fn get_tight_null_expr(null_col: String) -> Expr {
     use Expr::*;
     Expr::and(
-        Expr::or(
-            Column("tightBounds".to_string()).is_null(),
-            Expr::eq(
-                Column("tightBounds".to_string()),
-                Literal(Scalar::Boolean(true)),
-            ),
-        ),
+        Expr::distinct(Expr::column("tightBounds"), Expr::literal(false)),
         Expr::gt(Column(null_col), Literal(Scalar::Long(0))),
     )
 }

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -1,12 +1,13 @@
 use std::collections::HashSet;
+use std::ops::Not;
 use std::sync::Arc;
 
 use tracing::debug;
 
 use crate::actions::visitors::SelectionVectorVisitor;
 use crate::error::DeltaResult;
-use crate::expressions::{BinaryOperator, Expression as Expr, VariadicOperator};
-use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::expressions::{BinaryOperator, Expression as Expr, Scalar, UnaryOperator, VariadicOperator};
+use crate::schema::{DataType, PrimitiveType, SchemaRef, StructField, StructType};
 use crate::{Engine, EngineData, ExpressionEvaluator, JsonHandler};
 
 /// Returns `<op2>` (if any) such that `B <op2> A` is equivalent to `A <op> B`.
@@ -22,12 +23,43 @@ fn commute(op: &BinaryOperator) -> Option<BinaryOperator> {
     }
 }
 
+/// Get the expression that checks if a col could be null, assuming tight_bounds = true. In this
+/// case a column can contain null if any value > 0 is in the nullCount. This is further complicated
+/// by the default for tightBounds being true, so we have to check if it's EITHER `null` OR `true`
+fn get_tight_null_expr(null_col: String) -> Expr {
+    use Expr::*;
+    Expr::and_kleene(
+        Expr::or_kleene(
+            Column("tightBounds".to_string()).is_null(),
+            Expr::eq(Column("tightBounds".to_string()), Literal(Scalar::Boolean(true))),
+        ),
+        Expr::gt(Column(null_col), Literal(Scalar::Long(0)))
+    )
+}
+
+/// Get the expression that checks if a col could be null, assuming tight_bounds = false. In this
+/// case, we can only check if the WHOLE column is null, but checking if the number of records is
+/// equal to the null count, since all other values of nullCount must be ignored (except 0, which
+/// doesn't help us)
+fn get_not_tight_null_expr(null_col: String) -> Expr {
+    use Expr::*;
+    Expr::and_kleene(
+        Expr::eq(Column("tightBounds".to_string()), Literal(Scalar::Boolean(false))),
+        Expr::eq(Column("numRecords".to_string()), Column(null_col)),
+    )
+}
+
+
 /// Rewrites a predicate to a predicate that can be used to skip files based on their stats.
 /// Returns `None` if the predicate is not eligible for data skipping.
 ///
 /// We normalize each binary operation to a comparison between a column and a literal value
 /// and rewite that in terms of the min/max values of the column.
 /// For example, `1 < a` is rewritten as `minValues.a > 1`.
+///
+/// Unary `NOT` is transformed recursively then inverted
+///
+/// Unary `IsNull` checks if the null counts indicate that the column could contain a null
 ///
 /// The variadic operations are rewritten as follows:
 /// - `AND` is rewritten as a conjunction of the rewritten operands where we just skip
@@ -66,6 +98,28 @@ fn as_data_skipping_predicate(expr: &Expr) -> Option<Expr> {
             };
             let col = format!("{}.{}", stats_col, col);
             Some(Expr::binary(op, Column(col), Literal(val.clone())))
+        }
+        UnaryOperation { op, expr } => match op {
+            UnaryOperator::Not => {
+                // get the expr as a skipping predicate, then invert it
+                as_data_skipping_predicate(expr).map(|expr| {
+                    Expr::not(expr)
+                })
+            }
+            UnaryOperator::IsNull => {
+                // to check if a column could have a null, we need two different checks, to see if
+                // the bounds are tight and then to actually do the check
+                match expr.as_ref() {
+                    Column(col) => {
+                        let null_col = format!("nullCount.{col}");
+                        Some(Expr::or_kleene(
+                             get_tight_null_expr(null_col.clone()),
+                             get_not_tight_null_expr(null_col),
+                        ))
+                    }
+                    _ => None // can't check anything other than a col for null
+                }
+            }
         }
         VariadicOperation {
             op: op @ VariadicOperator::And,
@@ -139,6 +193,11 @@ impl DataSkippingFilter {
         }
 
         let stats_schema = Arc::new(StructType::new(vec![
+            StructField::new("numRecords", DataType::Primitive(PrimitiveType::Long), true),
+            StructField::new("tightBounds", DataType::Primitive(PrimitiveType::Boolean), true),
+            StructField::new("nullCount", StructType::new(data_fields.iter().map(|data_field| {
+                StructField::new(&data_field.name, DataType::Primitive(PrimitiveType::Long), true)
+            }).collect()), true),
             StructField::new("minValues", StructType::new(data_fields.clone()), true),
             StructField::new("maxValues", StructType::new(data_fields), true),
         ]));

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -106,15 +106,15 @@ fn as_data_skipping_predicate(expr: &Expr) -> Option<Expr> {
         } => {
             // to check if a column could have a null, we need two different checks, to see if
             // the bounds are tight and then to actually do the check
-            match expr.as_ref() {
-                Column(col) => {
-                    let null_col = format!("nullCount.{col}");
-                    Some(Expr::or(
-                        get_tight_null_expr(null_col.clone()),
-                        get_wide_null_expr(null_col),
-                    ))
-                }
-                _ => None, // can't check anything other than a col for null
+            if let Column(col) = expr.as_ref() {
+                let null_col = format!("nullCount.{col}");
+                Some(Expr::or(
+                    get_tight_null_expr(null_col.clone()),
+                    get_wide_null_expr(null_col),
+                ))
+            } else {
+                // can't check anything other than a col for null
+                None
             }
         }
         VariadicOperation { op, exprs } => {

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -59,7 +59,7 @@ impl ScanBuilder {
     }
 
     /// Optionally provide a [`SchemaRef`] for columns to select from the [`Snapshot`]. See
-    /// [`ScanBuilder::with_schema`] for details. If schema_opt is `None` this is a no-op.
+    /// [`ScanBuilder::with_schema`] for details. If `schema_opt` is `None` this is a no-op.
     pub fn with_schema_opt(self, schema_opt: Option<SchemaRef>) -> Self {
         match schema_opt {
             Some(schema) => self.with_schema(schema),
@@ -74,6 +74,15 @@ impl ScanBuilder {
     pub fn with_predicate(mut self, predicate: Expression) -> Self {
         self.predicate = Some(predicate);
         self
+    }
+
+    /// Optionally provide an [`Expression`] to filter rows. See [`ScanBuilder::with_predicate`] for
+    /// details. If `predicate_opt` is `None`, this is a no-op.
+    pub fn with_predicate_opt(self, predicate_opt: Option<Expression>) -> Self {
+        match predicate_opt {
+            Some(predicate) => self.with_predicate(predicate),
+            None => self,
+        }
     }
 
     /// Build the [`Scan`].


### PR DESCRIPTION
This adds support for applying data skipping when the provided filter is a `NOT` or an `IsNull`.

This turned out to be more "fun" than expected.

For `NOT`, things are fairly simple, we just recursively  transform and then invert.

For `IsNull` it's more tricky. We can't just check the value in the stats, because it has different meanings if `tightBounds` is present or not. So there's a more complex set of conditions, but because both the `tightBounds` AND `nullCount` can be `null`, but we ultimately want a boolean, we have to use [`kleene`](https://en.wikipedia.org/wiki/Three-valued_logic) logic.

This required changing the semantics of `and` and `or` in the expression evaluation. 

Have opened #245 and #246 as follow-ups to this work.