### PR TITLE
[chore] update deps, stop using caret

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,18 @@ readme = "README.md"
 version = "0.3.0"
 
 [workspace.dependencies]
-arrow = { version = "^52.0" }
-arrow-arith = { version = "^52.0" }
-arrow-array = { version = "^52.0" }
-arrow-buffer = { version = "^52.0" }
-arrow-cast = { version = "^52.0" }
-arrow-data = { version = "^52.0" }
-arrow-ord = { version = "^52.0" }
-arrow-json = { version = "^52.0" }
-arrow-select = { version = "^52.0" }
-arrow-schema = { version = "^52.0" }
-parquet = { version = "^52.0", features = ["object_store"] }
-object_store = "^0.10.2"
-hdfs-native-object-store = "0.11.0"
+arrow = { version = "53.0" }
+arrow-arith = { version = "53.0" }
+arrow-array = { version = "53.0" }
+arrow-buffer = { version = "53.0" }
+arrow-cast = { version = "53.0" }
+arrow-data = { version = "53.0" }
+arrow-ord = { version = "53.0" }
+arrow-json = { version = "53.0" }
+arrow-select = { version = "53.0" }
+arrow-schema = { version = "53.0" }
+parquet = { version = "53.0", features = ["object_store"] }
+object_store = "0.11.0"
+hdfs-native-object-store = "0.12.0"
 hdfs-native = "0.10.0"
 walkdir = "2.5.0"

--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = "1"
 url = "2"
 
 [build-dependencies]
-ureq = "2.2"
+ureq = "2.10"
 flate2 = "1.0"
 tar = "0.4"
 
@@ -36,8 +36,8 @@ tar = "0.4"
 datatest-stable = "0.2"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tempfile = "3"
