### PR TITLE
Index the partitionValues map with column's physical name

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -288,8 +288,9 @@ impl Scan {
                             let field = self.logical_schema.fields.get_index(*field_idx).ok_or_else(|| {
                                 Error::generic("logical schema did not contain expected field, can't execute scan")
                             })?.1;
+                            let name = field.physical_name(self.snapshot.column_mapping_mode)?;
                             let value_expression = parse_partition_value(
-                                add.partition_values.get(field.name()),
+                                add.partition_values.get(name),
                                 field.data_type(),
                             )?;
                             Ok::<Expression, Error>(Expression::Literal(value_expression))
@@ -462,8 +463,9 @@ pub fn transform_to_logical(
                         .ok_or_else(|| {
                             Error::generic("logical schema did not contain expected field, can't transform data")
                         })?.1;
+                    let name = field.physical_name(global_state.column_mapping_mode)?;
                     let value_expression = parse_partition_value(
-                        partition_values.get(field.name()),
+                        partition_values.get(name),
                         field.data_type(),
                     )?;
                     Ok::<Expression, Error>(Expression::Literal(value_expression))


### PR DESCRIPTION
From the protocol:
> In name mode, readers must resolve columns in the data files by their physical names as given by the column metadata property delta.columnMapping.physicalName in the Delta schema. Partition values and column level statistics will also be resolved by their physical names. For columns that are not found in the files, nulls need to be returned. Column ids are not used in this mode for resolution purposes.

So we need to map to physical name otherwise we won't find the column. Note the same is true for `id` mode, so this won't break when we add support for that.