### PR TITLE
fix: list log files with checkpoint when version is None

### DIFF
--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -149,6 +149,9 @@ impl Snapshot {
         // List relevant files from log
         let (mut commit_files, checkpoint_files) =
             match (read_last_checkpoint(fs_client.as_ref(), &log_url)?, version) {
+                (Some(cp), None) => {
+                    list_log_files_with_checkpoint(&cp, fs_client.as_ref(), &log_url)?
+                },
                 (Some(cp), Some(version)) if cp.version >= version => {
                     list_log_files_with_checkpoint(&cp, fs_client.as_ref(), &log_url)?
                 }

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -151,7 +151,7 @@ impl Snapshot {
             match (read_last_checkpoint(fs_client.as_ref(), &log_url)?, version) {
                 (Some(cp), None) => {
                     list_log_files_with_checkpoint(&cp, fs_client.as_ref(), &log_url)?
-                },
+                }
                 (Some(cp), Some(version)) if cp.version >= version => {
                     list_log_files_with_checkpoint(&cp, fs_client.as_ref(), &log_url)?
                 }

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -408,8 +408,8 @@ golden_test!("time-travel-start", latest_snapshot_test);
 golden_test!("time-travel-start-start20", latest_snapshot_test);
 golden_test!("time-travel-start-start20-start40", latest_snapshot_test);
 
-skip_test!("v2-checkpoint-json": "v2 checkpoint not supported"); // passing without v2 checkpoint support
-skip_test!("v2-checkpoint-parquet": "v2 checkpoint not supported"); // passing without v2 checkpoint support
+skip_test!("v2-checkpoint-json": "v2 checkpoint not supported");
+skip_test!("v2-checkpoint-parquet": "v2 checkpoint not supported");
 
 // BUG:
 // - AddFile: 'file:/some/unqualified/absolute/path'

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -408,8 +408,8 @@ golden_test!("time-travel-start", latest_snapshot_test);
 golden_test!("time-travel-start-start20", latest_snapshot_test);
 golden_test!("time-travel-start-start20-start40", latest_snapshot_test);
 
-golden_test!("v2-checkpoint-json", latest_snapshot_test); // passing without v2 checkpoint support
-golden_test!("v2-checkpoint-parquet", latest_snapshot_test); // passing without v2 checkpoint support
+skip_test!("v2-checkpoint-json": "v2 checkpoint not supported"); // passing without v2 checkpoint support
+skip_test!("v2-checkpoint-parquet": "v2 checkpoint not supported"); // passing without v2 checkpoint support
 
 // BUG:
 // - AddFile: 'file:/some/unqualified/absolute/path'


### PR DESCRIPTION
Previously, if read_last_checkpoint returned a valid _last_checkpoint hint but the version requested was None (i.e. requesting the lastest version) we would still list_log_files without listing from the checkpoint hint. This change will detect when we have a valid _last_checkpoint and request the latest version and instead list_log_files_with_checkpoint

A side effect, we will get following error when load a table via s3proxy with a lot log files (more than 1000), but the same issue doesn't occur on delta-rs, after some troubleshooting, the error can be fixed by add this line from delta-rs

https://github.com/delta-io/delta-rs/blob/main/crates/core/src/kernel/snapshot/log_segment.rs#L98


```
ObjectStore(
    Generic {
        store: "S3",
        source: ListRequest {
            source: Client {
                status: 400,
                body: Some(
                    "<?xml version='1.0' encoding='UTF-8'?><Error><Code>InvalidArgument</Code><Message>Bad Request</Message><RequestId>4442587FB7D0A2F9</RequestId></Error>",
                ),
            },
        },
    },
)
