### PR TITLE
chore: remove lazy_static in favor of LazyLock

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 readme.workspace = true
 version.workspace = true
 # exclude golden tests + golden test data since they push us over 10MB crate size limit
-exclude = ["tests/golden_tables.rs", "tests/golden_data/" ]
+exclude = ["tests/golden_tables.rs", "tests/golden_data/"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -21,7 +21,6 @@ either = "1.13"
 fix-hidden-lifetime-bug = "0.2"
 indexmap = "2.5.0"
 itertools = "0.13"
-lazy_static = "1.5"
 roaring = "0.10.6"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
@@ -68,44 +67,44 @@ walkdir = { workspace = true, optional = true }
 arrow-conversion = ["arrow-schema"]
 arrow-expression = ["arrow-arith", "arrow-array", "arrow-buffer", "arrow-ord", "arrow-schema"]
 cloud = [
-  "object_store/aws",
-  "object_store/azure",
-  "object_store/gcp",
-  "object_store/http",
-  "hdfs-native-object-store",
+    "object_store/aws",
+    "object_store/azure",
+    "object_store/gcp",
+    "object_store/http",
+    "hdfs-native-object-store",
 ]
 default = ["sync-engine"]
 default-engine = [
-  "arrow-conversion",
-  "arrow-expression",
-  "arrow-array",
-  "arrow-buffer",
-  "arrow-cast",
-  "arrow-json",
-  "arrow-schema",
-  "arrow-select",
-  "futures",
-  "object_store",
-  "parquet/async",
-  "parquet/object_store",
-  "reqwest",
-  "tokio",
+    "arrow-conversion",
+    "arrow-expression",
+    "arrow-array",
+    "arrow-buffer",
+    "arrow-cast",
+    "arrow-json",
+    "arrow-schema",
+    "arrow-select",
+    "futures",
+    "object_store",
+    "parquet/async",
+    "parquet/object_store",
+    "reqwest",
+    "tokio",
 ]
 
 developer-visibility = []
 sync-engine = [
-  "arrow-cast",
-  "arrow-conversion",
-  "arrow-expression",
-  "arrow-array",
-  "arrow-json",
-  "arrow-select",
-  "parquet",
+    "arrow-cast",
+    "arrow-conversion",
+    "arrow-expression",
+    "arrow-array",
+    "arrow-json",
+    "arrow-select",
+    "parquet",
 ]
 integration-test = [
-  "hdfs-native-object-store/integration-test",
-  "hdfs-native",
-  "walkdir",
+    "hdfs-native-object-store/integration-test",
+    "hdfs-native",
+    "walkdir",
 ]
 
 [build-dependencies]
@@ -120,6 +119,6 @@ tempfile = "3"
 tar = "0.4"
 zstd = "0.13"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
-  "env-filter",
-  "fmt",
+    "env-filter",
+    "fmt",
 ] }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 readme.workspace = true
 version.workspace = true
 # exclude golden tests + golden test data since they push us over 10MB crate size limit
-exclude = ["tests/golden_tables.rs", "tests/golden_data/"]
+exclude = ["tests/golden_tables.rs", "tests/golden_data/" ]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -21,6 +21,7 @@ either = "1.13"
 fix-hidden-lifetime-bug = "0.2"
 indexmap = "2.5.0"
 itertools = "0.13"
+lazy_static = "1.5"
 roaring = "0.10.6"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
