### PR TITLE
Wasm Engine Prototype

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -31,6 +31,9 @@ tracing = { version = "0.1", features = ["log"] }
 url = "2"
 uuid = "1.3.0"
 z85 = "3.0.5"
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.5"
+arrow = { version = "52.2.0", default-features = false, features = ["prettyprint"] }
 
 # bring in our derive macros
 delta_kernel_derive = { path = "../derive-macros", version = "0.3.0" }
@@ -51,11 +54,10 @@ futures = { version = "0.3", optional = true }
 object_store = { workspace = true, optional = true }
 hdfs-native-object-store = { workspace = true, optional = true }
 # Used in default and sync engine
-parquet = { workspace = true, optional = true }
+parquet = { version="52.2.0", optional = true, default-features = false, features=["arrow"]}
 # Used for fetching direct urls (like pre-signed urls)
 reqwest = { version = "^0.12.0", optional = true }
 strum = { version = "0.26", features = ["derive"] }
-
 
 # optionally used with default engine (though not required)
 tokio = { version = "1.39", optional = true, features = ["rt-multi-thread"] }
@@ -90,6 +92,7 @@ default-engine = [
   "parquet/object_store",
   "reqwest",
   "tokio",
+  "parquet"
 ]
 
 developer-visibility = []
@@ -107,6 +110,17 @@ integration-test = [
   "hdfs-native",
   "walkdir",
 ]
+wasm-engine = [
+  "arrow-cast",
+  "arrow-conversion",
+  "arrow-expression",
+  "arrow-array",
+  "arrow-json",
+  "arrow-select",
+  "arrow-buffer",
+  "arrow-array",
+  "arrow-schema"
+]
 
 [build-dependencies]
 rustc_version = "0.4.0"
@@ -123,3 +137,6 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
   "env-filter",
   "fmt",
 ] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -1,5 +1,5 @@
 //! Provides engine implementation that implement the required traits. These engines can optionally
-//! be built into the kernel by setting the `default-engine` or `sync-engine` feature flags. See the
+//! be built into the kernel by setting the `default-engine`, `sync-engine` or `wasm-engine` feature flags. See the
 //! related modules for more information.
 
 #[cfg(feature = "arrow-conversion")]
@@ -8,13 +8,13 @@ pub(crate) mod arrow_conversion;
 #[cfg(feature = "arrow-expression")]
 pub mod arrow_expression;
 
-#[cfg(any(feature = "default-engine", feature = "sync-engine"))]
+#[cfg(any(feature = "default-engine", feature = "sync-engine", feature = "wasm-engine"))]
 pub mod arrow_data;
 
-#[cfg(any(feature = "default-engine", feature = "sync-engine"))]
+#[cfg(any(feature = "default-engine", feature = "sync-engine", feature = "wasm-engine"))]
 pub(crate) mod arrow_get_data;
 
-#[cfg(any(feature = "default-engine", feature = "sync-engine"))]
+#[cfg(any(feature = "default-engine", feature = "sync-engine", feature = "wasm-engine"))]
 pub(crate) mod arrow_utils;
 
 #[cfg(feature = "default-engine")]
@@ -22,3 +22,6 @@ pub mod default;
 
 #[cfg(feature = "sync-engine")]
 pub mod sync;
+
+#[cfg(feature = "wasm-engine")]
+pub mod wasm;

--- a/kernel/src/engine/sync/fs_client.rs
+++ b/kernel/src/engine/sync/fs_client.rs
@@ -2,7 +2,7 @@ use std::time::SystemTime;
 
 use bytes::Bytes;
 use itertools::Itertools;
-use crate::url_util::Url;
+use crate::url_util::{Url, UrlExt};
 
 use crate::{DeltaResult, Error, FileMeta, FileSlice, FileSystemClient};
 

--- a/kernel/src/engine/sync/fs_client.rs
+++ b/kernel/src/engine/sync/fs_client.rs
@@ -2,7 +2,7 @@ use std::time::SystemTime;
 
 use bytes::Bytes;
 use itertools::Itertools;
-use crate::url_util::{Url, UrlExt};
+use crate::url_util::Url;
 
 use crate::{DeltaResult, Error, FileMeta, FileSlice, FileSystemClient};
 

--- a/kernel/src/engine/sync/fs_client.rs
+++ b/kernel/src/engine/sync/fs_client.rs
@@ -2,7 +2,7 @@ use std::time::SystemTime;
 
 use bytes::Bytes;
 use itertools::Itertools;
