### PR TITLE
Don't use a macro for expression visitor function def

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1084,26 +1084,60 @@ fn visit_expression_literal_string_impl(
     ))
 }
 
-macro_rules! fn_visit_literal_prim {
-    ( $(($name: ident, $typ: ty)), * ) => {
-        $(
-            #[no_mangle]
-            pub extern "C" fn $name(
-                state: &mut KernelExpressionVisitorState,
-                value: $typ,
-            ) -> usize {
-                wrap_expression(state, Expression::literal(value))
-            }
-        )*
-    };
+// We need to get parse.expand working to be able to macro everything below, see issue #255
+
+#[no_mangle]
+pub extern "C" fn visit_expression_literal_int(
+    state: &mut KernelExpressionVisitorState,
+    value: i32,
+) -> usize {
+    wrap_expression(state, Expression::literal(value))
 }
 
-fn_visit_literal_prim!(
-    (visit_expression_literal_int, i32),
-    (visit_expression_literal_long, i64),
-    (visit_expression_literal_short, i16),
-    (visit_expression_literal_byte, i8),
-    (visit_expression_literal_float, f32),
-    (visit_expression_literal_double, f64),
-    (visit_expression_literal_bool, bool) // TODO: timestamp/date/decimal?
-);
+#[no_mangle]
+pub extern "C" fn visit_expression_literal_long(
+    state: &mut KernelExpressionVisitorState,
+    value: i64,
+) -> usize {
+    wrap_expression(state, Expression::literal(value))
+}
+
+#[no_mangle]
+pub extern "C" fn visit_expression_literal_short(
+    state: &mut KernelExpressionVisitorState,
+    value: i16,
+) -> usize {
+    wrap_expression(state, Expression::literal(value))
+}
+
+#[no_mangle]
+pub extern "C" fn visit_expression_literal_byte(
+    state: &mut KernelExpressionVisitorState,
+    value: i8,
+) -> usize {
+    wrap_expression(state, Expression::literal(value))
+}
+
+#[no_mangle]
+pub extern "C" fn visit_expression_literal_float(
+    state: &mut KernelExpressionVisitorState,
+    value: f32,
+) -> usize {
+    wrap_expression(state, Expression::literal(value))
+}
+
+#[no_mangle]
+pub extern "C" fn visit_expression_literal_double(
+    state: &mut KernelExpressionVisitorState,
+    value: f64,
+) -> usize {
+    wrap_expression(state, Expression::literal(value))
+}
+
+#[no_mangle]
+pub extern "C" fn visit_expression_literal_bool(
+    state: &mut KernelExpressionVisitorState,
+    value: bool,
+) -> usize {
+    wrap_expression(state, Expression::literal(value))
+}


### PR DESCRIPTION
cbindgen doesn't pick up macro'd functions unless we set `parse.expand`. That has its own issues (see #255). For now, just remove the macro.