@@ -67,44 +68,44 @@ walkdir = { workspace = true, optional = true }
 arrow-conversion = ["arrow-schema"]
 arrow-expression = ["arrow-arith", "arrow-array", "arrow-buffer", "arrow-ord", "arrow-schema"]
 cloud = [
-    "object_store/aws",
-    "object_store/azure",
-    "object_store/gcp",
-    "object_store/http",
-    "hdfs-native-object-store",
+  "object_store/aws",
+  "object_store/azure",
+  "object_store/gcp",
+  "object_store/http",
+  "hdfs-native-object-store",
 ]
 default = ["sync-engine"]
 default-engine = [
-    "arrow-conversion",
-    "arrow-expression",
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-cast",
-    "arrow-json",
-    "arrow-schema",
-    "arrow-select",
-    "futures",
-    "object_store",
-    "parquet/async",
-    "parquet/object_store",
-    "reqwest",
-    "tokio",
+  "arrow-conversion",
+  "arrow-expression",
+  "arrow-array",
+  "arrow-buffer",
+  "arrow-cast",
+  "arrow-json",
+  "arrow-schema",
+  "arrow-select",
+  "futures",
+  "object_store",
+  "parquet/async",
+  "parquet/object_store",
+  "reqwest",
+  "tokio",
 ]
 
 developer-visibility = []
 sync-engine = [
-    "arrow-cast",
-    "arrow-conversion",
-    "arrow-expression",
-    "arrow-array",
-    "arrow-json",
-    "arrow-select",
-    "parquet",
+  "arrow-cast",
+  "arrow-conversion",
+  "arrow-expression",
+  "arrow-array",
+  "arrow-json",
+  "arrow-select",
+  "parquet",
 ]
 integration-test = [
-    "hdfs-native-object-store/integration-test",
-    "hdfs-native",
-    "walkdir",
+  "hdfs-native-object-store/integration-test",
+  "hdfs-native",
+  "walkdir",
 ]
 
 [build-dependencies]
@@ -119,6 +120,6 @@ tempfile = "3"
 tar = "0.4"
 zstd = "0.13"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "env-filter",
-    "fmt",
+  "env-filter",
+  "fmt",
 ] }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -21,7 +21,6 @@ either = "1.13"
 fix-hidden-lifetime-bug = "0.2"
 indexmap = "2.5.0"
 itertools = "0.13"
-lazy_static = "1.5"
 roaring = "0.10.6"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -5,11 +5,10 @@ pub mod deletion_vector;
 pub(crate) mod schemas;
 pub(crate) mod visitors;
 
-use std::collections::HashMap;
-
 use delta_kernel_derive::Schema;
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::LazyLock;
 use visitors::{AddVisitor, MetadataVisitor, ProtocolVisitor};
 
 use self::deletion_vector::DeletionVectorDescriptor;
@@ -23,21 +22,19 @@ pub(crate) const METADATA_NAME: &str = "metaData";
 pub(crate) const PROTOCOL_NAME: &str = "protocol";
 pub(crate) const TRANSACTION_NAME: &str = "txn";
 
-lazy_static! {
-    static ref LOG_SCHEMA: StructType = StructType::new(
-        vec![
-            Option::<Add>::get_struct_field(ADD_NAME),
-            Option::<Remove>::get_struct_field(REMOVE_NAME),
-            Option::<Metadata>::get_struct_field(METADATA_NAME),
-            Option::<Protocol>::get_struct_field(PROTOCOL_NAME),
-            Option::<Transaction>::get_struct_field(TRANSACTION_NAME),
-            // We don't support the following actions yet
-            //Option<Cdc>::get_field(CDC_NAME),
-            //Option<CommitInfo>::get_field(COMMIT_INFO_NAME),
-            //Option<DomainMetadata>::get_field(DOMAIN_METADATA_NAME),
-        ]
-    );
-}
+static LOG_SCHEMA: LazyLock<StructType> = LazyLock::new(|| {
+    StructType::new(vec![
+        Option::<Add>::get_struct_field(ADD_NAME),
+        Option::<Remove>::get_struct_field(REMOVE_NAME),
+        Option::<Metadata>::get_struct_field(METADATA_NAME),
+        Option::<Protocol>::get_struct_field(PROTOCOL_NAME),
+        Option::<Transaction>::get_struct_field(TRANSACTION_NAME),
+        // We don't support the following actions yet
+        //Option<Cdc>::get_field(CDC_NAME),
+        //Option<CommitInfo>::get_field(COMMIT_INFO_NAME),
+        //Option<DomainMetadata>::get_field(DOMAIN_METADATA_NAME),
+    ])
+});
 
 pub(crate) fn get_log_schema() -> &'static StructType {
     &LOG_SCHEMA

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -1,7 +1,7 @@
+use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
-
-use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use std::sync::LazyLock;
 
 use crate::schema::{ArrayType, DataType, PrimitiveType, StructField};
 use crate::utils::require;