-use url::Url;
+use crate::url_util::Url;
 
 use crate::{DeltaResult, Error, FileMeta, FileSlice, FileSystemClient};
 

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -14,7 +14,7 @@ use arrow_schema::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
 use arrow_select::concat::concat_batches;
 use itertools::Itertools;
 use tracing::debug;
-use crate::url_util::Url;
+use crate::url_util::{Url, UrlExt};
 
 use crate::engine::arrow_data::ArrowEngineData;
 

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -14,7 +14,7 @@ use arrow_schema::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
 use arrow_select::concat::concat_batches;
 use itertools::Itertools;
 use tracing::debug;
-use url::Url;
+use crate::url_util::Url;
 
 use crate::engine::arrow_data::ArrowEngineData;
 

--- a/kernel/src/engine/sync/parquet.rs
+++ b/kernel/src/engine/sync/parquet.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatchReaderBuilder};
 use tracing::debug;
-use url::Url;
+use crate::url_util::Url;
 
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::arrow_utils::{generate_mask, get_requested_indices, reorder_struct_array};

--- a/kernel/src/engine/sync/parquet.rs
+++ b/kernel/src/engine/sync/parquet.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatchReaderBuilder};
 use tracing::debug;
-use crate::url_util::Url;
+use crate::url_util::{Url, UrlExt};
 
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::arrow_utils::{generate_mask, get_requested_indices, reorder_struct_array};

--- a/kernel/src/engine/wasm/expression.rs
+++ b/kernel/src/engine/wasm/expression.rs
@@ -1,0 +1,29 @@
+use wasm_bindgen::prelude::*;
+use crate::ExpressionHandler;
+use arrow::datatypes::{DataType, SchemaRef};
+use std::sync::Arc;
+use crate::Expression;
+use crate::ExpressionEvaluator;
+
+pub struct WasmExpressionHandler(JsValue);
+
+impl WasmExpressionHandler {
+    pub fn new(js_value: JsValue) -> Self {
+        WasmExpressionHandler(js_value)
+    }
+}
+
+impl ExpressionHandler for WasmExpressionHandler {
+    fn get_evaluator(
+        &self,
+        schema: SchemaRef,
+        expression: Expression,
+        output_type: DataType,
+    ) -> Arc<dyn ExpressionEvaluator> {
+        self.0.get_evaluator(schema, expression, output_type)
+    }
+}
+
+// SAFETY: We're assuming a single-threaded environment for WASM
+unsafe impl Send for WasmExpressionHandler {}
+unsafe impl Sync for WasmExpressionHandler {}

--- a/kernel/src/engine/wasm/fs_client.rs
+++ b/kernel/src/engine/wasm/fs_client.rs
@@ -1,0 +1,18 @@
+use wasm_bindgen::prelude::*;
+use crate::FileSystemHandler;
+
+pub struct WasmFileSystemClient(JsValue);
+
+impl WasmFileSystemClient {
+    pub fn new(js_value: JsValue) -> Self {
+        WasmFileSystemClient(js_value)
+    }
+}
+
+impl FileSystemHandler for WasmFileSystemClient {
+    // Implement FileSystemHandler methods here, using self.0 to call JavaScript functions
+}
+
+// SAFETY: We're assuming a single-threaded environment for WASM
+unsafe impl Send for WasmFileSystemClient {}
+unsafe impl Sync for WasmFileSystemClient {}

--- a/kernel/src/engine/wasm/json.rs
+++ b/kernel/src/engine/wasm/json.rs
@@ -1,0 +1,34 @@
+use wasm_bindgen::prelude::*;
+use crate::JsonHandler;
+use crate::{DeltaResult, EngineData, SchemaRef, FileMeta, Expression, FileDataReadResultIterator};
+
+pub struct WasmJsonHandler(JsValue);
+
+impl WasmJsonHandler {
+    pub fn new(js_value: JsValue) -> Self {
+        WasmJsonHandler(js_value)
+    }
+}
+
+impl JsonHandler for WasmJsonHandler {
+    fn parse_json(
+        &self,
+        json_strings: Box<dyn EngineData>,
+        output_schema: SchemaRef,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        self.0.parse_json(json_strings, output_schema)
+    }
+
+    fn read_json_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<Expression>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        self.0.read_json_files(files, physical_schema, predicate)
+    }
+}
+
+// SAFETY: We're assuming a single-threaded environment for WASM
+unsafe impl Send for WasmJsonHandler {}
+unsafe impl Sync for WasmJsonHandler {}

