### PR TITLE
fix: make Map arrow type consistent with Map parquet type

### DIFF
--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -12,6 +12,9 @@ use crate::error::Error;
 use crate::schema::{ArrayType, DataType, MapType, PrimitiveType, StructField, StructType};
 
 pub(crate) const LIST_ARRAY_ROOT: &str = "item";
+pub(crate) const MAP_ROOT_DEFAULT: &str = "key_value";
+pub(crate) const MAP_KEY_DEFAULT: &str = "key";
+pub(crate) const MAP_VALUE_DEFAULT: &str = "value";
 
 impl TryFrom<&StructType> for ArrowSchema {
     type Error = ArrowError;
@@ -61,12 +64,12 @@ impl TryFrom<&MapType> for ArrowField {
 
     fn try_from(a: &MapType) -> Result<Self, ArrowError> {
         Ok(ArrowField::new(
-            "entries",
+            MAP_ROOT_DEFAULT,
             ArrowDataType::Struct(
                 vec![
-                    ArrowField::new("keys", ArrowDataType::try_from(a.key_type())?, false),
+                    ArrowField::new(MAP_KEY_DEFAULT, ArrowDataType::try_from(a.key_type())?, false),
                     ArrowField::new(
-                        "values",
+                        MAP_VALUE_DEFAULT,
                         ArrowDataType::try_from(a.value_type())?,
                         a.value_contains_null(),
                     ),

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -67,7 +67,11 @@ impl TryFrom<&MapType> for ArrowField {
             MAP_ROOT_DEFAULT,
             ArrowDataType::Struct(
                 vec![
-                    ArrowField::new(MAP_KEY_DEFAULT, ArrowDataType::try_from(a.key_type())?, false),
+                    ArrowField::new(
+                        MAP_KEY_DEFAULT,
+                        ArrowDataType::try_from(a.key_type())?,
+                        false,
+                    ),
                     ArrowField::new(
                         MAP_VALUE_DEFAULT,
                         ArrowDataType::try_from(a.value_type())?,


### PR DESCRIPTION
When we read parquet Map types in delta-rs, the data gets read as rootname "key_value" and then the struct type has two  fields "key", "value". We have casting logic that expects this schema, however when we convert our snapshot.schema to an arrow schema, a mismatch happens because kernel is using other field names.

Error when we optimize tables with Map types.
```python
SchemaMismatchError: Could not find column keys
```

Theoretically arrow fields can use whatever names they want, but since we are reading parquet data and therefore getting these RecordBatches with that structure, it would be just much easier to keep the structure of the datatypes consistent between the two.

See parquet docs:
https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps