### PR TITLE
Support annotation for nullable values in a container

### DIFF
--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Fields, PathArguments, Type};
+use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Fields, Meta, PathArguments, Type};
 
 /// Derive a `delta_kernel::schemas::ToDataType` implementation for the annotated struct. The actual
 /// field names in the schema (and therefore of the struct members) are all mandated by the Delta
@@ -10,7 +10,7 @@ use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Fields, PathArgument
 /// Change Metadata](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#change-metadata)
 /// action (this macro allows the use of standard rust snake_case, and will convert to the correct
 /// delta schema camelCase version).
-#[proc_macro_derive(Schema)]
+#[proc_macro_derive(Schema, attributes(schema_container_values_null))]
 pub fn derive_schema(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let struct_ident = input.ident;
@@ -20,7 +20,7 @@ pub fn derive_schema(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
         #[automatically_derived]
         impl crate::actions::schemas::ToDataType for #struct_ident {
             fn to_data_type() -> crate::schema::DataType {
-                use crate::actions::schemas::{ToDataType, GetStructField};
+                use crate::actions::schemas::{ToDataType, GetStructField, GetNullableContainerStructField};
                 crate::schema::StructType::new(vec![
                     #schema_fields
                 ]).into()
@@ -64,6 +64,14 @@ fn gen_schema_fields(data: &Data) -> TokenStream {
     let schema_fields = fields.iter().map(|field| {
         let name = field.ident.as_ref().unwrap(); // we know these are named fields
         let name = get_schema_name(name);
+        let have_schema_null = field.attrs.iter().any(|attr| {
+            // check if we have schema_map_values_null attr
+            match &attr.meta {
+                Meta::Path(path) => path.get_ident().map(|ident| ident == "schema_container_values_null").unwrap_or(false),
+                _ => false,
+            }
+        });
+
         match field.ty {
             Type::Path(ref type_path) => {
                 let type_path_quoted = type_path.path.segments.iter().map(|segment| {
@@ -74,7 +82,16 @@ fn gen_schema_fields(data: &Data) -> TokenStream {
                         _ => panic!("Can only handle <> type path args"),
                     }
                 });
-                quote_spanned! { field.span() => #(#type_path_quoted),* get_struct_field(stringify!(#name))}
+                if have_schema_null {
+                    if let Some(first_ident) = type_path.path.segments.first().map(|seg| &seg.ident) {
+                        if first_ident != "HashMap" && first_ident != "Vec" {
+                            panic!("Can only use schema_container_values_null on HashMap or Vec fields, not {first_ident:?}");
+                        }
+                    }
+                    quote_spanned! { field.span() => #(#type_path_quoted),* get_nullable_container_struct_field(stringify!(#name))}
+                } else {
+                    quote_spanned! { field.span() => #(#type_path_quoted),* get_struct_field(stringify!(#name))}
+                }
             }
             _ => {
                 panic!("Can't handle type: {:?}", field.ty);

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -70,7 +70,7 @@ fn gen_schema_fields(data: &Data) -> TokenStream {
         let name = field.ident.as_ref().unwrap(); // we know these are named fields
         let name = get_schema_name(name);
         let have_schema_null = field.attrs.iter().any(|attr| {
-            // check if we have schema_map_values_null attr
+            // check if we have drop_null_container_values attr
             match &attr.meta {
                 Meta::Path(path) => path.get_ident().is_some_and(|ident| ident == "drop_null_container_values"),
                 _ => false,

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -47,7 +47,7 @@ pub(crate) fn get_log_schema() -> &'static StructType {
 pub struct Format {
     /// Name of the encoding for files in this table
     pub provider: String,
-    /// A map containingconfiguration options for the format
+    /// A map containing configuration options for the format
     pub options: HashMap<String, String>,
 }
 
@@ -141,6 +141,7 @@ pub struct Add {
     pub path: String,
 
     /// A map from partition column to value for this logical file.
+    #[schema_container_values_null]
     pub partition_values: HashMap<String, String>,
 
     /// The size of this data file in bytes

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -143,7 +143,7 @@ pub struct Add {
     /// A map from partition column to value for this logical file. This map can contain null in the
     /// values meaning a partition is null. We drop those values from this map, due to the
     /// `drop_null_container_values` annotation. This means an engine can assume that if a partition
-    /// is found in [`Metadata`] `partition_columns`, but not in this map, it's value is null.
+    /// is found in [`Metadata`] `partition_columns`, but not in this map, its value is null.
     #[drop_null_container_values]
     pub partition_values: HashMap<String, String>,
 

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -140,8 +140,11 @@ pub struct Add {
     /// [RFC 2396 URI Generic Syntax]: https://www.ietf.org/rfc/rfc2396.txt
     pub path: String,
 
-    /// A map from partition column to value for this logical file.
-    #[schema_container_values_null]
+    /// A map from partition column to value for this logical file. This map can contain null in the
+    /// values meaning a partition is null. We drop those values from this map, due to the
+    /// `drop_null_container_values` annotation. This means an engine can assume that if a partition
+    /// is found in [`Metadata`] `partition_columns`, but not in this map, it's value is null.
+    #[drop_null_container_values]
     pub partition_values: HashMap<String, String>,
 
     /// The size of this data file in bytes
@@ -291,6 +294,40 @@ mod tests {
                     MapType::new(DataType::STRING, DataType::STRING, false),
                     false,
                 ),
+            ]),
+            true,
+        )]));
+        assert_eq!(schema, expected);
+    }
+
+    #[test]
+    fn test_add_schema() {
+        let schema = get_log_schema()
+            .project(&["add"])
+            .expect("Couldn't get add field");
+
+        let expected = Arc::new(StructType::new(vec![StructField::new(
+            "add",
+            StructType::new(vec![
+                StructField::new("path", DataType::STRING, false),
+                StructField::new(
+                    "partitionValues",
+                    MapType::new(DataType::STRING, DataType::STRING, true),
+                    false,
+                ),
+                StructField::new("size", DataType::LONG, false),
+                StructField::new("modificationTime", DataType::LONG, false),
+                StructField::new("dataChange", DataType::BOOLEAN, false),
+                StructField::new("stats", DataType::STRING, true),
+                StructField::new(
+                    "tags",
+                    MapType::new(DataType::STRING, DataType::STRING, false),
+                    true,
+                ),
+                deletion_vector_field(),
+                StructField::new("baseRowId", DataType::LONG, true),
+                StructField::new("defaultRowCommitVersion", DataType::LONG, true),
+                StructField::new("clusteringProvider", DataType::STRING, true),
             ]),
             true,
         )]));

--- a/kernel/src/actions/schemas.rs
+++ b/kernel/src/actions/schemas.rs
@@ -8,6 +8,10 @@ pub(crate) trait ToDataType {
     fn to_data_type() -> DataType;
 }
 
+pub(crate) trait ToNullableContainerType {
+    fn to_nullable_container_type() -> DataType;
+}
+
 macro_rules! impl_to_data_type {
     ( $(($rust_type: ty, $kernel_type: expr)), * ) => {
         $(
@@ -38,6 +42,13 @@ impl<T: ToDataType> ToDataType for Vec<T> {
     }
 }
 
+// ToDataType impl for nullable map types
+impl<T: ToDataType> ToNullableContainerType for Vec<T> {
+    fn to_nullable_container_type() -> DataType {
+        ArrayType::new(T::to_data_type(), true).into()
+    }
+}
+
 impl<T: ToDataType> ToDataType for HashSet<T> {
     fn to_data_type() -> DataType {
         ArrayType::new(T::to_data_type(), false).into()
@@ -51,8 +62,26 @@ impl<K: ToDataType, V: ToDataType> ToDataType for HashMap<K, V> {
     }
 }
 
+// ToDataType impl for nullable map types
+impl<K: ToDataType, V: ToDataType> ToNullableContainerType for HashMap<K, V> {
+    fn to_nullable_container_type() -> DataType {
+        MapType::new(K::to_data_type(), V::to_data_type(), true).into()
+    }
+}
+
 pub(crate) trait GetStructField {
     fn get_struct_field(name: impl Into<String>) -> StructField;
+}
+
+pub(crate) trait GetNullableContainerStructField {
+    fn get_nullable_container_struct_field(name: impl Into<String>) -> StructField;
+}
+
+// Normal types produce non-nullable fields
+impl<T: ToNullableContainerType> GetNullableContainerStructField for T {
+    fn get_nullable_container_struct_field(name: impl Into<String>) -> StructField {
+        StructField::new(name, T::to_nullable_container_type(), false)
+    }
 }
 
 // Normal types produce non-nullable fields

--- a/kernel/src/actions/schemas.rs
+++ b/kernel/src/actions/schemas.rs
@@ -42,13 +42,6 @@ impl<T: ToDataType> ToDataType for Vec<T> {
     }
 }
 
-// ToDataType impl for nullable array types
-impl<T: ToDataType> ToNullableContainerType for Vec<T> {
-    fn to_nullable_container_type() -> DataType {
-        ArrayType::new(T::to_data_type(), true).into()
-    }
-}
-
 impl<T: ToDataType> ToDataType for HashSet<T> {
     fn to_data_type() -> DataType {
         ArrayType::new(T::to_data_type(), false).into()

--- a/kernel/src/actions/schemas.rs
+++ b/kernel/src/actions/schemas.rs
@@ -77,7 +77,8 @@ pub(crate) trait GetNullableContainerStructField {
     fn get_nullable_container_struct_field(name: impl Into<String>) -> StructField;
 }
 
-// Normal types produce non-nullable fields
+// Normal types produce non-nullable fields, but in this case the container they reference has
+// nullable values
 impl<T: ToNullableContainerType> GetNullableContainerStructField for T {
     fn get_nullable_container_struct_field(name: impl Into<String>) -> StructField {
         StructField::new(name, T::to_nullable_container_type(), false)

--- a/kernel/src/actions/schemas.rs
+++ b/kernel/src/actions/schemas.rs
@@ -42,7 +42,7 @@ impl<T: ToDataType> ToDataType for Vec<T> {
     }
 }
 
-// ToDataType impl for nullable map types
+// ToDataType impl for nullable array types
 impl<T: ToDataType> ToNullableContainerType for Vec<T> {
     fn to_nullable_container_type() -> DataType {
         ArrayType::new(T::to_data_type(), true).into()


### PR DESCRIPTION
When arrow fixes https://github.com/apache/arrow-rs/issues/6391, our code will start to fail since we don't allow for nulls in partition values, but they can be null.

This adds an annotation that will cause the generated schema to allow null values. We already have the semantics that if value is null on the arrow side, then `materialize` will simply not include it in the final map, so nothing else needs to change.

Tested by:
1. All tests still pass
2. Added a new test for the `add` schema that ensures it sets the `value_contains_null` field to true on the `partitionValues` map.
3. Looking at generated code and noting we get
```rust
HashMap::<
  String,
  String,
>::get_nullable_container_struct_field("partitionValues"),
```