### PR TITLE
Enable some more golden tests

### DIFF
--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use crate::error::Error;
 use crate::schema::{ArrayType, DataType, MapType, PrimitiveType, StructField, StructType};
 
-pub(crate) const LIST_ARRAY_ROOT: &str = "item";
+pub(crate) const LIST_ARRAY_ROOT: &str = "element";
 pub(crate) const MAP_ROOT_DEFAULT: &str = "key_value";
 pub(crate) const MAP_KEY_DEFAULT: &str = "key";
 pub(crate) const MAP_VALUE_DEFAULT: &str = "value";

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -325,7 +325,7 @@ golden_test!("data-reader-date-types-Jst", latest_snapshot_test);
 golden_test!("data-reader-date-types-Pst", latest_snapshot_test);
 golden_test!("data-reader-date-types-utc", latest_snapshot_test);
 golden_test!("data-reader-escaped-chars", latest_snapshot_test);
-skip_test!("data-reader-map": "map field named 'entries' vs 'key_value'");
+golden_test!("data-reader-map", latest_snapshot_test);
 golden_test!("data-reader-nested-struct", latest_snapshot_test);
 golden_test!(
     "data-reader-nullable-field-invalid-schema-key",
@@ -394,7 +394,7 @@ golden_test!("snapshot-data3", latest_snapshot_test);
 golden_test!("snapshot-repartitioned", latest_snapshot_test);
 golden_test!("snapshot-vacuumed", latest_snapshot_test);
 
-// TODO use projections
+// TODO fix column mapping
 skip_test!("table-with-columnmapping-mode-id": "id column mapping mode not supported");
 skip_test!("table-with-columnmapping-mode-name":
   "BUG: Parquet(General('partial projection of MapArray is not supported'))");
@@ -415,7 +415,6 @@ golden_test!("v2-checkpoint-parquet", latest_snapshot_test); // passing without 
 // - AddFile: 'file:/some/unqualified/absolute/path'
 // - RemoveFile: '/some/unqualified/absolute/path'
 // --> should give no files for the table, but currently gives 1 file
-// golden_test!("canonicalized-paths-normal-a", canonicalized_paths_test);
 skip_test!("canonicalized-paths-normal-a": "BUG: path canonicalization");
 // BUG:
 // - AddFile: 'file:///some/unqualified/absolute/path'


### PR DESCRIPTION
Changes made:
- Use `element` as list root name, enable a bunch of tests. This matches the [parquet spec](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists)
- Allow sorting by lists if they contain primitives. arrow supports this and then we can test on tables that are all list cols
- make the call to `assert_columns_match` pass things in the expected order.