### PR TITLE
[chore] Update invalid handle test golden files

### DIFF
--- a/ffi/tests/invalid-handle-code/mut-clone-handle.stderr
+++ b/ffi/tests/invalid-handle-code/mut-clone-handle.stderr
@@ -2,13 +2,30 @@ error[E0599]: the method `clone_as_arc` exists for struct `Handle<MutFoo>`, but 
   --> tests/invalid-handle-code/mut-clone-handle.rs:13:15
    |
 8  | pub struct MutFoo;
-   | ----------------- doesn't satisfy `<MutFoo as HandleDescriptor>::Mutable = False`
+   | ----------------- doesn't satisfy 5 bounds
 ...
 13 |     let r = h.clone_as_arc();
    |               ^^^^^^^^^^^^ method cannot be called on `Handle<MutFoo>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
            `<MutFoo as HandleDescriptor>::Mutable = False`
+           `<MutFoo as handle::private::HandleOps<_, False, _>>::From = Arc<_>`
+           `MutFoo: handle::private::SharedHandleOps<_, _>`
+           `MutFoo: handle::private::SharedHandle`
+           which is required by `MutFoo: handle::private::SharedHandleOps<_, _>`
+           `MutFoo: handle::private::HandleOps<_, False, _>`
+           which is required by `MutFoo: handle::private::SharedHandleOps<_, _>`
+note: the traits `handle::private::SharedHandle`, `handle::private::HandleOps`,  and `handle::private::SharedHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait SharedHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait HandleOps<T: ?Sized, M, S> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait SharedHandleOps<T: ?Sized, S>: HandleOps<T, False, S> + SharedHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<MutFoo as HandleDescriptor>::Mutable == False`
   --> tests/invalid-handle-code/mut-clone-handle.rs:12:41
@@ -23,10 +40,27 @@ error[E0599]: the method `clone_handle` exists for struct `Handle<MutFoo>`, but 
   --> tests/invalid-handle-code/mut-clone-handle.rs:14:15
    |
 8  | pub struct MutFoo;
-   | ----------------- doesn't satisfy `<MutFoo as HandleDescriptor>::Mutable = False`
+   | ----------------- doesn't satisfy 5 bounds
 ...
 14 |     let h = h.clone_handle();
    |               ^^^^^^^^^^^^
    |
    = note: the following trait bounds were not satisfied:
            `<MutFoo as HandleDescriptor>::Mutable = False`
+           `<MutFoo as handle::private::HandleOps<_, False, _>>::From = Arc<_>`
+           `MutFoo: handle::private::SharedHandleOps<_, _>`
+           `MutFoo: handle::private::SharedHandle`
+           which is required by `MutFoo: handle::private::SharedHandleOps<_, _>`
+           `MutFoo: handle::private::HandleOps<_, False, _>`
+           which is required by `MutFoo: handle::private::SharedHandleOps<_, _>`
+note: the traits `handle::private::SharedHandle`, `handle::private::HandleOps`,  and `handle::private::SharedHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait SharedHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait HandleOps<T: ?Sized, M, S> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait SharedHandleOps<T: ?Sized, S>: HandleOps<T, False, S> + SharedHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ffi/tests/invalid-handle-code/shared-as-mut.stderr
+++ b/ffi/tests/invalid-handle-code/shared-as-mut.stderr
@@ -2,13 +2,29 @@ error[E0599]: the method `as_mut` exists for struct `Handle<SharedFoo>`, but its
   --> tests/invalid-handle-code/shared-as-mut.rs:12:15
    |
 7  | pub struct SharedFoo;
