### PR TITLE
Add unary visitors, and most other scalar types to ffi expressions

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1093,7 +1093,7 @@ macro_rules! fn_visit_literal_prim {
             #[no_mangle]
             pub extern "C" fn $name(
                 state: &mut KernelExpressionVisitorState,
-                value: i64,
+                value: $typ,
             ) -> usize {
                 wrap_expression(state, Expression::Literal(Scalar::from(value)))
             }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1095,7 +1095,7 @@ macro_rules! fn_visit_literal_prim {
                 state: &mut KernelExpressionVisitorState,
                 value: $typ,
             ) -> usize {
-                wrap_expression(state, Expression::Literal(Scalar::from(value)))
+                wrap_expression(state, Expression::literal(value))
             }
         )*
     };

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -967,12 +967,9 @@ fn visit_expression_unary(
     op: UnaryOperator,
     inner_expr: usize,
 ) -> usize {
-    if let Some(expr) = unwrap_kernel_expression(state, inner_expr).map(Box::new) {
-        wrap_expression(state, Expression::UnaryOperation { op, expr })
-    } else {
-        // invalid child => invalid node
-        0
-    }
+    unwrap_kernel_expression(state, inner_expr).map_or(0, |expr| {
+        wrap_expression(state, Expression::unary(op, expr))
+    })
 }
 
 // The EngineIterator is not thread safe, not reentrant, not owned by callee, not freed by callee.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tracing::debug;
 use url::Url;
 
-use delta_kernel::expressions::{BinaryOperator, Expression, Scalar};
+use delta_kernel::expressions::{BinaryOperator, Expression, Scalar, UnaryOperator};
 use delta_kernel::schema::{ArrayType, DataType, MapType, PrimitiveType, StructType};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::{DeltaResult, Engine, Error, Table};
@@ -851,6 +851,8 @@ pub unsafe extern "C" fn visit_schema(
     visit_struct_fields(visitor, snapshot.schema())
 }
 
+// TODO move expression visitors to separate module
+
 // A set that can identify its contents by address
 pub struct ReferenceSet<T> {
     map: std::collections::HashMap<usize, T>,
@@ -944,7 +946,6 @@ fn unwrap_kernel_expression(
     state.inflight_expressions.take(exprid)
 }
 
-// TODO move visitors to separate module
 fn visit_expression_binary(
     state: &mut KernelExpressionVisitorState,
     op: BinaryOperator,
@@ -958,6 +959,19 @@ fn visit_expression_binary(
             wrap_expression(state, Expression::BinaryOperation { op, left, right })
         }
         None => 0, // invalid child => invalid node
+    }
+}
+
+fn visit_expression_unary(
+    state: &mut KernelExpressionVisitorState,
+    op: UnaryOperator,
+    inner_expr: usize,
+) -> usize {
+    if let Some(expr) = unwrap_kernel_expression(state, inner_expr).map(Box::new) {
+        wrap_expression(state, Expression::UnaryOperation { op, expr })
+    } else {
+        // invalid child => invalid node
+        0
     }
 }
 
@@ -1036,6 +1050,22 @@ fn visit_expression_column_impl(
     Ok(wrap_expression(state, Expression::Column(name?)))
 }
 
+#[no_mangle]
+pub extern "C" fn visit_expression_not(
+    state: &mut KernelExpressionVisitorState,
+    inner_expr: usize,
+) -> usize {
+    visit_expression_unary(state, UnaryOperator::Not, inner_expr)
+}
+
+#[no_mangle]
+pub extern "C" fn visit_expression_is_null(
+    state: &mut KernelExpressionVisitorState,
+    inner_expr: usize,
+) -> usize {
+    visit_expression_unary(state, UnaryOperator::IsNull, inner_expr)
+}
+
 /// # Safety
 /// The string slice must be valid
 #[no_mangle]
@@ -1057,10 +1087,26 @@ fn visit_expression_literal_string_impl(
     ))
 }
 
-#[no_mangle]
-pub extern "C" fn visit_expression_literal_long(
-    state: &mut KernelExpressionVisitorState,
-    value: i64,
-) -> usize {
-    wrap_expression(state, Expression::Literal(Scalar::from(value)))
+macro_rules! fn_visit_literal_prim {
+    ( $(($name: ident, $typ: ty)), * ) => {
+        $(
+            #[no_mangle]
+            pub extern "C" fn $name(
+                state: &mut KernelExpressionVisitorState,
+                value: i64,
+            ) -> usize {
+                wrap_expression(state, Expression::Literal(Scalar::from(value)))
+            }
+        )*
+    };
 }
+
+fn_visit_literal_prim!(
+    (visit_expression_literal_int, i32),
+    (visit_expression_literal_long, i64),
+    (visit_expression_literal_short, i16),
+    (visit_expression_literal_byte, i8),
+    (visit_expression_literal_float, f32),
+    (visit_expression_literal_double, f64),
+    (visit_expression_literal_bool, bool) // TODO: timestamp/date/decimal?
+);

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -202,6 +202,18 @@ impl From<i64> for Scalar {
     }
 }
 
+impl From<f32> for Scalar {
+    fn from(i: f32) -> Self {
+        Self::Float(i)
+    }
+}
+
+impl From<f64> for Scalar {
+    fn from(i: f64) -> Self {
+        Self::Double(i)
+    }
+}
+
 impl From<bool> for Scalar {
     fn from(b: bool) -> Self {
         Self::Boolean(b)


### PR DESCRIPTION
As a follow-up to #231:

Add a `visit_unary` and make a macro for the other literal scalar types. Also adds some missing `From`s to `Scalar`.

Punting on date/timestamp/decimal for now, need to think more on those how we want to pass them.