### PR TITLE
bump arrow to 52.0 and object_store to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,15 @@ license = "Apache-2.0"
 repository = "https://github.com/delta-incubator/delta-kernel-rs"
 readme = "README.md"
 version = "0.1.0"
+
+[workspace.dependencies]
+arrow = { version = "^52.0" }
+arrow-arith = { version = "^52.0" }
+arrow-array = { version = "^52.0" }
+arrow-data = { version = "^52.0" }
+arrow-ord = { version = "^52.0" }
+arrow-json = { version = "^52.0" }
+arrow-select = { version = "^52.0" }
+arrow-schema = { version = "^52.0" }
+parquet = { version = "^52.0", features = ["object_store"] }
+object_store = "^0.10.1"

--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -10,17 +10,17 @@ readme.workspace = true
 version.workspace = true
 
 [dependencies]
-arrow-array = { version = "^51.0" }
-arrow-ord = { version = "^51.0" }
-arrow-select = { version = "^51.0" }
-arrow-schema = { version = "^51.0" }
+arrow-array = { workspace = true }
+arrow-ord = { workspace = true }
+arrow-select = { workspace = true }
+arrow-schema = { workspace = true }
 delta_kernel = { path = "../kernel", features = [
   "default-engine",
   "developer-visibility",
 ] }
 futures = "0.3"
-object_store = "^0.9.0"
-parquet = { version = "^51.0", features = ["object_store"] }
+object_store = { workspace = true }
+parquet = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -21,13 +21,13 @@ delta_kernel = { path = "../kernel", default-features = false, features = [
 delta_kernel_ffi_macros = { path = "../ffi-proc-macros", version = "0.1.0" }
 
 # used if we use the default engine to be able to move arrow data into the c-ffi format
-arrow-schema = { version = "^51.0", default-features = false, features = [
+arrow-schema = { version = "^52.0", default-features = false, features = [
   "ffi",
 ], optional = true }
-arrow-data = { version = "^51.0", default-features = false, features = [
+arrow-data = { version = "^52.0", default-features = false, features = [
   "ffi",
 ], optional = true }
-arrow-array = { version = "^51.0", default-features = false, optional = true }
+arrow-array = { version = "^52.0", default-features = false, optional = true }
 
 [build-dependencies]
 cbindgen = "0.26.0"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -37,16 +37,16 @@ delta_kernel_derive = { path = "../derive-macros", version = "0.1.0" }
 visibility = "0.1.0"
 
 # Used in default engine
-arrow-array = { version = "^51.0", optional = true }
-arrow-select = { version = "^51.0", optional = true }
-arrow-arith = { version = "^51.0", optional = true }
-arrow-json = { version = "^51.0", optional = true }
-arrow-ord = { version = "^51.0", optional = true }
-arrow-schema = { version = "^51.0", optional = true }
+arrow-array = { workspace = true, optional = true }
+arrow-select = { workspace = true, optional = true }
+arrow-arith = { workspace = true, optional = true }
+arrow-json = { workspace = true, optional = true }
+arrow-ord = { workspace = true, optional = true }
+arrow-schema = { workspace = true, optional = true }
 futures = { version = "0.3", optional = true }
-object_store = { version = "^0.9.0", optional = true }
+object_store = { workspace = true, optional = true }
 # Used in default and sync engine
-parquet = { version = "^51.0", optional = true }
+parquet = { workspace = true, optional = true }
 # Used for fetching direct urls (like pre-signed urls)
 reqwest = { version = "^0.12.0", optional = true }
 
@@ -92,7 +92,7 @@ sync-engine = [
 rustc_version = "0.4.0"
 
 [dev-dependencies]
-arrow = { version = "^51.0", features = ["json", "prettyprint"] }
+arrow = { workspace = true, features = ["json", "prettyprint"] }
 delta_kernel = { path = ".", features = ["default-engine", "sync-engine"] }
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tempfile = "3"

--- a/kernel/examples/inspect-table/Cargo.toml
+++ b/kernel/examples/inspect-table/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow-array = { version = "^51.0" }
-arrow-schema = { version = "^51.0" }
+arrow-array = { workspace = true }
+arrow-schema = { workspace = true }
 delta_kernel = { path = "../../../kernel", features = [
   "default",
   "tokio",

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow = { version = "^51.0", features = ["prettyprint", "chrono-tz"] }
+arrow = { workspace = true, features = ["prettyprint", "chrono-tz"] }
 clap = { version = "^4.4", features = ["derive"] }
 delta_kernel = { path = "../../../kernel", features = [
   "cloud",

--- a/kernel/examples/read-table-single-threaded/Cargo.toml
+++ b/kernel/examples/read-table-single-threaded/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow = { version = "^51.0", features = ["prettyprint", "chrono-tz"] }
+arrow = { workspace = true, features = ["prettyprint", "chrono-tz"] }
 clap = { version = "^4.4", features = ["derive"] }
 delta_kernel = { path = "../../../kernel", features = [
   "cloud",

--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -155,9 +155,9 @@ mod tests {
         let tmp_store = LocalFileSystem::new_with_prefix(tmp.path()).unwrap();
 
         let data = Bytes::from("kernel-data");
-        tmp_store.put(&Path::from("a"), data.clone()).await.unwrap();
-        tmp_store.put(&Path::from("b"), data.clone()).await.unwrap();
-        tmp_store.put(&Path::from("c"), data.clone()).await.unwrap();
+        tmp_store.put(&Path::from("a"), data.clone().into()).await.unwrap();
+        tmp_store.put(&Path::from("b"), data.clone().into()).await.unwrap();
+        tmp_store.put(&Path::from("c"), data.clone().into()).await.unwrap();
 
         let mut url = Url::from_directory_path(tmp.path()).unwrap();
 

--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -155,9 +155,18 @@ mod tests {
         let tmp_store = LocalFileSystem::new_with_prefix(tmp.path()).unwrap();
 
         let data = Bytes::from("kernel-data");
-        tmp_store.put(&Path::from("a"), data.clone().into()).await.unwrap();
-        tmp_store.put(&Path::from("b"), data.clone().into()).await.unwrap();
-        tmp_store.put(&Path::from("c"), data.clone().into()).await.unwrap();
+        tmp_store
+            .put(&Path::from("a"), data.clone().into())
+            .await
+            .unwrap();
+        tmp_store
+            .put(&Path::from("b"), data.clone().into())
+            .await
+            .unwrap();
+        tmp_store
+            .put(&Path::from("c"), data.clone().into())
+            .await
+            .unwrap();
 
         let mut url = Url::from_directory_path(tmp.path()).unwrap();
 


### PR DESCRIPTION
Required for downstream pyo3 dependency of delta-rs to be updated https://github.com/delta-io/delta-rs/pull/2581/. Also converts the arrow dependencies into workspace deps so all members share it. 