### PR TITLE
fix: add arrow-buffer to arrow-expression feature

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -66,7 +66,7 @@ walkdir = { workspace = true, optional = true }
 
 [features]
 arrow-conversion = ["arrow-schema"]
-arrow-expression = ["arrow-arith", "arrow-array", "arrow-ord", "arrow-schema"]
+arrow-expression = ["arrow-arith", "arrow-array", "arrow-buffer", "arrow-ord", "arrow-schema"]
 cloud = [
   "object_store/aws",
   "object_store/azure",


### PR DESCRIPTION
When running cargo-publish the delta_kernel crate failed to compile; needed to add `arrow-buffer` to `arrow-expression` feature.
```
error[E0432]: unresolved import `arrow_buffer`
  --> src/engine/arrow_expression.rs:13:5
   |
13 | use arrow_buffer::OffsetBuffer;
   |     ^^^^^^^^^^^^ use of undeclared crate or module `arrow_buffer`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `delta_kernel` (lib) due to 1 previous error
```