### PR TITLE
Remove feature flag requirement for GetData on ()

### DIFF
--- a/kernel/src/engine/arrow_get_data.rs
+++ b/kernel/src/engine/arrow_get_data.rs
@@ -77,24 +77,3 @@ impl<'a> GetData<'a> for MapArray {
         }
     }
 }
-
-macro_rules! impl_null_get {
-    ( $(($name: ident, $typ: ty)), * ) => {
-        $(
-            fn $name(&'a self, _row_index: usize, _field_name: &str) -> DeltaResult<Option<$typ>> {
-                Ok(None)
-            }
-        )*
-    };
-}
-
-impl<'a> GetData<'a> for () {
-    impl_null_get!(
-        (get_bool, bool),
-        (get_int, i32),
-        (get_long, i64),
-        (get_str, &'a str),
-        (get_list, ListItem<'a>),
-        (get_map, MapItem<'a>)
-    );
-}

--- a/kernel/src/engine_data.rs
+++ b/kernel/src/engine_data.rs
@@ -102,6 +102,27 @@ pub trait GetData<'a> {
     );
 }
 
+macro_rules! impl_null_get {
+    ( $(($name: ident, $typ: ty)), * ) => {
+        $(
+            fn $name(&'a self, _row_index: usize, _field_name: &str) -> DeltaResult<Option<$typ>> {
+                Ok(None)
+            }
+        )*
+    };
+}
+
+impl<'a> GetData<'a> for () {
+    impl_null_get!(
+        (get_bool, bool),
+        (get_int, i32),
+        (get_long, i64),
+        (get_str, &'a str),
+        (get_list, ListItem<'a>),
+        (get_map, MapItem<'a>)
+    );
+}
+
 // This is a convenience wrapper over `GetData` to allow code like:
 // `let name: Option<String> = getters[1].get_opt(row_index, "metadata.name")?;`
 pub(crate) trait TypedGetData<'a, T> {


### PR DESCRIPTION
Currently, the GetData trait implementation for unit type `()` is in arrow_get_data.rs. This makes the trait impl blocked behind either the `default-engine` or `sync-engine` flags. This PR moves the GetData trait implementation to engine_data.rs to make it available without the flags so that it can be used by other engines.

Closes: #315 