-test-case = { version = "3.1.0" }
-tokio = { version = "1.39" }
+test-case = { version = "3.3.1" }
+tokio = { version = "1.40" }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
   "env-filter",
   "fmt",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -21,17 +21,17 @@ delta_kernel = { path = "../kernel", default-features = false, features = [
 delta_kernel_ffi_macros = { path = "../ffi-proc-macros", version = "0.3.0" }
 
 # used if we use the default engine to be able to move arrow data into the c-ffi format
-arrow-schema = { version = "^52.0", default-features = false, features = [
+arrow-schema = { version = "53.0", default-features = false, features = [
   "ffi",
 ], optional = true }
-arrow-data = { version = "^52.0", default-features = false, features = [
+arrow-data = { version = "53.0", default-features = false, features = [
   "ffi",
 ], optional = true }
-arrow-array = { version = "^52.0", default-features = false, optional = true }
+arrow-array = { version = "53.0", default-features = false, optional = true }
 
 [build-dependencies]
-cbindgen = "0.26.0"
-libc = "0.2.147"
+cbindgen = "0.27.0"
+libc = "0.2.158"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -15,28 +15,28 @@ exclude = ["tests/golden_tables.rs", "tests/golden_data/" ]
 all-features = true
 
 [dependencies]
-bytes = "1.4"
+bytes = "1.7"
 chrono = { version = "0.4" }
-either = "1.8"
+either = "1.13"
 fix-hidden-lifetime-bug = "0.2"
-indexmap = "2.2.1"
+indexmap = "2.5.0"
 itertools = "0.13"
-lazy_static = "1.4"
-roaring = "0.10.1"
+lazy_static = "1.5"
+roaring = "0.10.6"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 thiserror = "1"
 # only for structured logging
 tracing = { version = "0.1", features = ["log"] }
 url = "2"
-uuid = "1.3.0"
+uuid = "1.10.0"
 z85 = "3.0.5"
 
 # bring in our derive macros
 delta_kernel_derive = { path = "../derive-macros", version = "0.3.0" }
 
 # used for developer-visibility
-visibility = "0.1.0"
+visibility = "0.1.1"
 
 # Used in default engine
 arrow-buffer = { workspace = true, optional = true }
@@ -53,12 +53,12 @@ hdfs-native-object-store = { workspace = true, optional = true }
 # Used in default and sync engine
 parquet = { workspace = true, optional = true }
 # Used for fetching direct urls (like pre-signed urls)
-reqwest = { version = "^0.12.0", optional = true }
+reqwest = { version = "0.12.7", optional = true }
 strum = { version = "0.26", features = ["derive"] }
 
 
 # optionally used with default engine (though not required)
-tokio = { version = "1.39", optional = true, features = ["rt-multi-thread"] }
+tokio = { version = "1.40", optional = true, features = ["rt-multi-thread"] }
 
 # Used in integration tests
 hdfs-native = { workspace = true, optional = true }
@@ -109,7 +109,7 @@ integration-test = [
 ]
 
 [build-dependencies]
-rustc_version = "0.4.0"
+rustc_version = "0.4.1"
 
 [dev-dependencies]
 arrow = { workspace = true, features = ["json", "prettyprint"] }

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -6,14 +6,14 @@ publish = false
 
 [dependencies]
 arrow = { workspace = true, features = ["prettyprint", "chrono-tz"] }
-clap = { version = "^4.4", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 delta_kernel = { path = "../../../kernel", features = [
   "cloud",
   "default-engine",
   "developer-visibility",
   "tokio",
 ] }
-env_logger = "0.11.3"
+env_logger = "0.11.5"
 itertools = "0.13"
 spmc = "0.3.0"
 url = "2"

--- a/kernel/examples/read-table-single-threaded/Cargo.toml
+++ b/kernel/examples/read-table-single-threaded/Cargo.toml
@@ -6,13 +6,13 @@ publish = false
 
 [dependencies]
 arrow = { workspace = true, features = ["prettyprint", "chrono-tz"] }
-clap = { version = "^4.4", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 delta_kernel = { path = "../../../kernel", features = [
   "cloud",
   "default-engine",
   "developer-visibility",
   "tokio",
 ] }
-env_logger = "0.11.3"
+env_logger = "0.11.5"
 itertools = "0.13"
 url = "2"


### PR DESCRIPTION
TLDR used [cargo-edit](https://github.com/killercup/cargo-edit) to upgrade dependencies in cargo.tomls and also removed caret in a few places (notably arrow dependency) since it is the default.
```
$ cargo upgrade -i --pinned allow # after install cargo-edit

name                     old req compatible latest new req
====                     ======= ========== ====== =======
arrow                    ^52.0   52.2.0     53.0.0 ^53.0
arrow-arith              ^52.0   52.2.0     53.0.0 ^53.0
arrow-array              ^52.0   52.2.0     53.0.0 ^53.0
arrow-buffer             ^52.0   52.2.0     53.0.0 ^53.0
arrow-cast               ^52.0   52.2.0     53.0.0 ^53.0
arrow-data               ^52.0   52.2.0     53.0.0 ^53.0
arrow-ord                ^52.0   52.2.0     53.0.0 ^53.0
arrow-json               ^52.0   52.2.0     53.0.0 ^53.0
arrow-select             ^52.0   52.2.0     53.0.0 ^53.0
arrow-schema             ^52.0   52.2.0     53.0.0 ^53.0
parquet                  ^52.0   52.2.0     53.0.0 ^53.0
object_store             ^0.10.2 0.10.2     0.11.0 ^0.11.0
hdfs-native-object-store 0.11.0  0.11.0     0.12.0 0.12.0
    Checking acceptance's dependencies
name      old req compatible latest new req
====      ======= ========== ====== =======
ureq      2.2     2.10.1     2.10.1 2.10
test-case 3.1.0   3.3.1      3.3.1  3.3.1
tokio     1.39    1.40.0     1.40.0 1.40
    Checking delta_kernel's dependencies
name          old req compatible latest new req
====          ======= ========== ====== =======
bytes         1.4     1.7.1      1.7.1  1.7
either        1.8     1.13.0     1.13.0 1.13
indexmap      2.2.1   2.5.0      2.5.0  2.5.0
lazy_static   1.4     1.5.0      1.5.0  1.5
roaring       0.10.1  0.10.6     0.10.6 0.10.6
uuid          1.3.0   1.10.0     1.10.0 1.10.0
visibility    0.1.0   0.1.1      0.1.1  0.1.1
reqwest       ^0.12.0 0.12.7     0.12.7 ^0.12.7
tokio         1.39    1.40.0     1.40.0 1.40
rustc_version 0.4.0   0.4.1      0.4.1  0.4.1
    Checking delta_kernel_derive's dependencies
    Checking delta_kernel_ffi's dependencies
name         old req compatible latest  new req
====         ======= ========== ======  =======
arrow-schema ^52.0   52.2.0     53.0.0  ^53.0
arrow-data   ^52.0   52.2.0     53.0.0  ^53.0
arrow-array  ^52.0   52.2.0     53.0.0  ^53.0
cbindgen     0.26.0  0.26.0     0.27.0  0.27.0
libc         0.2.147 0.2.158    0.2.158 0.2.158
    Checking delta_kernel_ffi_macros's dependencies
    Checking read-table-multi-threaded's dependencies
name       old req compatible latest new req
====       ======= ========== ====== =======
clap       ^4.4    4.5.17     4.5.17 ^4.5
env_logger 0.11.3  0.11.5     0.11.5 0.11.5
    Checking read-table-single-threaded's dependencies
name       old req compatible latest new req
====       ======= ========== ====== =======
clap       ^4.4    4.5.17     4.5.17 ^4.5
env_logger 0.11.3  0.11.5     0.11.5 0.11.5
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
    Removing doc-comment v0.3.3
    Removing object_store v0.10.2
    Removing snafu v0.7.5
    Removing snafu-derive v0.7.5
note: pass `--verbose` to see 10 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 29 packages
  local: delta_kernel
```