### PR TITLE
Add a --limit option to read-table-multi-threaded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: build and lint with clippy
-        run: cargo clippy --benches --tests --all-features -- -D warnings --
+        run: cargo clippy --benches --tests --all-features -- -D warnings
       - name: lint without default features
         run: cargo clippy --no-default-features -- -D warnings
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: build and lint with clippy
-        run: cargo clippy --tests -- -D warnings
+        run: cargo clippy --benches --tests --all-features -- -D warnings --
       - name: lint without default features
         run: cargo clippy --no-default-features -- -D warnings
   test:

--- a/kernel/src/engine/default/storage.rs
+++ b/kernel/src/engine/default/storage.rs
@@ -34,5 +34,5 @@ where
         .collect();
     let store = HdfsObjectStore::with_config(url.as_str(), options_map)?;
     let path = Path::parse(url.path())?;
-    return Ok((Box::new(store), path));
+    Ok((Box::new(store), path))
 }


### PR DESCRIPTION
Arrow printing is actually _really_ slow, so for a big table it's useful to be able to just print a few rows and the total count, for testing, or to get a sense of how fast kernel 