### PR TITLE
add contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,6 @@ Always better to get aligned with the core devs before writing any code.
 
 ## Do you have questions about the source code?
 
-Feel free to create an issue or join the Delta Lake Slack channel with questions!
+Feel free to create an issue or join the [Delta Lake Slack](https://go.delta.io/slack) with questions!  We chat in the `#delta-kernel` channel.
 
 Thanks for reading! :heart: :crab:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# How to contribute to Delta Kernel Rust
+
+Welcome!  We'd love to have you contribute to Delta Kernel Rust!
+
+## Did you find a bug?
+
+Create an issue with a reproducible example.  Please specify the Rust version, delta-kernel-rs version, the code executed, and the error message.
+
+## Did you create a PR to fix a bug?
+
+Open a pull request and add "Fixes #issue_number" in the PR description.
+
+We appreciate bug fixes - thank you in advance!
+
+## Would you like to add a new feature or change existing code?
+
+If you would like to add a feature or change existing behavior, please make sure to create an issue and get the planned work approved by the core team first!
+
+Always better to get aligned with the core devs before writing any code.
+
+## Do you have questions about the source code?
+
+Feel free to create an issue or join the Delta Lake Slack channel with questions!
+
+Thanks for reading! :heart: :crab:


### PR DESCRIPTION
Fixes #321

The CONTRIBUTING.md file is conventional in OSS repos.  This one draws inspiration from the [Rails CONTRIBUTING.md file](https://github.com/rails/rails/blob/main/CONTRIBUTING.md).