### PR TITLE
Ensure we return a sorted listing when using a local client

### DIFF
--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -52,8 +52,6 @@ impl<E: TaskExecutor> FileSystemClient for ObjectStoreFileSystemClient<E> {
         // TODO properly handle table prefix
         let prefix = self.table_root.child("_delta_log");
 
-        println!("Prefix is {:?}", prefix);
-
         let store = self.inner.clone();
 
         // This channel will become the iterator
@@ -237,14 +235,6 @@ mod tests {
         let url = Url::from_directory_path(tmp.path()).unwrap();
         let store = Arc::new(LocalFileSystem::new());
         let prefix = Path::from_url_path(url.path()).expect("Couldn't get path");
-
-        // debug code for windows
-        let s = store.clone();
-        let mut l = s.list(Some(&prefix));
-        while let Some(meta) = l.next().await {
-            println!("DBG GOT {:?}", meta.unwrap());
-        }
-
         let engine = DefaultEngine::new(store, prefix, Arc::new(TokioBackgroundExecutor::new()));
         let client = engine.get_file_system_client();
 

--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -52,6 +52,8 @@ impl<E: TaskExecutor> FileSystemClient for ObjectStoreFileSystemClient<E> {
         // TODO properly handle table prefix
         let prefix = self.table_root.child("_delta_log");
 
+        println!("Prefix is {:?}", prefix);
+
         let store = self.inner.clone();
 
         // This channel will become the iterator
@@ -234,8 +236,15 @@ mod tests {
 
         let url = Url::from_directory_path(tmp.path()).unwrap();
         let store = Arc::new(LocalFileSystem::new());
-        let prefix = Path::from(url.path());
-        let store: Arc<DynObjectStore> = store;
+        let prefix = Path::from_url_path(url.path()).expect("Couldn't get path");
+
+        // debug code for windows
+        let s = store.clone();
+        let mut l = s.list(Some(&prefix));
+        while let Some(meta) = l.next().await {
+            println!("DBG GOT {:?}", meta.unwrap());
+        }
+
         let engine = DefaultEngine::new(store, prefix, Arc::new(TokioBackgroundExecutor::new()));
         let client = engine.get_file_system_client();
 

--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -83,7 +83,7 @@ impl<E: TaskExecutor> FileSystemClient for ObjectStoreFileSystemClient<E> {
         if self.is_local {
             // LocalFileSystem doesn't return things in the order we require
             let mut fms: Vec<FileMeta> = receiver.into_iter().try_collect()?;
-            fms.sort();
+            fms.sort_unstable();
             Ok(Box::new(fms.into_iter().map(Ok)))
         } else {
             Ok(Box::new(receiver.into_iter()))

--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -84,7 +84,7 @@ impl<E: TaskExecutor> FileSystemClient for ObjectStoreFileSystemClient<E> {
             // LocalFileSystem doesn't return things in the order we require
             let mut fms: Vec<FileMeta> = receiver.into_iter().try_collect()?;
             fms.sort();
-            Ok(Box::new(fms.into_iter().map(|fm| Ok(fm))))
+            Ok(Box::new(fms.into_iter().map(Ok)))
         } else {
             Ok(Box::new(receiver.into_iter()))
         }

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -79,7 +79,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
         Self {
             file_system: Arc::new(ObjectStoreFileSystemClient::new(
                 store.clone(),
-                is_local,
+                !is_local,
                 prefix,
                 task_executor.clone(),
             )),

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -55,7 +55,25 @@ impl<E: TaskExecutor> DefaultEngine<E> {
     }
 
     pub fn new(store: Arc<DynObjectStore>, prefix: Path, task_executor: Arc<E>) -> Self {
-        // HACK to check if we're using a LocalFileSystem from ObjectStore
+        // HACK to check if we're using a LocalFileSystem from ObjectStore. We need this because
+        // local filesystem doesn't return a sorted list by default. Although the `object_store`
+        // crate explicitly says it _does not_ return a sorted listing, in practice all the cloud
+        // implementations actually do:
+        // - AWS:
+        //   [`ListObjectsV2`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)
+        //   states: "For general purpose buckets, ListObjectsV2 returns objects in lexicographical
+        //   order based on their key names." (Directory buckets are out of scope for now)
+        // - Azure: Docs state
+        //   [here](https://learn.microsoft.com/en-us/rest/api/storageservices/enumerating-blob-resources):
+        //   "A listing operation returns an XML response that contains all or part of the requested
+        //   list. The operation returns entities in alphabetical order."
+        // - GCP: The [main](https://cloud.google.com/storage/docs/xml-api/get-bucket-list) doc
+        //   doesn't indicate order, but [this
+        //   page](https://cloud.google.com/storage/docs/xml-api/get-bucket-list) does say: "This page
+        //   shows you how to list the [objects](https://cloud.google.com/storage/docs/objects) stored
+        //   in your Cloud Storage buckets, which are ordered in the list lexicographically by name."
+        // So we just need to know if we're local and then if so, we sort the returned file list in
+        // `filesystem.rs`
         let store_str = format!("{}", store);
         let is_local = store_str.starts_with("LocalFileSystem");
         Self {

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -51,26 +51,17 @@ impl<E: TaskExecutor> DefaultEngine<E> {
     {
         let (store, prefix) = parse_url_opts(path, options)?;
         let store = Arc::new(store);
-        Ok(Self {
-            file_system: Arc::new(ObjectStoreFileSystemClient::new(
-                store.clone(),
-                prefix,
-                task_executor.clone(),
-            )),
-            json: Arc::new(DefaultJsonHandler::new(
-                store.clone(),
-                task_executor.clone(),
-            )),
-            parquet: Arc::new(DefaultParquetHandler::new(store.clone(), task_executor)),
-            store,
-            expression: Arc::new(ArrowExpressionHandler {}),
-        })
+        Ok(Self::new(store, prefix, task_executor))
     }
 
     pub fn new(store: Arc<DynObjectStore>, prefix: Path, task_executor: Arc<E>) -> Self {
+        // HACK to check if we're using a LocalFileSystem from ObjectStore
+        let store_str = format!("{}", store);
+        let is_local = store_str.starts_with("LocalFileSystem");
         Self {
             file_system: Arc::new(ObjectStoreFileSystemClient::new(
                 store.clone(),
+                is_local,
                 prefix,
                 task_executor.clone(),
             )),

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -50,8 +50,8 @@
     rust_2021_compatibility
 )]
 
-use std::ops::Range;
 use std::sync::Arc;
+use std::{cmp::Ordering, ops::Range};
 
 use bytes::Bytes;
 use url::Url;
@@ -109,6 +109,18 @@ pub struct FileMeta {
     pub last_modified: i64,
     /// The size in bytes of the object
     pub size: usize,
+}
+
+impl Ord for FileMeta {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.location.cmp(&other.location)
+    }
+}
+
+impl PartialOrd for FileMeta {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 /// Trait for implementing an Expression evaluator.

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -521,6 +521,7 @@ mod tests {
         let prefix = Path::from(url.path());
         let client = ObjectStoreFileSystemClient::new(
             store,
+            true,
             prefix,
             Arc::new(TokioBackgroundExecutor::new()),
         );
@@ -624,6 +625,7 @@ mod tests {
 
         let client = ObjectStoreFileSystemClient::new(
             store,
+            true,
             Path::from("/"),
             Arc::new(TokioBackgroundExecutor::new()),
         );

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -397,6 +397,10 @@ fn list_log_files_with_checkpoint(
         )));
     }
 
+    debug_assert!(
+        commit_files.windows(2).all(|cfs| cfs[0].version <= cfs[1].version),
+        "fs_client.list_from() didn't return a sorted listing! {:?}", commit_files
+    );
     // We assume listing returned ordered, we want reverse order
     let commit_files = commit_files.into_iter().rev().collect();
 
@@ -442,6 +446,10 @@ fn list_log_files(
 
     commit_files.retain(|f| f.version as i64 > max_checkpoint_version);
 
+    debug_assert!(
+        commit_files.windows(2).all(|cfs| cfs[0].version <= cfs[1].version),
+        "fs_client.list_from() didn't return a sorted listing! {:?}", commit_files
+    );
     // We assume listing returned ordered, we want reverse order
     let commit_files = commit_files.into_iter().rev().collect();
 

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -536,7 +536,7 @@ mod tests {
         let prefix = Path::from(url.path());
         let client = ObjectStoreFileSystemClient::new(
             store,
-            true,
+            false, // don't have ordered listing
             prefix,
             Arc::new(TokioBackgroundExecutor::new()),
         );
@@ -596,7 +596,7 @@ mod tests {
 
         let client = ObjectStoreFileSystemClient::new(
             store,
-            true, // is_local
+            false, // don't have ordered listing
             Path::from("/"),
             Arc::new(TokioBackgroundExecutor::new()),
         );
@@ -641,7 +641,7 @@ mod tests {
 
         let client = ObjectStoreFileSystemClient::new(
             store,
-            true,
+            false, // don't have ordered listing
             Path::from("/"),
             Arc::new(TokioBackgroundExecutor::new()),
         );

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -581,6 +581,7 @@ mod tests {
 
         let client = ObjectStoreFileSystemClient::new(
             store,
+            true, // is_local
             Path::from("/"),
             Arc::new(TokioBackgroundExecutor::new()),
         );

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -397,8 +397,8 @@ fn list_log_files_with_checkpoint(
         )));
     }
 
-    // NOTE this will sort in reverse order
-    commit_files.sort_unstable_by(|a, b| b.version.cmp(&a.version));
+    // We assume listing returned ordered, we want reverse order
+    let commit_files = commit_files.into_iter().rev().collect();
 
     Ok((commit_files, checkpoint_files))
 }
@@ -441,8 +441,9 @@ fn list_log_files(
     }
 
     commit_files.retain(|f| f.version as i64 > max_checkpoint_version);
-    // NOTE this will sort in reverse order
-    commit_files.sort_unstable_by(|a, b| b.version.cmp(&a.version));
+
+    // We assume listing returned ordered, we want reverse order
+    let commit_files = commit_files.into_iter().rev().collect();
 
     Ok((commit_files, checkpoint_files))
 }

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -398,8 +398,11 @@ fn list_log_files_with_checkpoint(
     }
 
     debug_assert!(
-        commit_files.windows(2).all(|cfs| cfs[0].version <= cfs[1].version),
-        "fs_client.list_from() didn't return a sorted listing! {:?}", commit_files
+        commit_files
+            .windows(2)
+            .all(|cfs| cfs[0].version <= cfs[1].version),
+        "fs_client.list_from() didn't return a sorted listing! {:?}",
+        commit_files
     );
     // We assume listing returned ordered, we want reverse order
     let commit_files = commit_files.into_iter().rev().collect();
@@ -447,8 +450,11 @@ fn list_log_files(
     commit_files.retain(|f| f.version as i64 > max_checkpoint_version);
 
     debug_assert!(
-        commit_files.windows(2).all(|cfs| cfs[0].version <= cfs[1].version),
-        "fs_client.list_from() didn't return a sorted listing! {:?}", commit_files
+        commit_files
+            .windows(2)
+            .all(|cfs| cfs[0].version <= cfs[1].version),
+        "fs_client.list_from() didn't return a sorted listing! {:?}",
+        commit_files
     );
     // We assume listing returned ordered, we want reverse order
     let commit_files = commit_files.into_iter().rev().collect();


### PR DESCRIPTION
This ensures that calls to `list_files` are returned sorted if a `LocalFileSystem` `ObjectStore` is used.

It's not clean for a few reasons:
1. We have to materialize the entire iter in order to sort it
2. We can't easily detect if we're local just by using `type_of` or similar. We have a foreign trait object that doesn't have an `as_any` on it, so we can force the reference into an `Any` which would allow us to use [`is`](https://doc.rust-lang.org/std/any/trait.Any.html#method.is), and we can't _add_ an implementation of something like `as_any` because `dyn ObjectStore` isn't `Sized`. So this resorts to `format`ing the object at creation (since `ObjectStore` requires `Display`) and checking if it starts with `LocalFileSystem`....

Adds a test that when using local client things come back sorted now. Without these changes the test failed.

I think we should merge (or something like it) and then also see about adding a `list_sorted` and `list_with_offset_sorted` to `ObjectStore`