### PR TITLE
Update to dat 0.3

### DIFF
--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 
 [dependencies]
 arrow-array = { workspace = true }
+arrow-cast = { workspace = true }
 arrow-ord = { workspace = true }
 arrow-select = { workspace = true }
 arrow-schema = { workspace = true }

--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -10,7 +10,7 @@ use tar::Archive;
 
 const DAT_EXISTS_FILE_CHECK: &str = "tests/dat/.done";
 const OUTPUT_FOLDER: &str = "tests/dat";
-const VERSION: &str = "0.0.2";
+const VERSION: &str = "0.0.3";
 
 fn main() {
     if dat_exists() {

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -88,7 +88,7 @@ fn assert_schema_fields_match(schema: &Schema, golden: &Schema) {
 fn normalize_col(col: Arc<dyn Array>) -> Arc<dyn Array> {
     if let DataType::Timestamp(unit, Some(zone)) = col.data_type() {
         if **zone == *"+00:00" {
-            arrow_cast::cast::cast(&col, &DataType::Timestamp(unit.clone(), Some("UTC".into())))
+            arrow_cast::cast::cast(&col, &DataType::Timestamp(*unit, Some("UTC".into())))
                 .expect("Could not cast to UTC")
         } else {
             col

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -102,15 +102,11 @@ fn assert_columns_match(actual: &[Arc<dyn Array>], expected: &[Arc<dyn Array>]) 
     for (actual, expected) in actual.iter().zip(expected) {
         let actual = normalize_col(actual.clone());
         let expected = normalize_col(expected.clone());
+        // note that array equality includes data_type equality
+        // See: https://arrow.apache.org/rust/arrow_data/equal/fn.equal.html
         assert_eq!(
             &actual, &expected,
             "Column data didn't match. Got {actual:?}, expected {expected:?}"
-        );
-        let actual_dt = actual.data_type();
-        let expected_dt = expected.data_type();
-        assert_eq!(
-            actual_dt, expected_dt,
-            "Column data types didn't match. Got {actual_dt:?}, expected {expected_dt:?}"
         );
     }
 }

--- a/ffi/tests/read-table-testing/expected-data/basic-partitioned.expected
+++ b/ffi/tests/read-table-testing/expected-data/basic-partitioned.expected
@@ -7,25 +7,25 @@ Schema:
 └─ a_float: double
 
 number:  [
-  6,
   4,
   5,
+  6,
   1,
   2,
   3
 ]
 a_float:  [
-  6.6,
   4.4,
   5.5,
+  6.6,
   1.1,
   2.2,
   3.3
 ]
 letter:  [
-  null,
   "a",
   "e",
+  "f",
   "a",
   "b",
   "c"


### PR DESCRIPTION
- Update to the latest version of DAT
- Don't skip any tests

This requires some slight massaging of the expected data. In particular, some of the expected timestamps are in zone `+00:00` which _is_ UTC ([link](https://en.wikipedia.org/wiki/UTC%2B00:00)), so if we find that, we just convert.

This requires going column-by-column and normalizing if needed. 

This also removes the data_type check, since that actually needs to happen after column normalization, and it does already  happen as part of checking if two columns are equal. See [here](https://arrow.apache.org/rust/arrow_data/equal/fn.equal.html).