### PR TITLE
exclude golden tests+data when publishing package

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 version.workspace = true
+# exclude golden tests + golden test data since they push us over 10MB crate size limit
+exclude = ["tests/golden_tables.rs", "tests/golden_data/" ]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
We exceeded 10MB limit on crates.io for package size. Exclude golden tests and golden data from publishing to stay under the limit.

new package size:
```
 Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.96s
    Packaged 112 files, 557.5KiB (120.8KiB compressed)
```

old package size (and error):
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.06s
    Packaged 203 files, 13.9MiB (13.0MiB compressed)
   Uploading delta_kernel v0.3.0 (/Users/zach.schuermann/dev/delta-kernel-rs/kernel)
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error (status 413 Payload Too Large): max upload size is: 10485760
```