### PR TITLE
handle nested struct in schemaString 

### DIFF
--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -62,9 +62,7 @@ pub fn sort_record_batch(batch: RecordBatch) -> DeltaResult<RecordBatch> {
     Ok(RecordBatch::try_new(batch.schema(), columns)?)
 }
 
-static SKIPPED_TESTS: &[&str; 2] = &[
-    // iceberg compat requires column mapping
-    "iceberg_compat_v1",
+static SKIPPED_TESTS: &[&str; 1] = &[
     // For multi_partitioned_2: The golden table stores the timestamp as an INT96 (which is
     // nanosecond precision), while the spec says we should read partition columns as
     // microseconds. This means the read and golden data don't line up. When this is released in

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -21,6 +21,14 @@ pub enum MetadataValue {
     Number(i32),
     String(String),
     Boolean(bool),
+    // to support things like icebergv2 compat, where we can have fields like:
+    // "parquet.field.nested.ids": {
+    //    "col1.element": 100,
+    //    "col1.element.element": 101
+    // }
+    // TODO: Perhaps make this more restrictive, the PROTOCOL seems to indicate that this should
+    // always be a `String->Int` map
+    Object(serde_json::Map<String, serde_json::Value>),
 }
 
 impl From<String> for MetadataValue {

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -21,14 +21,11 @@ pub enum MetadataValue {
     Number(i32),
     String(String),
     Boolean(bool),
-    // to support things like icebergv2 compat, where we can have fields like:
-    // "parquet.field.nested.ids": {
-    //    "col1.element": 100,
-    //    "col1.element.element": 101
-    // }
-    // TODO: Perhaps make this more restrictive, the PROTOCOL seems to indicate that this should
-    // always be a `String->Int` map
-    Object(serde_json::Map<String, serde_json::Value>),
+    // The [PROTOCOL](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#struct-field) states
+    // only that the metadata is "A JSON map containing information about this column.", so we can
+    // actually have any valid json here. `Other` is therefore a catchall for things we don't need
+    // to handle.
+    Other(serde_json::Value),
 }
 
 impl From<String> for MetadataValue {


### PR DESCRIPTION
Handle parsing nested structs in `schemaString`. Setting iceberg compat causes this. Also enable the iceberg_compat_v1 test for dat, since we do now support column mapping.

Closes #253 .