--- a/kernel/src/engine/wasm/mod.rs
+++ b/kernel/src/engine/wasm/mod.rs
@@ -1,0 +1,66 @@
+use wasm_bindgen::prelude::*;
+use std::sync::Arc;
+use crate::{Engine, ExpressionHandler, FileSystemClient, JsonHandler, ParquetHandler};
+
+#[wasm_bindgen]
+pub struct WasmEngine {
+    fs_client: Option<Arc<dyn FileSystemClient>>,
+    json_handler: Option<Arc<dyn JsonHandler>>,
+    parquet_handler: Option<Arc<dyn ParquetHandler>>,
+    expression_handler: Option<Arc<dyn ExpressionHandler>>,
+}
+
+#[wasm_bindgen]
+impl WasmEngine {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmEngine {
+        WasmEngine {
+            fs_client: None,
+            json_handler: None,
+            parquet_handler: None,
+            expression_handler: None,
+        }
+    }
+
+    #[wasm_bindgen]
+    pub fn set_fs_client(&mut self, fs_client: JsValue) -> Result<(), JsValue> {
+        self.fs_client = Some(Arc::new(fs_client.into_serde().map_err(|e| e.to_string())?));
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub fn set_json_handler(&mut self, json_handler: JsValue) -> Result<(), JsValue> {
+        self.json_handler = Some(Arc::new(json_handler.into_serde().map_err(|e| e.to_string())?));
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub fn set_parquet_handler(&mut self, parquet_handler: JsValue) -> Result<(), JsValue> {
+        self.parquet_handler = Some(Arc::new(parquet_handler.into_serde().map_err(|e| e.to_string())?));
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub fn set_expression_handler(&mut self, expression_handler: JsValue) -> Result<(), JsValue> {
+        self.expression_handler = Some(Arc::new(expression_handler.into_serde().map_err(|e| e.to_string())?));
+        Ok(())
+    }
+}
+
+impl Engine for WasmEngine {
+    fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler> {
+        self.expression_handler.clone().expect("Expression handler not set")
+    }
+
+    fn get_file_system_client(&self) -> Arc<dyn FileSystemClient> {
+        self.fs_client.clone().expect("File system client not set")
+    }
+
+    fn get_parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        self.parquet_handler.clone().expect("Parquet handler not set")
+    }
+
+    fn get_json_handler(&self) -> Arc<dyn JsonHandler> {
+        self.json_handler.clone().expect("JSON handler not set")
+    }
+}

--- a/kernel/src/engine/wasm/mod.rs
+++ b/kernel/src/engine/wasm/mod.rs
@@ -2,65 +2,51 @@ use wasm_bindgen::prelude::*;
 use std::sync::Arc;
 use crate::{Engine, ExpressionHandler, FileSystemClient, JsonHandler, ParquetHandler};
 
+mod fs_client;
+mod json;
+mod parquet;
+mod expression;
+
 #[wasm_bindgen]
 pub struct WasmEngine {
-    fs_client: Option<Arc<dyn FileSystemClient>>,
-    json_handler: Option<Arc<dyn JsonHandler>>,
-    parquet_handler: Option<Arc<dyn ParquetHandler>>,
-    expression_handler: Option<Arc<dyn ExpressionHandler>>,
+    fs_client: Arc<fs_client::WasmFileSystemClient>,
+    json_handler: Arc<json::WasmJsonHandler>,
+    parquet_handler: Arc<parquet::WasmParquetHandler>,
+    expression_handler: Arc<expression::WasmExpressionHandler>,
 }
 
 #[wasm_bindgen]
 impl WasmEngine {
     #[wasm_bindgen(constructor)]
-    pub fn new() -> WasmEngine {
+    pub fn new(
+        fs_client: JsValue,
+        json_handler: JsValue,
+        parquet_handler: JsValue,
+        expression_handler: JsValue
+    ) -> Self {
         WasmEngine {
-            fs_client: None,
-            json_handler: None,
-            parquet_handler: None,
-            expression_handler: None,
+            fs_client: Arc::new(fs_client::WasmFileSystemClient::new(fs_client)),
+            json_handler: Arc::new(json::WasmJsonHandler::new(json_handler)),
+            parquet_handler: Arc::new(parquet::WasmParquetHandler::new(parquet_handler)),
+            expression_handler: Arc::new(expression::WasmExpressionHandler::new(expression_handler)),
         }
-    }
-
-    #[wasm_bindgen]
-    pub fn set_fs_client(&mut self, fs_client: JsValue) -> Result<(), JsValue> {
-        self.fs_client = Some(Arc::new(fs_client.into_serde().map_err(|e| e.to_string())?));
-        Ok(())
-    }
-
-    #[wasm_bindgen]
-    pub fn set_json_handler(&mut self, json_handler: JsValue) -> Result<(), JsValue> {
-        self.json_handler = Some(Arc::new(json_handler.into_serde().map_err(|e| e.to_string())?));
-        Ok(())
-    }
-
-    #[wasm_bindgen]
-    pub fn set_parquet_handler(&mut self, parquet_handler: JsValue) -> Result<(), JsValue> {
-        self.parquet_handler = Some(Arc::new(parquet_handler.into_serde().map_err(|e| e.to_string())?));
-        Ok(())
-    }
-
-    #[wasm_bindgen]
-    pub fn set_expression_handler(&mut self, expression_handler: JsValue) -> Result<(), JsValue> {
-        self.expression_handler = Some(Arc::new(expression_handler.into_serde().map_err(|e| e.to_string())?));
-        Ok(())
     }
 }
 
 impl Engine for WasmEngine {
-    fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler> {
-        self.expression_handler.clone().expect("Expression handler not set")
-    }
-
     fn get_file_system_client(&self) -> Arc<dyn FileSystemClient> {
-        self.fs_client.clone().expect("File system client not set")
-    }
-
-    fn get_parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-        self.parquet_handler.clone().expect("Parquet handler not set")
+        self.fs_client.clone()
     }
 
     fn get_json_handler(&self) -> Arc<dyn JsonHandler> {
-        self.json_handler.clone().expect("JSON handler not set")
+        self.json_handler.clone()
+    }
+
+    fn get_parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        self.parquet_handler.clone()
+    }
+
+    fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler> {
+        self.expression_handler.clone()
     }
 }

--- a/kernel/src/engine/wasm/parquet.rs
+++ b/kernel/src/engine/wasm/parquet.rs
@@ -1,0 +1,26 @@
+use wasm_bindgen::prelude::*;
+use crate::ParquetHandler;
+use crate::{DeltaResult, Expression, FileDataReadResultIterator, FileMeta, SchemaRef};
+
+pub struct WasmParquetHandler(JsValue);
+
+impl WasmParquetHandler {
+    pub fn new(js_value: JsValue) -> Self {
+        WasmParquetHandler(js_value)
+    }
+}
+
+impl ParquetHandler for WasmParquetHandler {
+    fn read_parquet_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<Expression>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        self.0.read_parquet_files(files, physical_schema, predicate)
+    }
+}
+
+// SAFETY: We're assuming a single-threaded environment for WASM
+unsafe impl Send for WasmParquetHandler {}
+unsafe impl Sync for WasmParquetHandler {}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -55,6 +55,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use url::Url;
+mod url_util;
 
 use self::schema::{DataType, SchemaRef};
 
