### PR TITLE
Make `scan::execute` return a lazy iterator

### DIFF
--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -20,13 +20,13 @@ delta_kernel = { path = "../kernel", features = [
   "developer-visibility",
 ] }
 futures = "0.3"
+itertools = "0.13"
 object_store = { workspace = true }
 parquet = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 url = "2"
-itertools = "0.13"
 
 [build-dependencies]
 ureq = "2.10"

--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -20,7 +20,6 @@ delta_kernel = { path = "../kernel", features = [
   "developer-visibility",
 ] }
 futures = "0.3"
-itertools = "0.13"
 object_store = { workspace = true }
 parquet = { workspace = true }
 serde = { version = "1", features = ["derive"] }

--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -20,6 +20,7 @@ delta_kernel = { path = "../kernel", features = [
   "developer-visibility",
 ] }
 futures = "0.3"
+itertools = "0.13"
 object_store = { workspace = true }
 parquet = { workspace = true }
 serde = { version = "1", features = ["derive"] }

--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 url = "2"
+itertools = "0.13"
 
 [build-dependencies]
 ureq = "2.10"

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -128,9 +128,9 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
-        .map(|sr| -> DeltaResult<_> {
-            let sr = sr?;
-            let data = sr.raw_data?;
+        .map(|scan_result| -> DeltaResult<_> {
+            let scan_result = scan_result?;
+            let data = scan_result.raw_data?;
             let record_batch: RecordBatch = data
                 .into_any()
                 .downcast::<ArrowEngineData>()

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -128,7 +128,8 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
         .map(|res| {
-            let data = res.unwrap().raw_data.unwrap();
+            let res = res.unwrap();
+            let data = res.raw_data.unwrap();
             let record_batch: RecordBatch = data
                 .into_any()
                 .downcast::<ArrowEngineData>()

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -127,8 +127,8 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
-        .into_iter()
         .map(|res| {
+            let res = res.unwrap();
             let data = res.raw_data.unwrap();
             let record_batch: RecordBatch = data
                 .into_any()

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -7,6 +7,7 @@ use arrow_select::{concat::concat_batches, filter::filter_record_batch, take::ta
 
 use delta_kernel::{engine::arrow_data::ArrowEngineData, DeltaResult, Engine, Error, Table};
 use futures::{stream::TryStreamExt, StreamExt};
+use itertools::Itertools;
 use object_store::{local::LocalFileSystem, ObjectStore};
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 
@@ -144,7 +145,7 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
                 Ok(record_batch)
             }
         })
-        .collect::<DeltaResult<Vec<RecordBatch>>>()?;
+        .try_collect()?;
     let all_data = concat_batches(&schema.unwrap(), batches.iter()).map_err(Error::from)?;
     let all_data = sort_record_batch(all_data)?;
     let golden = read_golden(test_case.root_dir(), None).await?;

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -127,9 +127,8 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
-        .map(Result::unwrap)
         .map(|res| {
-            let data = res.raw_data.unwrap();
+            let data = res.unwrap().raw_data.unwrap();
             let record_batch: RecordBatch = data
                 .into_any()
                 .downcast::<ArrowEngineData>()

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -7,6 +7,7 @@ use arrow_select::{concat::concat_batches, filter::filter_record_batch, take::ta
 
 use delta_kernel::{engine::arrow_data::ArrowEngineData, DeltaResult, Engine, Error, Table};
 use futures::{stream::TryStreamExt, StreamExt};
+use itertools::Itertools;
 use object_store::{local::LocalFileSystem, ObjectStore};
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 
@@ -127,9 +128,9 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
-        .map(|res| {
-            let res = res.unwrap();
-            let data = res.raw_data.unwrap();
+        .map(|res| -> DeltaResult<_> {
+            let res = res?;
+            let data = res.raw_data?;
             let record_batch: RecordBatch = data
                 .into_any()
                 .downcast::<ArrowEngineData>()
@@ -139,12 +140,12 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
                 schema = Some(record_batch.schema());
             }
             if let Some(mask) = res.mask {
-                filter_record_batch(&record_batch, &mask.into()).unwrap()
+                Ok(filter_record_batch(&record_batch, &mask.into())?)
             } else {
-                record_batch
+                Ok(record_batch)
             }
         })
-        .collect();
+        .try_collect()?;
     let all_data = concat_batches(&schema.unwrap(), batches.iter()).map_err(Error::from)?;
     let all_data = sort_record_batch(all_data)?;
     let golden = read_golden(test_case.root_dir(), None).await?;

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -128,23 +128,24 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
-        .map_ok(|res| -> DeltaResult<_> {
-            let data = res.raw_data?;
-            let record_batch: RecordBatch = data
-                .into_any()
-                .downcast::<ArrowEngineData>()
-                .unwrap()
-                .into();
-            if schema.is_none() {
-                schema = Some(record_batch.schema());
-            }
-            if let Some(mask) = res.mask {
-                Ok(filter_record_batch(&record_batch, &mask.into())?)
-            } else {
-                Ok(record_batch)
-            }
+        .map(|res| -> DeltaResult<_> {
+            res.and_then(|res| {
+                let data = res.raw_data?;
+                let record_batch: RecordBatch = data
+                    .into_any()
+                    .downcast::<ArrowEngineData>()
+                    .unwrap()
+                    .into();
+                if schema.is_none() {
+                    schema = Some(record_batch.schema());
+                }
+                if let Some(mask) = res.mask {
+                    Ok(filter_record_batch(&record_batch, &mask.into())?)
+                } else {
+                    Ok(record_batch)
+                }
+            })
         })
-        .flatten_ok()
         .try_collect()?;
     let all_data = concat_batches(&schema.unwrap(), batches.iter()).map_err(Error::from)?;
     let all_data = sort_record_batch(all_data)?;

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -128,8 +128,8 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
-        .map(|sr_res| -> DeltaResult<_> {
-            let sr = sr_res?;
+        .map(|sr| -> DeltaResult<_> {
+            let sr = sr?;
             let data = sr.raw_data?;
             let record_batch: RecordBatch = data
                 .into_any()

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -128,9 +128,9 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
-        .map(|res| -> DeltaResult<_> {
-            res.and_then(|res| {
-                let data = res.raw_data?;
+        .map(|sr_res| -> DeltaResult<_> {
+            sr_res.and_then(|sr| {
+                let data = sr.raw_data?;
                 let record_batch: RecordBatch = data
                     .into_any()
                     .downcast::<ArrowEngineData>()
@@ -139,7 +139,7 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
                 if schema.is_none() {
                     schema = Some(record_batch.schema());
                 }
-                if let Some(mask) = res.mask {
+                if let Some(mask) = sr.mask {
                     Ok(filter_record_batch(&record_batch, &mask.into())?)
                 } else {
                     Ok(record_batch)

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -127,8 +127,8 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
+        .map(Result::unwrap)
         .map(|res| {
-            let res = res.unwrap();
             let data = res.raw_data.unwrap();
             let record_batch: RecordBatch = data
                 .into_any()

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -7,7 +7,6 @@ use arrow_select::{concat::concat_batches, filter::filter_record_batch, take::ta
 
 use delta_kernel::{engine::arrow_data::ArrowEngineData, DeltaResult, Engine, Error, Table};
 use futures::{stream::TryStreamExt, StreamExt};
-use itertools::Itertools;
 use object_store::{local::LocalFileSystem, ObjectStore};
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 
@@ -145,7 +144,7 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
                 Ok(record_batch)
             }
         })
-        .try_collect()?;
+        .collect::<DeltaResult<Vec<RecordBatch>>>()?;
     let all_data = concat_batches(&schema.unwrap(), batches.iter()).map_err(Error::from)?;
     let all_data = sort_record_batch(all_data)?;
     let golden = read_golden(test_case.root_dir(), None).await?;

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -128,8 +128,7 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
-        .map(|res| -> DeltaResult<_> {
-            let res = res?;
+        .map_ok(|res| -> DeltaResult<_> {
             let data = res.raw_data?;
             let record_batch: RecordBatch = data
                 .into_any()
@@ -145,6 +144,7 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
                 Ok(record_batch)
             }
         })
+        .flatten_ok()
         .try_collect()?;
     let all_data = concat_batches(&schema.unwrap(), batches.iter()).map_err(Error::from)?;
     let all_data = sort_record_batch(all_data)?;

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -139,7 +139,7 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
             if schema.is_none() {
                 schema = Some(record_batch.schema());
             }
-            if let Some(mask) = sr.mask {
+            if let Some(mask) = scan_result.mask {
                 Ok(filter_record_batch(&record_batch, &mask.into())?)
             } else {
                 Ok(record_batch)

--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -128,7 +128,7 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
-        .map(|sr_res| -> DeltaResult<_> {
+        .map(|sr_res| {
             sr_res.and_then(|sr| {
                 let data = sr.raw_data?;
                 let record_batch: RecordBatch = data

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -114,7 +114,8 @@ fn try_main() -> DeltaResult<()> {
         .build()?;
 
     let mut batches = vec![];
-    for res in scan.execute(engine.as_ref())?.into_iter() {
+    for res in scan.execute(engine.as_ref())? {
+        let res = res?;
         let data = res.raw_data?;
         let record_batch: RecordBatch = data
             .into_any()

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -116,7 +116,7 @@ fn try_main() -> DeltaResult<()> {
 
     let batches: Vec<RecordBatch> = scan
         .execute(engine.as_ref())?
-        .map(|sr_res| -> DeltaResult<RecordBatch> {
+        .map(|sr_res| {
             sr_res.and_then(|sr| {
                 let data = sr.raw_data?;
                 let record_batch: RecordBatch = data

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -115,9 +115,9 @@ fn try_main() -> DeltaResult<()> {
 
     let batches: Vec<RecordBatch> = scan
         .execute(engine.as_ref())?
-        .map(|sr| -> DeltaResult<_> {
-            let sr = sr?;
-            let data = sr.raw_data?;
+        .map(|scan_result| -> DeltaResult<_> {
+            let scan_result = scan_result?;
+            let data = scan_result.raw_data?;
             let record_batch: RecordBatch = data
                 .into_any()
                 .downcast::<ArrowEngineData>()

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -123,7 +123,7 @@ fn try_main() -> DeltaResult<()> {
                 .downcast::<ArrowEngineData>()
                 .map_err(|_| delta_kernel::Error::EngineDataType("ArrowEngineData".to_string()))?
                 .into();
-            if let Some(mut mask) = sr.mask {
+            if let Some(mut mask) = scan_result.mask {
                 let extra_rows = record_batch.num_rows() - mask.len();
                 if extra_rows > 0 {
                     // we need to extend the mask here in case it's too short

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -115,8 +115,8 @@ fn try_main() -> DeltaResult<()> {
 
     let batches: Vec<RecordBatch> = scan
         .execute(engine.as_ref())?
-        .map(|sr_res| -> DeltaResult<_> {
-            let sr = sr_res?;
+        .map(|sr| -> DeltaResult<_> {
+            let sr = sr?;
             let data = sr.raw_data?;
             let record_batch: RecordBatch = data
                 .into_any()

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -13,6 +13,7 @@ use delta_kernel::schema::Schema;
 use delta_kernel::{DeltaResult, Engine, Table};
 
 use clap::{Parser, ValueEnum};
+use itertools::Itertools;
 
 /// An example program that dumps out the data of a delta table. Struct and Map types are not
 /// supported.
@@ -113,27 +114,28 @@ fn try_main() -> DeltaResult<()> {
         .with_schema_opt(read_schema_opt)
         .build()?;
 
-    let mut batches = vec![];
-    for res in scan.execute(engine.as_ref())? {
-        let res = res?;
-        let data = res.raw_data?;
-        let record_batch: RecordBatch = data
-            .into_any()
-            .downcast::<ArrowEngineData>()
-            .map_err(|_| delta_kernel::Error::EngineDataType("ArrowEngineData".to_string()))?
-            .into();
-        let batch = if let Some(mut mask) = res.mask {
-            let extra_rows = record_batch.num_rows() - mask.len();
-            if extra_rows > 0 {
-                // we need to extend the mask here in case it's too short
-                mask.extend(std::iter::repeat(true).take(extra_rows));
+    let batches: Vec<RecordBatch> = scan
+        .execute(engine.as_ref())?
+        .map_ok(|res| -> DeltaResult<RecordBatch> {
+            let data = res.raw_data?;
+            let record_batch: RecordBatch = data
+                .into_any()
+                .downcast::<ArrowEngineData>()
+                .map_err(|_| delta_kernel::Error::EngineDataType("ArrowEngineData".to_string()))?
+                .into();
+            if let Some(mut mask) = res.mask {
+                let extra_rows = record_batch.num_rows() - mask.len();
+                if extra_rows > 0 {
+                    // we need to extend the mask here in case it's too short
+                    mask.extend(std::iter::repeat(true).take(extra_rows));
+                }
+                Ok(filter_record_batch(&record_batch, &mask.into())?)
+            } else {
+                Ok(record_batch)
             }
-            filter_record_batch(&record_batch, &mask.into())?
-        } else {
-            record_batch
-        };
-        batches.push(batch);
-    }
+        })
+        .flatten_ok()
+        .try_collect()?;
     print_batches(&batches)?;
     Ok(())
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -227,7 +227,7 @@ impl Scan {
     }
 
     /// Perform an "all in one" scan. This will use the provided `engine` to read and
-    /// process all the data for the query. Each [`ScanResult`] in the resultant vector encapsulates
+    /// process all the data for the query. Each [`ScanResult`] in the resultant iterator encapsulates
     /// the raw data and an optional boolean vector built from the deletion vector if it was
     /// present. See the documentation for [`ScanResult`] for more details. Generally
     /// connectors/engines will want to use [`Scan::scan_data`] so they can have more control over

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -640,7 +640,7 @@ mod tests {
         let table = Table::new(url);
         let snapshot = table.snapshot(&engine, None).unwrap();
         let scan = snapshot.into_scan_builder().build().unwrap();
-        let files: Vec<_> = scan.execute(&engine).unwrap().try_collect().unwrap();
+        let files: Vec<ScanResult> = scan.execute(&engine).unwrap().try_collect().unwrap();
 
         assert_eq!(files.len(), 1);
         let num_rows = files[0].raw_data.as_ref().unwrap().length();

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -275,7 +275,8 @@ impl Scan {
                 state::visit_scan_files(data.as_ref(), &vec, scan_files, scan_data_callback)
                     .map(IntoIterator::into_iter)
             })
-            .flatten_ok();
+            .flatten_ok(); // Iterator<DeltaResult<Iterator<ScanFile>>> to
+                           // Iterator<DeltaResult<ScanFile>>
 
         let result = scan_files_iter
             .map_and_then(move |scan_file| -> DeltaResult<_> {

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -641,7 +641,7 @@ mod tests {
         let table = Table::new(url);
         let snapshot = table.snapshot(&engine, None).unwrap();
         let scan = snapshot.into_scan_builder().build().unwrap();
-        let files: Vec<ScanResult> = scan.execute(&engine).unwrap().map(|x| x.unwrap()).collect();
+        let files: Vec<ScanResult> = scan.execute(&engine).unwrap().map(Result::unwrap).collect();
 
         assert_eq!(files.len(), 1);
         let num_rows = files[0].raw_data.as_ref().unwrap().length();

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -237,7 +237,7 @@ impl Scan {
     pub fn execute<'a>(
         &'a self,
         engine: &'a dyn Engine,
-    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<ScanResult>> + 'a>> {
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanResult>> + 'a> {
         struct ScanFile {
             path: String,
             size: i64,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -258,7 +258,7 @@ impl Scan {
                 size,
                 dv_info,
                 partition_values,
-            })
+            });
         }
 
         debug!(

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -276,7 +276,7 @@ impl Scan {
             .flatten_ok()
             .flatten_ok();
 
-        let scan_result_iter = scan_files_iter
+        Ok(scan_files_iter
             .map_ok(move |scan_file| -> DeltaResult<_> {
                 let file_path = self.snapshot.table_root.join(&scan_file.path)?;
                 let mut selection_vector = scan_file
@@ -323,8 +323,7 @@ impl Scan {
             })
             .flatten_ok()
             .flatten_ok()
-            .flatten_ok();
-        Ok(scan_result_iter)
+            .flatten_ok())
     }
 }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -232,7 +232,7 @@ impl Scan {
     /// present. See the documentation for [`ScanResult`] for more details. Generally
     /// connectors/engines will want to use [`Scan::scan_data`] so they can have more control over
     /// the execution of the scan.
-    // This calls [`Scan::files`] to get a set of `Add` actions for the scan, and then uses the
+    // This calls [`Scan::scan_data`] to get an iterator of `ScanData` actions for the scan, and then uses the
     // `engine`'s [`crate::ParquetHandler`] to read the actual table data.
     pub fn execute<'a>(
         &'a self,
@@ -273,7 +273,8 @@ impl Scan {
                 let scan_files = vec![];
                 state::visit_scan_files(data.as_ref(), &vec, scan_files, scan_data_callback)
             })
-            .flatten_ok(); // Iterator<DeltaResult<Vec<ScanFile>>> to Iterator<DeltaResult<ScanFile>>
+            // Iterator<DeltaResult<Vec<ScanFile>>> to Iterator<DeltaResult<ScanFile>>
+            .flatten_ok();
 
         let result = scan_files_iter
             .map(move |scan_file| -> DeltaResult<_> {
@@ -319,8 +320,10 @@ impl Scan {
                     Ok(result)
                 }))
             })
-            .flatten_ok() // Iterator<DeltaResult<Iterator<DeltaResult<ScanResult>>>> to Iterator<DeltaResult<DeltaResult<ScanResult>>>
-            .map(|x| x?); // Iterator<DeltaResult<DeltaResult<ScanResult>>> to Iterator<DeltaResult<ScanResult>>
+            // Iterator<DeltaResult<Iterator<DeltaResult<ScanResult>>>> to Iterator<DeltaResult<DeltaResult<ScanResult>>>
+            .flatten_ok()
+            // Iterator<DeltaResult<DeltaResult<ScanResult>>> to Iterator<DeltaResult<ScanResult>>
+            .map(|x| x?);
         Ok(result)
     }
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -273,9 +273,8 @@ impl Scan {
             .map_and_then(|(data, vec)| {
                 let scan_files = vec![];
                 state::visit_scan_files(data.as_ref(), &vec, scan_files, scan_data_callback)
-                    .map(IntoIterator::into_iter)
             })
-            .flatten_ok(); // Iterator<DeltaResult<Iterator<ScanFile>>> to
+            .flatten_ok(); // Iterator<DeltaResult<Vec<ScanFile>>> to
                            // Iterator<DeltaResult<ScanFile>>
 
         let result = scan_files_iter

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -640,11 +640,7 @@ mod tests {
         let table = Table::new(url);
         let snapshot = table.snapshot(&engine, None).unwrap();
         let scan = snapshot.into_scan_builder().build().unwrap();
-        let files = scan
-            .execute(&engine)
-            .unwrap()
-            .map(Result::unwrap)
-            .collect_vec();
+        let files: Vec<_> = scan.execute(&engine).unwrap().try_collect().unwrap();
 
         assert_eq!(files.len(), 1);
         let num_rows = files[0].raw_data.as_ref().unwrap().length();

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -322,7 +322,7 @@ impl Scan {
             .flatten_ok()
             .flatten_ok()
             .flatten_ok();
-        Ok(Box::new(scan_result_iter))
+        Ok(scan_result_iter)
     }
 }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -274,8 +274,7 @@ impl Scan {
                 let scan_files = vec![];
                 state::visit_scan_files(data.as_ref(), &vec, scan_files, scan_data_callback)
             })
-            .flatten_ok(); // Iterator<DeltaResult<Vec<ScanFile>>> to
-                           // Iterator<DeltaResult<ScanFile>>
+            .flatten_ok(); // Iterator<DeltaResult<Vec<ScanFile>>> to Iterator<DeltaResult<ScanFile>>
 
         let result = scan_files_iter
             .map_and_then(move |scan_file| {
@@ -320,8 +319,7 @@ impl Scan {
                 }))
             })
             .flatten_ok() // Iterator<DeltaResult<Iterator<DeltaResult<ScanResult>>>> to Iterator<DeltaResult<DeltaResult<ScanResult>>>
-            .map_and_then(identity); // Iterator<DeltaResult<DeltaResult<ScanResult>>> to
-                                     // Iterator<DeltaResult<ScanResult>>
+            .map_and_then(identity); // Iterator<DeltaResult<DeltaResult<ScanResult>>> to Iterator<DeltaResult<ScanResult>>
         Ok(result)
     }
 }

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -9,20 +9,4 @@ macro_rules! require {
     };
 }
 
-/// Applies `f` to every `Result::Ok` value, returning a `Result`. `Result::Err` values are
-/// unchanged. This is equivalent to applying `and_then(f)` to each result item in the iterator.
-pub(crate) trait MapAndThen: Iterator {
-    fn map_and_then<F, T, U, E>(self, mut f: F) -> impl Iterator<Item = Result<U, E>>
-    where
-        Self: Iterator<Item = Result<T, E>> + Sized,
-        F: FnMut(T) -> Result<U, E>,
-    {
-        // NOTE: FnMut is-a FnOnce, but using it that way consumes `f`. Fortunately,
-        // &mut FnMut is _also_ FnOnce, and using it that way does _not_ consume `f`.
-        self.map(move |result| result.and_then(&mut f))
-    }
-}
-
-impl<T: Iterator> MapAndThen for T {}
-
 pub(crate) use require;

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -8,7 +8,7 @@ macro_rules! require {
         }
     };
 }
-pub trait MapAndThen: Iterator {
+pub(super) trait MapAndThen: Iterator {
     fn map_and_then<F, T, U, E>(self, mut f: F) -> impl Iterator<Item = Result<U, E>>
     where
         Self: Iterator<Item = Result<T, E>> + Sized,

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -8,5 +8,18 @@ macro_rules! require {
         }
     };
 }
+pub trait MapAndThen: Iterator {
+    fn map_and_then<F, T, U, E>(self, mut f: F) -> impl Iterator<Item = Result<U, E>>
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        F: FnMut(T) -> Result<U, E>,
+    {
+        // NOTE: FnMut is-a FnOnce, but using it that way consumes `f`. Fortunately,
+        // &mut FnMut is _also_ FnOnce, and using it that way does _not_ consume `f`.
+        self.map(move |result| result.and_then(&mut f))
+    }
+}
+
+impl<T: Iterator> MapAndThen for T {}
 
 pub(crate) use require;

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -8,7 +8,7 @@ macro_rules! require {
         }
     };
 }
-pub(super) trait MapAndThen: Iterator {
+pub(crate) trait MapAndThen: Iterator {
     fn map_and_then<F, T, U, E>(self, mut f: F) -> impl Iterator<Item = Result<U, E>>
     where
         Self: Iterator<Item = Result<T, E>> + Sized,

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -8,6 +8,9 @@ macro_rules! require {
         }
     };
 }
+
+/// Applies `f` to every `Result::Ok` value, returning a `Result`. `Result::Err` values are
+/// unchanged. This is equivalent to calling `and_then(f)` for each result item in the iterator.
 pub(crate) trait MapAndThen: Iterator {
     fn map_and_then<F, T, U, E>(self, mut f: F) -> impl Iterator<Item = Result<U, E>>
     where

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -10,7 +10,7 @@ macro_rules! require {
 }
 
 /// Applies `f` to every `Result::Ok` value, returning a `Result`. `Result::Err` values are
-/// unchanged. This is equivalent to calling `and_then(f)` for each result item in the iterator.
+/// unchanged. This is equivalent to applying `and_then(f)` to each result item in the iterator.
 pub(crate) trait MapAndThen: Iterator {
     fn map_and_then<F, T, U, E>(self, mut f: F) -> impl Iterator<Item = Result<U, E>>
     where

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -15,17 +15,16 @@ fn count_total_scan_rows(
 ) -> DeltaResult<usize> {
     stream
         .map(|sr_res| {
-            sr_res.and_then(|sr| {
-                let data = sr.raw_data?;
-                let rows = data.length();
-                let valid_rows = sr.mask.as_ref().map_or(rows, |mask| {
-                    // [`ScanResult`] states that the mask may be *shorter* than the number of
-                    // rows. Missing rows are counted as true, so we add them in.
-                    let extra_rows = rows - mask.len();
-                    mask.iter().filter(|&&m| m).count() + extra_rows
-                });
-                Ok(valid_rows)
-            })
+            let sr = sr_res?;
+            let data = sr.raw_data?;
+            let rows = data.length();
+            let valid_rows = sr.mask.as_ref().map_or(rows, |mask| {
+                // [`ScanResult`] states that the mask may be *shorter* than the number of
+                // rows. Missing rows are counted as true, so we add them in.
+                let extra_rows = rows - mask.len();
+                mask.iter().filter(|&&m| m).count() + extra_rows
+            });
+            Ok(valid_rows)
         })
         .fold_ok(0, Add::add)
 }

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -43,9 +43,10 @@ fn non_dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let snapshot = table.snapshot(&engine, None)?;
     let scan = snapshot.into_scan_builder().build()?;
 
-    let stream = scan.execute(&engine)?.map(Result::unwrap);
+    let stream = scan.execute(&engine)?;
     let mut total_rows = 0;
     for res in stream {
+        let res = res?;
         let data = res.raw_data?;
         let rows = data.length();
         for i in 0..rows {

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -14,15 +14,15 @@ fn count_total_scan_rows(
     stream: impl Iterator<Item = DeltaResult<ScanResult>>,
 ) -> DeltaResult<usize> {
     stream
-        .map(|res| -> DeltaResult<_> {
-            res.and_then(|res| {
-                let data = res.raw_data?;
+        .map(|sr_res| -> DeltaResult<_> {
+            sr_res.and_then(|sr| {
+                let data = sr.raw_data?;
                 let rows = data.length();
-                let valid_rows = res.mask.as_ref().map_or(rows, |mask| {
+                let valid_rows = sr.mask.as_ref().map_or(rows, |mask| {
                     // [`ScanResult`] states that the mask may be *shorter* than the number of
-                    // rows. Missing elements are considered true, so we include them in the count.
-                    let missing_elems = rows - mask.len();
-                    mask.iter().filter(|&&m| m).count() + missing_elems
+                    // rows. Missing rows are counted as true, so we add them in.
+                    let extra_rows = rows - mask.len();
+                    mask.iter().filter(|&&m| m).count() + extra_rows
                 });
                 Ok(valid_rows)
             })

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -17,9 +17,10 @@ fn dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let snapshot = table.snapshot(&engine, None)?;
     let scan = snapshot.into_scan_builder().build()?;
 
-    let stream = scan.execute(&engine)?.map(Result::unwrap);
+    let stream = scan.execute(&engine)?;
     let mut total_rows = 0;
     for res in stream {
+        let res = res?;
         let data = res.raw_data?;
         let rows = data.length();
         for i in 0..rows {

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -14,13 +14,14 @@ fn count_total_scan_rows(
     stream: impl Iterator<Item = DeltaResult<ScanResult>>,
 ) -> DeltaResult<usize> {
     stream
-        .map(|sr_res| {
-            let sr = sr_res?;
+        .map(|sr| {
+            let sr = sr?;
             let data = sr.raw_data?;
             // NOTE: The mask only suppresses rows for which it is both present and false.
-            let deleted_rows = sr.mask.as_ref().map_or(0, |mask| {
-                mask.iter().filter(|&&m| !m).count()
-            });
+            let deleted_rows = sr
+                .mask
+                .as_ref()
+                .map_or(0, |mask| mask.iter().filter(|&&m| !m).count());
             Ok(data.length() - deleted_rows)
         })
         .fold_ok(0, Add::add)

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -14,7 +14,7 @@ fn count_total_scan_rows(
     stream: impl Iterator<Item = DeltaResult<ScanResult>>,
 ) -> DeltaResult<usize> {
     stream
-        .map(|sr_res| -> DeltaResult<_> {
+        .map(|sr_res| {
             sr_res.and_then(|sr| {
                 let data = sr.raw_data?;
                 let rows = data.length();

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -20,6 +20,7 @@ fn dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let stream = scan.execute(&engine)?;
     let mut total_rows = 0;
     for res in stream {
+        let res = res.unwrap();
         let data = res.raw_data?;
         let rows = data.length();
         for i in 0..rows {
@@ -45,6 +46,7 @@ fn non_dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let stream = scan.execute(&engine)?;
     let mut total_rows = 0;
     for res in stream {
+        let res = res.unwrap();
         let data = res.raw_data?;
         let rows = data.length();
         for i in 0..rows {

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -11,14 +11,14 @@ use itertools::Itertools;
 use test_log::test;
 
 fn count_total_scan_rows(
-    stream: impl Iterator<Item = DeltaResult<ScanResult>>,
+    scan_result_iter: impl Iterator<Item = DeltaResult<ScanResult>>,
 ) -> DeltaResult<usize> {
-    stream
-        .map(|sr| {
-            let sr = sr?;
-            let data = sr.raw_data?;
+    scan_result_iter
+        .map(|scan_result| {
+            let scan_result = scan_result?;
+            let data = scan_result.raw_data?;
             // NOTE: The mask only suppresses rows for which it is both present and false.
-            let deleted_rows = sr
+            let deleted_rows = scan_result
                 .mask
                 .as_ref()
                 .map_or(0, |mask| mask.iter().filter(|&&m| !m).count());

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -17,10 +17,9 @@ fn dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let snapshot = table.snapshot(&engine, None)?;
     let scan = snapshot.into_scan_builder().build()?;
 
-    let stream = scan.execute(&engine)?;
+    let stream = scan.execute(&engine)?.map(Result::unwrap);
     let mut total_rows = 0;
     for res in stream {
-        let res = res.unwrap();
         let data = res.raw_data?;
         let rows = data.length();
         for i in 0..rows {
@@ -43,10 +42,9 @@ fn non_dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let snapshot = table.snapshot(&engine, None)?;
     let scan = snapshot.into_scan_builder().build()?;
 
-    let stream = scan.execute(&engine)?;
+    let stream = scan.execute(&engine)?.map(Result::unwrap);
     let mut total_rows = 0;
     for res in stream {
-        let res = res.unwrap();
         let data = res.raw_data?;
         let rows = data.length();
         for i in 0..rows {

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -159,8 +159,8 @@ async fn latest_snapshot_test(
     let scan = snapshot.into_scan_builder().build()?;
     let scan_res = scan.execute(&engine)?;
     let batches: Vec<RecordBatch> = scan_res
-        .map(|sr| {
-            sr.and_then(|sr| {
+        .map(|sr_res| {
+            sr_res.and_then(|sr| {
                 let data = sr.raw_data?;
                 let record_batch = to_arrow(data)?;
                 if let Some(mut mask) = sr.mask {

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -7,7 +7,6 @@ use arrow::{compute::filter_record_batch, record_batch::RecordBatch};
 use arrow_ord::sort::{lexsort_to_indices, SortColumn};
 use arrow_schema::Schema;
 use arrow_select::{concat::concat_batches, take::take};
-use itertools::Itertools;
 use paste::paste;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -174,7 +173,7 @@ async fn latest_snapshot_test(
                 Ok(record_batch)
             }
         })
-        .try_collect()?;
+        .collect::<DeltaResult<Vec<RecordBatch>>>()?;
 
     let expected = read_expected(&expected_path.expect("expect an expected dir")).await?;
 

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -7,6 +7,7 @@ use arrow::{compute::filter_record_batch, record_batch::RecordBatch};
 use arrow_ord::sort::{lexsort_to_indices, SortColumn};
 use arrow_schema::Schema;
 use arrow_select::{concat::concat_batches, take::take};
+use itertools::Itertools;
 use paste::paste;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -153,37 +154,35 @@ async fn latest_snapshot_test(
     table: Table,
     expected_path: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot = table.snapshot(&engine, None).unwrap();
+    let snapshot = table.snapshot(&engine, None)?;
 
-    let scan = snapshot.into_scan_builder().build().unwrap();
-    let scan_res = scan.execute(&engine).unwrap();
+    let scan = snapshot.into_scan_builder().build()?;
+    let scan_res = scan.execute(&engine)?;
     let batches: Vec<RecordBatch> = scan_res
-        .map(|sr| {
-            let sr = sr.unwrap();
-            let data = sr.raw_data.unwrap();
-            let record_batch = to_arrow(data).unwrap();
+        .map(|sr| -> DeltaResult<_> {
+            let sr = sr?;
+            let data = sr.raw_data?;
+            let record_batch = to_arrow(data)?;
             if let Some(mut mask) = sr.mask {
                 let extra_rows = record_batch.num_rows() - mask.len();
                 if extra_rows > 0 {
                     // we need to extend the mask here in case it's too short
                     mask.extend(std::iter::repeat(true).take(extra_rows));
                 }
-                filter_record_batch(&record_batch, &mask.into()).unwrap()
+                Ok(filter_record_batch(&record_batch, &mask.into())?)
             } else {
-                record_batch
+                Ok(record_batch)
             }
         })
-        .collect();
+        .try_collect()?;
 
-    let expected = read_expected(&expected_path.expect("expect an expected dir"))
-        .await
-        .unwrap();
+    let expected = read_expected(&expected_path.expect("expect an expected dir")).await?;
 
-    let schema: Arc<Schema> = Arc::new(scan.schema().as_ref().try_into().unwrap());
+    let schema: Arc<Schema> = Arc::new(scan.schema().as_ref().try_into()?);
 
-    let result = concat_batches(&schema, &batches).unwrap();
-    let result = sort_record_batch(result).unwrap();
-    let expected = sort_record_batch(expected).unwrap();
+    let result = concat_batches(&schema, &batches)?;
+    let result = sort_record_batch(result)?;
+    let expected = sort_record_batch(expected)?;
     assert_columns_match(result.columns(), expected.columns());
     assert_schema_fields_match(expected.schema().as_ref(), result.schema().as_ref());
     assert!(

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -159,11 +159,11 @@ async fn latest_snapshot_test(
     let scan = snapshot.into_scan_builder().build()?;
     let scan_res = scan.execute(&engine)?;
     let batches: Vec<RecordBatch> = scan_res
-        .map(|sr| -> DeltaResult<_> {
-            let sr = sr?;
-            let data = sr.raw_data?;
+        .map(|scan_result| -> DeltaResult<_> {
+            let scan_result = scan_result?;
+            let data = scan_result.raw_data?;
             let record_batch = to_arrow(data)?;
-            if let Some(mut mask) = sr.mask {
+            if let Some(mut mask) = scan_result.mask {
                 let extra_rows = record_batch.num_rows() - mask.len();
                 if extra_rows > 0 {
                     // we need to extend the mask here in case it's too short

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -159,7 +159,7 @@ async fn latest_snapshot_test(
     let scan = snapshot.into_scan_builder().build()?;
     let scan_res = scan.execute(&engine)?;
     let batches: Vec<RecordBatch> = scan_res
-        .map(|sr| -> DeltaResult<_> {
+        .map(|sr| {
             sr.and_then(|sr| {
                 let data = sr.raw_data?;
                 let record_batch = to_arrow(data)?;

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -158,9 +158,8 @@ async fn latest_snapshot_test(
     let scan = snapshot.into_scan_builder().build().unwrap();
     let scan_res = scan.execute(&engine).unwrap();
     let batches: Vec<RecordBatch> = scan_res
-        .into_iter()
+        .map(Result::unwrap)
         .map(|sr| {
-            let sr = sr.unwrap();
             let data = sr.raw_data.unwrap();
             let record_batch = to_arrow(data).unwrap();
             if let Some(mut mask) = sr.mask {

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -159,21 +159,20 @@ async fn latest_snapshot_test(
     let scan = snapshot.into_scan_builder().build()?;
     let scan_res = scan.execute(&engine)?;
     let batches: Vec<RecordBatch> = scan_res
-        .map(|sr_res| {
-            sr_res.and_then(|sr| {
-                let data = sr.raw_data?;
-                let record_batch = to_arrow(data)?;
-                if let Some(mut mask) = sr.mask {
-                    let extra_rows = record_batch.num_rows() - mask.len();
-                    if extra_rows > 0 {
-                        // we need to extend the mask here in case it's too short
-                        mask.extend(std::iter::repeat(true).take(extra_rows));
-                    }
-                    Ok(filter_record_batch(&record_batch, &mask.into())?)
-                } else {
-                    Ok(record_batch)
+        .map(|sr_res| -> DeltaResult<_> {
+            let sr = sr_res?;
+            let data = sr.raw_data?;
+            let record_batch = to_arrow(data)?;
+            if let Some(mut mask) = sr.mask {
+                let extra_rows = record_batch.num_rows() - mask.len();
+                if extra_rows > 0 {
+                    // we need to extend the mask here in case it's too short
+                    mask.extend(std::iter::repeat(true).take(extra_rows));
                 }
-            })
+                Ok(filter_record_batch(&record_batch, &mask.into())?)
+            } else {
+                Ok(record_batch)
+            }
         })
         .try_collect()?;
 

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -7,6 +7,7 @@ use arrow::{compute::filter_record_batch, record_batch::RecordBatch};
 use arrow_ord::sort::{lexsort_to_indices, SortColumn};
 use arrow_schema::Schema;
 use arrow_select::{concat::concat_batches, take::take};
+use itertools::Itertools;
 use paste::paste;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -158,8 +159,7 @@ async fn latest_snapshot_test(
     let scan = snapshot.into_scan_builder().build().unwrap();
     let scan_res = scan.execute(&engine).unwrap();
     let batches: Vec<RecordBatch> = scan_res
-        .map(Result::unwrap)
-        .map(|sr| {
+        .map_ok(|sr| {
             let data = sr.raw_data.unwrap();
             let record_batch = to_arrow(data).unwrap();
             if let Some(mut mask) = sr.mask {
@@ -173,7 +173,7 @@ async fn latest_snapshot_test(
                 record_batch
             }
         })
-        .collect();
+        .try_collect()?;
 
     let expected = read_expected(&expected_path.expect("expect an expected dir"))
         .await

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -159,8 +159,8 @@ async fn latest_snapshot_test(
     let scan = snapshot.into_scan_builder().build()?;
     let scan_res = scan.execute(&engine)?;
     let batches: Vec<RecordBatch> = scan_res
-        .map(|sr_res| -> DeltaResult<_> {
-            let sr = sr_res?;
+        .map(|sr| -> DeltaResult<_> {
+            let sr = sr?;
             let data = sr.raw_data?;
             let record_batch = to_arrow(data)?;
             if let Some(mut mask) = sr.mask {

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -160,6 +160,7 @@ async fn latest_snapshot_test(
     let batches: Vec<RecordBatch> = scan_res
         .into_iter()
         .map(|sr| {
+            let sr = sr.unwrap();
             let data = sr.raw_data.unwrap();
             let record_batch = to_arrow(data).unwrap();
             if let Some(mut mask) = sr.mask {

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -7,7 +7,6 @@ use arrow::{compute::filter_record_batch, record_batch::RecordBatch};
 use arrow_ord::sort::{lexsort_to_indices, SortColumn};
 use arrow_schema::Schema;
 use arrow_select::{concat::concat_batches, take::take};
-use itertools::Itertools;
 use paste::paste;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -159,7 +158,8 @@ async fn latest_snapshot_test(
     let scan = snapshot.into_scan_builder().build().unwrap();
     let scan_res = scan.execute(&engine).unwrap();
     let batches: Vec<RecordBatch> = scan_res
-        .map_ok(|sr| {
+        .map(|sr| {
+            let sr = sr.unwrap();
             let data = sr.raw_data.unwrap();
             let record_batch = to_arrow(data).unwrap();
             if let Some(mut mask) = sr.mask {
@@ -173,7 +173,7 @@ async fn latest_snapshot_test(
                 record_batch
             }
         })
-        .try_collect()?;
+        .collect();
 
     let expected = read_expected(&expected_path.expect("expect an expected dir"))
         .await

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -18,7 +18,6 @@ use delta_kernel::scan::state::{visit_scan_files, DvInfo, Stats};
 use delta_kernel::scan::{transform_to_logical, Scan};
 use delta_kernel::schema::Schema;
 use delta_kernel::{DeltaResult, Engine, EngineData, FileMeta, Table};
-use itertools::Itertools;
 use object_store::{memory::InMemory, path::Path, ObjectStore};
 use parquet::arrow::arrow_writer::ArrowWriter;
 use parquet::file::properties::WriterProperties;
@@ -414,7 +413,7 @@ fn read_with_execute(
                 Ok(record_batch)
             }
         })
-        .try_collect()?;
+        .collect::<DeltaResult<Vec<RecordBatch>>>()?;
 
     if expected.is_empty() {
         assert_eq!(batches.len(), 0);

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -399,8 +399,8 @@ fn read_with_execute(
     let result_schema: ArrowSchemaRef = Arc::new(scan.schema().as_ref().try_into()?);
     let scan_results = scan.execute(engine)?;
     let batches: Vec<RecordBatch> = scan_results
-        .map(|sr_res| -> DeltaResult<_> {
-            let sr = sr_res?;
+        .map(|sr| -> DeltaResult<_> {
+            let sr = sr?;
             let data = sr.raw_data?;
             let record_batch = to_arrow(data)?;
             if let Some(mut mask) = sr.mask {

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -399,8 +399,8 @@ fn read_with_execute(
     let result_schema: ArrowSchemaRef = Arc::new(scan.schema().as_ref().try_into()?);
     let scan_results = scan.execute(engine)?;
     let batches: Vec<RecordBatch> = scan_results
-        .map(|sr| -> DeltaResult<_> {
-            sr.and_then(|sr| {
+        .map(|sr_res| {
+            sr_res.and_then(|sr| {
                 let data = sr.raw_data?;
                 let record_batch = to_arrow(data)?;
                 if let Some(mut mask) = sr.mask {

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -120,10 +120,13 @@ async fn single_commit_two_add_files() -> Result<(), Box<dyn std::error::Error>>
     let scan = snapshot.into_scan_builder().build()?;
 
     let mut files = 0;
-    let stream = scan.execute(&engine)?.zip(expected_data);
+    let stream = scan
+        .execute(&engine)?
+        .map(Result::unwrap)
+        .zip(expected_data);
 
     for (data, expected) in stream {
-        let raw_data = data?.raw_data?;
+        let raw_data = data.raw_data?;
         files += 1;
         assert_eq!(into_record_batch(raw_data), expected);
     }
@@ -171,10 +174,13 @@ async fn two_commits() -> Result<(), Box<dyn std::error::Error>> {
     let scan = snapshot.into_scan_builder().build()?;
 
     let mut files = 0;
-    let stream = scan.execute(&engine)?.zip(expected_data);
+    let stream = scan
+        .execute(&engine)?
+        .map(Result::unwrap)
+        .zip(expected_data);
 
     for (data, expected) in stream {
-        let raw_data = data?.raw_data?;
+        let raw_data = data.raw_data?;
         files += 1;
         assert_eq!(into_record_batch(raw_data), expected);
     }
@@ -351,10 +357,13 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
 
         let expected_files = expected_batches.len();
         let mut files_scanned = 0;
-        let stream = scan.execute(&engine)?.zip(expected_batches);
+        let stream = scan
+            .execute(&engine)?
+            .map(Result::unwrap)
+            .zip(expected_batches);
 
         for (batch, expected) in stream {
-            let raw_data = batch?.raw_data?;
+            let raw_data = batch.raw_data?;
             files_scanned += 1;
             assert_eq!(into_record_batch(raw_data), expected.clone());
         }
@@ -455,10 +464,10 @@ fn read_with_scan_data(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let global_state = scan.global_scan_state();
     let result_schema: ArrowSchemaRef = Arc::new(scan.schema().as_ref().try_into()?);
-    let scan_data = scan.scan_data(engine)?;
+    let scan_data = scan.scan_data(engine)?.map(Result::unwrap);
     let mut scan_files = vec![];
     for data in scan_data {
-        let (data, vec) = data?;
+        let (data, vec) = data;
         scan_files = visit_scan_files(data.as_ref(), &vec, scan_files, scan_data_callback)?;
     }
 

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -18,6 +18,7 @@ use delta_kernel::scan::state::{visit_scan_files, DvInfo, Stats};
 use delta_kernel::scan::{transform_to_logical, Scan};
 use delta_kernel::schema::Schema;
 use delta_kernel::{Engine, EngineData, FileMeta, Table};
+use itertools::Itertools;
 use object_store::{memory::InMemory, path::Path, ObjectStore};
 use parquet::arrow::arrow_writer::ArrowWriter;
 use parquet::file::properties::WriterProperties;
@@ -120,13 +121,10 @@ async fn single_commit_two_add_files() -> Result<(), Box<dyn std::error::Error>>
     let scan = snapshot.into_scan_builder().build()?;
 
     let mut files = 0;
-    let stream = scan
-        .execute(&engine)?
-        .map(Result::unwrap)
-        .zip(expected_data);
+    let stream = scan.execute(&engine)?.zip(expected_data);
 
     for (data, expected) in stream {
-        let raw_data = data.raw_data?;
+        let raw_data = data?.raw_data?;
         files += 1;
         assert_eq!(into_record_batch(raw_data), expected);
     }
@@ -174,13 +172,10 @@ async fn two_commits() -> Result<(), Box<dyn std::error::Error>> {
     let scan = snapshot.into_scan_builder().build()?;
 
     let mut files = 0;
-    let stream = scan
-        .execute(&engine)?
-        .map(Result::unwrap)
-        .zip(expected_data);
+    let stream = scan.execute(&engine)?.zip(expected_data);
 
     for (data, expected) in stream {
-        let raw_data = data.raw_data?;
+        let raw_data = data?.raw_data?;
         files += 1;
         assert_eq!(into_record_batch(raw_data), expected);
     }
@@ -231,14 +226,11 @@ async fn remove_action() -> Result<(), Box<dyn std::error::Error>> {
     let snapshot = table.snapshot(&engine, None)?;
     let scan = snapshot.into_scan_builder().build()?;
 
-    let stream = scan
-        .execute(&engine)?
-        .map(Result::unwrap)
-        .zip(expected_data);
+    let stream = scan.execute(&engine)?.zip(expected_data);
 
     let mut files = 0;
     for (data, expected) in stream {
-        let raw_data = data.raw_data?;
+        let raw_data = data?.raw_data?;
         files += 1;
         assert_eq!(into_record_batch(raw_data), expected);
     }
@@ -360,13 +352,10 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
 
         let expected_files = expected_batches.len();
         let mut files_scanned = 0;
-        let stream = scan
-            .execute(&engine)?
-            .map(Result::unwrap)
-            .zip(expected_batches);
+        let stream = scan.execute(&engine)?.zip(expected_batches);
 
         for (batch, expected) in stream {
-            let raw_data = batch.raw_data?;
+            let raw_data = batch?.raw_data?;
             files_scanned += 1;
             assert_eq!(into_record_batch(raw_data), expected.clone());
         }
@@ -410,8 +399,7 @@ fn read_with_execute(
     let result_schema: ArrowSchemaRef = Arc::new(scan.schema().as_ref().try_into()?);
     let scan_results = scan.execute(engine)?;
     let batches: Vec<RecordBatch> = scan_results
-        .map(Result::unwrap)
-        .map(|sr| {
+        .map_ok(|sr| {
             let data = sr.raw_data.unwrap();
             let record_batch = to_arrow(data).unwrap();
             if let Some(mut mask) = sr.mask {
@@ -425,7 +413,7 @@ fn read_with_execute(
                 record_batch
             }
         })
-        .collect();
+        .try_collect()?;
 
     if expected.is_empty() {
         assert_eq!(batches.len(), 0);

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -399,11 +399,11 @@ fn read_with_execute(
     let result_schema: ArrowSchemaRef = Arc::new(scan.schema().as_ref().try_into()?);
     let scan_results = scan.execute(engine)?;
     let batches: Vec<RecordBatch> = scan_results
-        .map(|sr| -> DeltaResult<_> {
-            let sr = sr?;
-            let data = sr.raw_data?;
+        .map(|scan_result| -> DeltaResult<_> {
+            let scan_result = scan_result?;
+            let data = scan_result.raw_data?;
             let record_batch = to_arrow(data)?;
-            if let Some(mut mask) = sr.mask {
+            if let Some(mut mask) = scan_result.mask {
                 let extra_rows = record_batch.num_rows() - mask.len();
                 if extra_rows > 0 {
                     // we need to extend the mask here in case it's too short

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -17,7 +17,7 @@ use delta_kernel::expressions::{BinaryOperator, Expression};
 use delta_kernel::scan::state::{visit_scan_files, DvInfo, Stats};
 use delta_kernel::scan::{transform_to_logical, Scan};
 use delta_kernel::schema::Schema;
-use delta_kernel::{DeltaResult, Engine, EngineData, FileMeta, Table};
+use delta_kernel::{Engine, EngineData, FileMeta, Table};
 use itertools::Itertools;
 use object_store::{memory::InMemory, path::Path, ObjectStore};
 use parquet::arrow::arrow_writer::ArrowWriter;


### PR DESCRIPTION
Currently, `scan::execute` computes all `ScanResult`s ahead of time and returns a vector. This PR changes it to return an iterator that lazily fetches scan files, reads parquet data, and applies deletion vectors. This avoids a large upfront performance cost when executing a scan.

Closes: #123 