### PR TITLE
Fix including files that were removed if scan_batch with predicate

### DIFF
--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -213,6 +213,8 @@ impl LogReplayScanner {
                     "Filtering out Add due to it being removed {}, is log {is_log_batch}",
                     add.path
                 );
+                // we may have a true here because the data-skipping predicate included the file
+                selection_vector[index] = false;
             }
         }
 

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -373,15 +373,8 @@ macro_rules! assert_batches_sorted_eq {
             .unwrap()
             .to_string();
         // fix for windows: \r\n -->
-
         let mut actual_lines: Vec<&str> = formatted.trim().lines().collect();
-
-        // sort except for header + footer
-        let num_lines = actual_lines.len();
-        if num_lines > 3 {
-            actual_lines.as_mut_slice()[2..num_lines - 1].sort_unstable()
-        }
-
+        sort_lines!(actual_lines);
         assert_eq!(
             $expected_lines_sorted, actual_lines,
             "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",


### PR DESCRIPTION
The data skipping filter can indicate that a file should be included, but then the file could be removed later on, so we need to not assume that the selection vector is false.

The actual fix is just one line, but I realized we weren't really testing the `scan_data` way of doing scans at all. So I've updated the way we do tests in `read.rs` to run all the scans using _both_ `execute` and `get_scan_data` from the `Scan` to ensure that both work.

I added a test that would fail without the fix as well.