### PR TITLE
prepare 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [v0.2.1](https://github.com/delta-incubator/delta-kernel-rs/tree/v0.2.1/) (2024-08-06)
+
+[Full Changelog](https://github.com/delta-incubator/delta-kernel-rs/compare/v0.2.0...v0.2.1)
+
+**API Changes**
+
+*Additions*
+
+1. New deletion vector API `row_indexes` (and accompanying FFI) to get row indexes instead of seletion vector of deleted rows. This can be more efficient for sparse DVs. [\#215](https://github.com/delta-incubator/delta-kernel-rs/pull/215)
+2. Typed table features: `ReaderFeatures`, `WriterFeatures` enums and `has_reader_feature`/`has_writer_feature` API [\#222](https://github.com/delta-incubator/delta-kernel-rs/pull/297)
+
+**Implemented enhancements:**
+
+- Add `--limit` option to example `read-table-multi-threaded` [\#297](https://github.com/delta-incubator/delta-kernel-rs/pull/297)
+- FFI now built with cmake. Move to using the read-test example as an ffi-test. And building on macos. [\#288](https://github.com/delta-incubator/delta-kernel-rs/pull/288)
+- Golden table tests migrated from delta-spark/delta-kernel java [\#295](https://github.com/delta-incubator/delta-kernel-rs/pull/295)
+- Code coverage implemented via [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) and reported with [codecov](https://app.codecov.io/github/delta-incubator/delta-kernel-rs) [\#287](https://github.com/delta-incubator/delta-kernel-rs/pull/287)
+- All tests enabled to run in CI [\#284](https://github.com/delta-incubator/delta-kernel-rs/pull/284)
+- Updated DAT to 0.3 [\#290](https://github.com/delta-incubator/delta-kernel-rs/pull/290)
+
+**Fixed bugs:**
+
+- Read UTC timestamps as "UTC" instead of "+00:00" for timezone [\#295](https://github.com/delta-incubator/delta-kernel-rs/pull/295)
+- Make Map arrow type field naming consistent with parquet field naming [\#299](https://github.com/delta-incubator/delta-kernel-rs/pull/299)
+
+
 ## [v0.2.0](https://github.com/delta-incubator/delta-kernel-rs/tree/v0.2.0/) (2024-07-17)
 
 [Full Changelog](https://github.com/delta-incubator/delta-kernel-rs/compare/v0.1.1...v0.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.2.1](https://github.com/delta-incubator/delta-kernel-rs/tree/v0.2.1/) (2024-08-06)
+## [v0.2.1](https://github.com/delta-incubator/delta-kernel-rs/tree/v0.2.1/) (2024-08-07)
 
 [Full Changelog](https://github.com/delta-incubator/delta-kernel-rs/compare/v0.2.0...v0.2.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 **Fixed bugs:**
 
-- Read UTC timestamps as "UTC" instead of "+00:00" for timezone [\#295](https://github.com/delta-incubator/delta-kernel-rs/pull/295)
+- Evaluate timestamps as "UTC" instead of "+00:00" for timezone [\#295](https://github.com/delta-incubator/delta-kernel-rs/pull/295)
 - Make Map arrow type field naming consistent with parquet field naming [\#299](https://github.com/delta-incubator/delta-kernel-rs/pull/299)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## [v0.2.1](https://github.com/delta-incubator/delta-kernel-rs/tree/v0.2.1/) (2024-08-07)
+## [v0.3.0](https://github.com/delta-incubator/delta-kernel-rs/tree/v0.3.0/) (2024-08-07)
 
-[Full Changelog](https://github.com/delta-incubator/delta-kernel-rs/compare/v0.2.0...v0.2.1)
+[Full Changelog](https://github.com/delta-incubator/delta-kernel-rs/compare/v0.2.0...v0.3.0)
 
 **API Changes**
+
+*Breaking*
+
+1. `delta_kernel::column_mapping` module moved to `delta_kernel::features::column_mapping` [\#222](https://github.com/delta-incubator/delta-kernel-rs/pull/297)
+
 
 *Additions*
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["deltalake", "delta", "datalake"]
 license = "Apache-2.0"
 repository = "https://github.com/delta-incubator/delta-kernel-rs"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [workspace.dependencies]
 arrow = { version = "^52.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["deltalake", "delta", "datalake"]
 license = "Apache-2.0"
 repository = "https://github.com/delta-incubator/delta-kernel-rs"
 readme = "README.md"
-version = "0.2.1"
+version = "0.3.0"
 
 [workspace.dependencies]
 arrow = { version = "^52.0" }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -18,7 +18,7 @@ url = "2"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "developer-visibility",
 ] }
-delta_kernel_ffi_macros = { path = "../ffi-proc-macros", version = "0.2.0" }
+delta_kernel_ffi_macros = { path = "../ffi-proc-macros", version = "0.2.1" }
 
 # used if we use the default engine to be able to move arrow data into the c-ffi format
 arrow-schema = { version = "^52.0", default-features = false, features = [

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -18,7 +18,7 @@ url = "2"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "developer-visibility",
 ] }
-delta_kernel_ffi_macros = { path = "../ffi-proc-macros", version = "0.2.1" }
+delta_kernel_ffi_macros = { path = "../ffi-proc-macros", version = "0.3.0" }
 
 # used if we use the default engine to be able to move arrow data into the c-ffi format
 arrow-schema = { version = "^52.0", default-features = false, features = [

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -31,7 +31,7 @@ uuid = "1.3.0"
 z85 = "3.0.5"
 
 # bring in our derive macros
-delta_kernel_derive = { path = "../derive-macros", version = "0.2.1" }
+delta_kernel_derive = { path = "../derive-macros", version = "0.3.0" }
 
 # used for developer-visibility
 visibility = "0.1.0"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -31,7 +31,7 @@ uuid = "1.3.0"
 z85 = "3.0.5"
 
 # bring in our derive macros
-delta_kernel_derive = { path = "../derive-macros", version = "0.2.0" }
+delta_kernel_derive = { path = "../derive-macros", version = "0.2.1" }
 
 # used for developer-visibility
 visibility = "0.1.0"

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -167,6 +167,8 @@ impl DeletionVectorDescriptor {
         }
     }
 
+    /// Materialize the row indexes of the deletion vector as a Vec<u64> in which each element
+    /// represents a row index that is deleted from the table.
     pub fn row_indexes(
         &self,
         fs_client: Arc<dyn FileSystemClient>,


### PR DESCRIPTION
release `0.3.0` 🚀 

(don't merge for me please, I'll adjust the date in the changelog when I'm actually about to do the release)