### PR TITLE
Fix column name for protocol in P&M query

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -625,12 +625,8 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn test_scan_data() {
-        use tracing_subscriber::EnvFilter;
-        tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .init();
         let path =
             std::fs::canonicalize(PathBuf::from("./tests/data/table-without-dv-small/")).unwrap();
         let url = url::Url::from_directory_path(path).unwrap();

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -76,7 +76,7 @@ impl LogSegment {
         use Expression as Expr;
         let filter = Some(Expr::or(
             Expr::not(Expr::is_null(Expr::column("metaData.id"))),
-            Expr::not(Expr::is_null(Expr::column("protocol.min_reader_version"))),
+            Expr::not(Expr::is_null(Expr::column("protocol.minReaderVersion"))),
         ));
         // read the same protocol and metadata schema for both commits and checkpoints
         let data_batches = self.replay(engine, schema.clone(), schema, filter)?;


### PR DESCRIPTION
This is a followup to [this PR](https://github.com/delta-incubator/delta-kernel-rs/pull/336) which patches a mistake in the filter. Protocol has a `protocol.minReaderVersion`,  and no `protocol.min_reader_version` field.

This PR also fixes an intermittent test failure caused by repeat initialization of tracing.  This PR changes the `test_scan_data` test to instead use the test_log crate for initializing logs.