@@ -296,9 +296,8 @@ impl PrimitiveType {
     pub fn parse_scalar(&self, raw: &str) -> Result<Scalar, Error> {
         use PrimitiveType::*;
 
-        lazy_static::lazy_static! {
-            static ref UNIX_EPOCH: DateTime<Utc> = DateTime::from_timestamp(0, 0).unwrap();
-        }
+        static UNIX_EPOCH: LazyLock<DateTime<Utc>> =
+            LazyLock::new(|| DateTime::from_timestamp(0, 0).unwrap());
 
         if raw.is_empty() {
             return Ok(Scalar::Null(self.data_type()));

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -181,7 +181,7 @@ impl DataSkippingFilter {
         predicate: &Option<Expr>,
     ) -> Option<Self> {
         static PREDICATE_SCHEMA: LazyLock<DataType> = LazyLock::new(|| {
-            StructType::new(vec![StructField::new("predicate", DataType::BOOLEAN, true)]).into()
+            DataType::struct_type(vec![StructField::new("predicate", DataType::BOOLEAN, true)])
         });
         static STATS_EXPR: LazyLock<Expr> = LazyLock::new(|| Expr::column("add.stats"));
         static FILTER_EXPR: LazyLock<Expr> =

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::ops::Not;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use tracing::debug;
 
@@ -180,13 +180,12 @@ impl DataSkippingFilter {
         table_schema: &SchemaRef,
         predicate: &Option<Expr>,
     ) -> Option<Self> {
-        lazy_static::lazy_static!(
-            static ref PREDICATE_SCHEMA: DataType = StructType::new(vec![
-                StructField::new("predicate", DataType::BOOLEAN, true),
-            ]).into();
-            static ref STATS_EXPR: Expr = Expr::column("add.stats");
-            static ref FILTER_EXPR: Expr = Expr::column("predicate").distinct(Expr::literal(false));
-        );
+        static PREDICATE_SCHEMA: LazyLock<DataType> = LazyLock::new(|| {
+            StructType::new(vec![StructField::new("predicate", DataType::BOOLEAN, true)]).into()
+        });
+        static STATS_EXPR: LazyLock<Expr> = LazyLock::new(|| Expr::column("add.stats"));
+        static FILTER_EXPR: LazyLock<Expr> =
+            LazyLock::new(|| Expr::column("predicate").distinct(Expr::literal(false)));
 
         let predicate = match predicate {
             Some(predicate) => predicate,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1,8 +1,8 @@
+use std::clone::Clone;
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use either::Either;
-use lazy_static::lazy_static;
 use tracing::debug;
 
 use super::data_skipping::DataSkippingFilter;
@@ -77,11 +77,11 @@ impl DataVisitor for AddRemoveVisitor {
     }
 }
 
-lazy_static! {
-    // NB: If you update this schema, ensure you update the comment describing it in the doc comment
-    // for `scan_row_schema` in scan/mod.rs! You'll also need to update ScanFileVisitor as the
-    // indexes will be off
-    pub(crate) static ref SCAN_ROW_SCHEMA: Arc<StructType> = Arc::new(StructType::new(vec!(
+// NB: If you update this schema, ensure you update the comment describing it in the doc comment
+// for `scan_row_schema` in scan/mod.rs! You'll also need to update ScanFileVisitor as the
+// indexes will be off
+pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| {
+    Arc::new(StructType::new(vec![
         StructField::new("path", DataType::STRING, false),
         StructField::new("size", DataType::LONG, true),
         StructField::new("modificationTime", DataType::LONG, true),
@@ -95,7 +95,7 @@ lazy_static! {
                 StructField::new("sizeInBytes", DataType::INTEGER, false),
                 StructField::new("cardinality", DataType::LONG, false),
             ]),
-            true
+            true,
         ),
         StructField::new(
             "fileConstantValues",
@@ -104,11 +104,11 @@ lazy_static! {
                 MapType::new(DataType::STRING, DataType::STRING, false),
                 true,
             )]),
-            true
+            true,
         ),
-    )));
-    static ref SCAN_ROW_DATATYPE: DataType = SCAN_ROW_SCHEMA.as_ref().clone().into();
-}
+    ]))
+});
+static SCAN_ROW_DATATYPE: LazyLock<DataType> = LazyLock::new(|| SCAN_ROW_SCHEMA.clone().into());
 
 impl LogReplayScanner {
     /// Create a new [`LogReplayScanner`] instance


### PR DESCRIPTION
Turns out we don't use lazy static in many places so potentially removing the dependency is straight forward. Lazy static itself even gives an example from the standard library. 

https://github.com/rust-lang-nursery/lazy-static.rs?tab=readme-ov-file#standard-library