### PR TITLE
Minor updates to the examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "derive-macros",
     "ffi",
     "kernel",
-    "kernel/examples/dump-table", # todo: put back to `examples/*` when inspect-table is fixed
+    "kernel/examples/read-table-single-threaded", # todo: put back to `examples/*` when inspect-table is fixed
     "kernel/examples/read-table-multi-threaded"
 ]
 # Only check / build main crates by default (check all with `--workspace`)

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow = { version = "^51.0", features = ["prettyprint"] }
+arrow = { version = "^51.0", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "^4.4", features = ["derive"] }
 delta_kernel = { path = "../../../kernel", features = [
-  "default-engine",
   "cloud",
-  "tokio",
+  "default-engine",
   "developer-visibility",
+  "tokio",
 ] }
 env_logger = "0.11.3"
 itertools = "0.13"

--- a/kernel/examples/read-table-single-threaded/Cargo.toml
+++ b/kernel/examples/read-table-single-threaded/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
-name = "dump-table"
+name = "read-table-single-threaded"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
 [dependencies]
-arrow = { version = "^51.0", features = ["prettyprint"] }
+arrow = { version = "^51.0", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "^4.4", features = ["derive"] }
 delta_kernel = { path = "../../../kernel", features = [
+  "cloud",
   "default-engine",
-  "tokio",
   "developer-visibility",
+  "tokio",
 ] }
 env_logger = "0.11.3"
 itertools = "0.13"

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -82,7 +82,7 @@ fn try_main() -> DeltaResult<()> {
             Box::new(DefaultEngine::try_new(
                 table.location(),
                 options,
-                Arc::new(TokioBackgroundExecutor::new())
+                Arc::new(TokioBackgroundExecutor::new()),
             )?)
         }
         EngineType::Sync => Box::new(SyncEngine::new()),


### PR DESCRIPTION
1. Rename `dump-table` -> `read-table-single-threaded`. Matches naming on Java side, and is more descriptive
2. Add `chrono-tz` feature to both examples. This is needed to print timestamps. Previously the examples would fail on the `all-primitive-values` table, but now they can print it out.
3. Add support for reading from s3 to the single threaded example.