@@ -79,7 +80,8 @@ pub use table::Table;
 #[cfg(any(
     feature = "default-engine",
     feature = "sync-engine",
-    feature = "arrow-conversion"
+    feature = "arrow-conversion",
+    feature = "wasm-engine",
 ))]
 pub mod engine;
 

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -1,6 +1,6 @@
 //! Utilities to make working with directory and file paths easier
 
-use url::Url;
+use crate::url_util::Url;
 
 use crate::{DeltaResult, Version};
 

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
-use url::Url;
+use crate::url_util::Url;
 
 use crate::actions::{get_log_schema, Metadata, Protocol, METADATA_NAME, PROTOCOL_NAME};
 use crate::features::{ColumnMappingMode, COLUMN_MAPPING_MODE_KEY};

--- a/kernel/src/table.rs
+++ b/kernel/src/table.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use url::Url;
+use crate::url_util::Url;
 
 use crate::snapshot::Snapshot;
 use crate::{DeltaResult, Engine, Error, Version};

--- a/kernel/src/table.rs
+++ b/kernel/src/table.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use crate::url_util::Url;
+use crate::url_util::{Url, UrlExt};
 
 use crate::snapshot::Snapshot;
 use crate::{DeltaResult, Engine, Error, Version};

--- a/kernel/src/url_util.rs
+++ b/kernel/src/url_util.rs
@@ -1,0 +1,50 @@
+use std::path::{Path, PathBuf};
+pub use url::Url;  // Re-export Url from the url crate
+
+pub trait UrlExt {
+    fn to_file_path(&self) -> Result<PathBuf, &'static str>;
+    fn from_file_path(path: impl AsRef<Path>) -> Result<Self, url::ParseError> where Self: Sized;
+    fn from_directory_path(path: impl AsRef<Path>) -> Result<Self, url::ParseError> where Self: Sized;
+}
+
+impl UrlExt for Url {
+    fn to_file_path(&self) -> Result<PathBuf, &'static str> {
+        #[cfg(feature = "wasm-engine")]
+        {
+            tracing::debug!("Converting URL to file path in WebAssembly context: {}", self);
+            let path = self.path();
+            tracing::debug!("Extracted path: {}", path);
+            Ok(path.into())
+        }
+
+        #[cfg(not(feature = "wasm-engine"))]
+        self.to_file_path()
+    }
+
+    fn from_file_path(path: impl AsRef<Path>) -> Result<Self, url::ParseError> {
+        #[cfg(feature = "wasm-engine")]
+        {
+            let path = path.as_ref();
+            let path_str = path.to_str().ok_or_else(|| url::ParseError::IdnaError)?;
+            Url::parse(&format!(path_str))
+        }
+
+        #[cfg(not(feature = "wasm-engine"))]
+        Url::from_file_path(path)
+    }
+
+    fn from_directory_path(path: impl AsRef<Path>) -> Result<Self, url::ParseError> {
+        #[cfg(feature = "wasm-engine")]
+        {
+            let path = path.as_ref();
+            let mut path_str = path.to_str().ok_or_else(|| url::ParseError::IdnaError)?.to_string();
+            if !path_str.ends_with('/') {
+                path_str.push('/');
+            }
+            Url::parse(&format!(path_str))
+        }
+
+        #[cfg(not(feature = "wasm-engine"))]
+        Url::from_directory_path(path)
+    }
+}

