### PR TITLE
fix: allow kernel to read tables with invalid _last_checkpoint

### DIFF
--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -303,7 +303,7 @@ fn read_last_checkpoint(
         .and_then(|mut data| data.next().expect("read_files should return one file"))
     {
         Ok(data) => Ok(serde_json::from_slice(&data)
-            .map_err(|e| warn!("invalid _last_checkpoint JSON: {e}"))
+            .inspect_err(|e| warn!("invalid _last_checkpoint JSON: {e}"))
             .ok()),
         Err(Error::FileNotFound(_)) => Ok(None),
         Err(err) => Err(err),

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -409,7 +409,9 @@ mod tests {
     use std::sync::Arc;
 
     use object_store::local::LocalFileSystem;
+    use object_store::memory::InMemory;
     use object_store::path::Path;
+    use object_store::ObjectStore;
 
     use crate::engine::default::executor::tokio::TokioBackgroundExecutor;
     use crate::engine::default::filesystem::ObjectStoreFileSystemClient;
@@ -477,6 +479,49 @@ mod tests {
         );
         let cp = read_last_checkpoint(&client, &url).unwrap();
         assert!(cp.is_none())
+    }
+
+    fn valid_last_checkpoint() -> Vec<u8> {
+        r#"{"size":8,"size_in_bytes":21857,"version":1}"#
+            .as_bytes()
+            .to_vec()
+    }
+
+    #[test]
+    fn test_read_table_with_invalid_last_checkpoint() {
+        // in memory file system
+        let store = Arc::new(InMemory::new());
+
+        // put _last_checkpoint file
+        let data = valid_last_checkpoint();
+        let invalid_data = "invalid".as_bytes().to_vec();
+        let path = Path::from("valid/_last_checkpoint");
+        let invalid_path = Path::from("invalid/_last_checkpoint");
+
+        tokio::runtime::Runtime::new()
+            .expect("create tokio runtime")
+            .block_on(async {
+                store
+                    .put(&path, data.into())
+                    .await
+                    .expect("put _last_checkpoint");
+                store
+                    .put(&invalid_path, invalid_data.into())
+                    .await
+                    .expect("put _last_checkpoint");
+            });
+
+        let client = ObjectStoreFileSystemClient::new(
+            store,
+            Path::from("/"),
+            Arc::new(TokioBackgroundExecutor::new()),
+        );
+        let url = Url::parse("memory:///valid/").expect("valid url");
+        let valid = read_last_checkpoint(&client, &url).expect("read last checkpoint");
+        let url = Url::parse("memory:///invalid/").expect("valid url");
+        let invalid = read_last_checkpoint(&client, &url).expect("read last checkpoint");
+        assert!(valid.is_some());
+        assert!(invalid.is_none())
     }
 
     #[test_log::test]

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -482,9 +482,7 @@ mod tests {
     }
 
     fn valid_last_checkpoint() -> Vec<u8> {
-        r#"{"size":8,"size_in_bytes":21857,"version":1}"#
-            .as_bytes()
-            .to_vec()
+        r#"{"size":8,"size_in_bytes":21857,"version":1}"#.as_bytes().to_vec()
     }
 
     #[test]

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -314,7 +314,7 @@ golden_test!(
     latest_snapshot_test
 );
 golden_test!("checkpoint", checkpoint_test);
-skip_test!("corrupted-last-checkpoint-kernel": "BUG: should fallback to old commits/checkpoint");
+golden_test!("corrupted-last-checkpoint-kernel", latest_snapshot_test);
 golden_test!("data-reader-array-complex-objects", latest_snapshot_test);
 golden_test!("data-reader-array-primitives", latest_snapshot_test);
 golden_test!("data-reader-date-types-America", latest_snapshot_test);


### PR DESCRIPTION
Previously, `read_last_checkpoint` would return `Err(<json error>)` if json parsing of the `_last_checkpoint` file failed. This caused the upstream call to fail due to propagation of the error. Instead we now return `None` from `read_last_checkpoint` in this case - similar to what is returned if the `_last_checkpoint` is not found. This allows log replay to continue without the hint and read the table.

Additionally, this unblocks the `corrupted-last-checkpoint-kernel` golden table test.