-   | -------------------- doesn't satisfy `<SharedFoo as HandleDescriptor>::Mutable = True`
+   | -------------------- doesn't satisfy `<SharedFoo as HandleDescriptor>::Mutable = True`, `SharedFoo: handle::private::HandleOps<_, True, _>`, `SharedFoo: handle::private::MutableHandleOps<_, _>` or `SharedFoo: handle::private::MutableHandle`
 ...
 12 |     let r = h.as_mut();
    |               ^^^^^^ method cannot be called on `Handle<SharedFoo>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
            `<SharedFoo as HandleDescriptor>::Mutable = True`
+           `SharedFoo: handle::private::MutableHandleOps<_, _>`
+           `SharedFoo: handle::private::MutableHandle`
+           which is required by `SharedFoo: handle::private::MutableHandleOps<_, _>`
+           `SharedFoo: handle::private::HandleOps<_, True, _>`
+           which is required by `SharedFoo: handle::private::MutableHandleOps<_, _>`
+note: the traits `handle::private::MutableHandle`, `handle::private::HandleOps`,  and `handle::private::MutableHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait MutableHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait HandleOps<T: ?Sized, M, S> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait MutableHandleOps<T: ?Sized, S>: HandleOps<T, True, S> + MutableHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<SharedFoo as HandleDescriptor>::Mutable == True`
   --> tests/invalid-handle-code/shared-as-mut.rs:11:44

--- a/ffi/tests/invalid-handle-code/shared-not-sync.stderr
+++ b/ffi/tests/invalid-handle-code/shared-not-sync.stderr
@@ -2,14 +2,23 @@ error[E0599]: the method `clone_as_arc` exists for struct `Handle<SharedNotSync>
   --> tests/invalid-handle-code/shared-not-sync.rs:15:15
    |
 10 | pub struct SharedNotSync;
-   | ------------------------ doesn't satisfy `_: SharedHandleOps<NotSync, True>`
+   | ------------------------ doesn't satisfy `SharedNotSync: handle::private::SharedHandle` or `_: SharedHandleOps<_, _>`
 ...
 15 |     let r = h.clone_as_arc();
    |               ^^^^^^^^^^^^ method cannot be called on `Handle<SharedNotSync>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
-           `*mut u32: Sync`
-           which is required by `SharedNotSync: handle::private::SharedHandleOps<NotSync, True>`
+           `SharedNotSync: handle::private::SharedHandleOps<_, _>`
+           `SharedNotSync: handle::private::SharedHandle`
+           which is required by `SharedNotSync: handle::private::SharedHandleOps<_, _>`
+note: the traits `handle::private::SharedHandle` and `handle::private::SharedHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait SharedHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait SharedHandleOps<T: ?Sized, S>: HandleOps<T, False, S> + SharedHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `*mut u32` cannot be shared between threads safely
   --> tests/invalid-handle-code/shared-not-sync.rs:14:48
@@ -31,11 +40,20 @@ error[E0599]: the method `clone_handle` exists for struct `Handle<SharedNotSync>
   --> tests/invalid-handle-code/shared-not-sync.rs:16:15
    |
 10 | pub struct SharedNotSync;
-   | ------------------------ doesn't satisfy `_: SharedHandleOps<NotSync, True>`
+   | ------------------------ doesn't satisfy `SharedNotSync: handle::private::SharedHandle` or `_: SharedHandleOps<_, _>`
 ...
 16 |     let h = h.clone_handle();
    |               ^^^^^^^^^^^^
    |
    = note: the following trait bounds were not satisfied:
-           `*mut u32: Sync`
-           which is required by `SharedNotSync: handle::private::SharedHandleOps<NotSync, True>`
+           `SharedNotSync: handle::private::SharedHandleOps<_, _>`
+           `SharedNotSync: handle::private::SharedHandle`
+           which is required by `SharedNotSync: handle::private::SharedHandleOps<_, _>`
+note: the traits `handle::private::SharedHandle` and `handle::private::SharedHandleOps` must be implemented
+  --> src/handle.rs
+   |
+   |     pub trait SharedHandle {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub trait SharedHandleOps<T: ?Sized, S>: HandleOps<T, False, S> + SharedHandle {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
At some point a compiler upgrade started producing more verbose diagnostics, but golden files were never updated to match. Update them now.