### PR TITLE
changed _last_snapshot_ stats to i64

### DIFF
--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -259,13 +259,13 @@ struct CheckpointMetadata {
     #[allow(unreachable_pub)] // used by acceptance tests (TODO make an fn accessor?)
     pub version: Version,
     /// The number of actions that are stored in the checkpoint.
-    pub(crate) size: i32,
+    pub(crate) size: i64,
     /// The number of fragments if the last checkpoint was written in multiple parts.
     pub(crate) parts: Option<i32>,
     /// The number of bytes of the checkpoint.
-    pub(crate) size_in_bytes: Option<i32>,
+    pub(crate) size_in_bytes: Option<i64>,
     /// The number of AddFile actions in the checkpoint.
-    pub(crate) num_of_add_files: Option<i32>,
+    pub(crate) num_of_add_files: Option<i64>,
     /// The schema of the checkpoint file.
     pub(crate) checkpoint_schema: Option<Schema>,
     /// The checksum of the last checkpoint JSON.


### PR DESCRIPTION
In spark delta these stats are long 

https://github.com/delta-io/delta/blob/97439835a4a667ac2ad86ec6054f0e85e8214760/spark/src/main/scala/org/apache/spark/sql/delta/LastCheckpointInfo.scala#L102-L112

see https://github.com/delta-io/delta-rs/pull/2649 for more information