--- a/kernel/src/url_util.rs
+++ b/kernel/src/url_util.rs
@@ -26,7 +26,7 @@ impl UrlExt for Url {
         {
             let path = path.as_ref();
             let path_str = path.to_str().ok_or_else(|| url::ParseError::IdnaError)?;
-            Url::parse(&format!(path_str))
+            Url::parse(&format!("{}", path_str))
         }
 
         #[cfg(not(feature = "wasm-engine"))]
@@ -41,7 +41,7 @@ impl UrlExt for Url {
             if !path_str.ends_with('/') {
                 path_str.push('/');
             }
-            Url::parse(&format!(path_str))
+            Url::parse(&format!("{}", path_str))
         }
 
         #[cfg(not(feature = "wasm-engine"))]


### PR DESCRIPTION
We wanted to explore what it would take to a) compile the delta kernel to WASM and b) create an abstract WASM engine that could be implemented in other programming languages like Javascript. 

The main changes we had to do to the existing codebase were: 

- Remove Arrow & Parquet default features so it compiles to WASM
- Reimplement the URL object as a Crate to handle none file system friendly OSes like browsers
- Change the Cargo-toml to compile as a library

These changes were enough to compile the library into Wasm, particularly ignoring the default & sync engines which rely on FS dependencies. 
![image](https://github.com/user-attachments/assets/9f33d449-1689-491c-811f-fd7a9e19e6be)

We are looking to add delta support in [Evefan](https://evefan.com/) and hence would want to have the engine drive which file changes are needed for read/writes but have the FS specific things be handled outside Wasm. Hence, we introduced a prototype wasm engine that could be another example. Ideally this can be brought into the repo as a official compilation option within the workspace with something like: 

```
wasm-pack build --target web --release --features "wasm-engine"
```

To note
- I've never done Rust before and this was a one day stint 
- The latter bit of Wasm engine doesn't compile yet but I put it in to serve as a discussion starter for the right abstraction for something like this 
- There's probably a nicer way of doing the URL bit and also make this work within the build process of the entire workspace.  