### PR TITLE
Adding cargo semver checks

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -6,12 +6,13 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   check_if_pr_breaks_semver:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         name: checkout full rep

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -10,7 +10,10 @@ jobs:
   check_if_pr_breaks_semver:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        name: checkout full rep
+        with:
+          fetch-depth: 0
       - name: Install minimal stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,29 @@
+name: semver-checks
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  check_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install minimal stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
+      - name: Get main branch SHA and install cargo-semver-checks
+        shell: bash
+        run: |
+          echo "main_sha=$(git rev-parse main)" >> "$GITHUB_ENV"
+          cargo install cargo-semver-checks --locked
+      - name: Run check
+        uses: Swatinem/rust-cache@v2
+        shell: bash
+        run: |
+          cargo cargo semver-checks  --baseline-rev ${{ env.main_sha }}

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run check
         shell: bash
         run: |
-          cargo semver-checks ${{ github.event.pull_request.base.sha }}
+          cargo semver-checks --baseline-rev ${{ github.event.pull_request.base.sha }}
       - name: On success
         if: success()
         shell: bash

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -30,7 +30,6 @@ jobs:
         run: |
           cargo install cargo-semver-checks --locked
       - name: Run check
-        continue-on-error: true # don't fail the whole check if this step fails
         shell: bash
         run: |
           cargo semver-checks --all-features --baseline-rev ${{ github.event.pull_request.base.sha }}
@@ -41,6 +40,6 @@ jobs:
           labels: breaking-change
       - name: On Success
         if: success()
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: breaking-change
+        shell: bash
+        run: |
+          echo "Checks succeed"

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: main
-      - uses: actions/checkout@v4
         name: checkout full rep
         with:
           fetch-depth: 0
@@ -27,10 +24,18 @@ jobs:
       - name: Install cargo-semver-checks
         shell: bash
         run: |
-          echo ${{ github.event.pull_request.base.sha }}
-      #     cargo install cargo-semver-checks --locked
-      # - name: Run check
-      #   shell: bash
-      #   run: |
-      #     git rev-parse HEAD
-      #     cargo semver-checks  --baseline-rev $(git rev-parse main)
+          cargo install cargo-semver-checks --locked
+      - name: Run check
+        shell: bash
+        run: |
+          cargo semver-checks ${{ github.event.pull_request.base.sha }}
+      - name: On success
+        if: success()
+        shell: bash
+        run: |
+          echo "semver check is okay"
+      - name: On success
+        if: failure()
+        shell: bash
+        run: |
+          echo "semver check is NOT okay"

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,6 +1,6 @@
 name: semver-checks
 
-on: [push, pull_request]
+on: [pull_request]
 
 env:
   CARGO_TERM_COLOR: always
@@ -10,7 +10,6 @@ jobs:
   check_if_pr_breaks_semver:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
@@ -33,13 +32,10 @@ jobs:
         run: |
           cargo semver-checks --all-features --baseline-rev ${{ github.event.pull_request.base.sha }}
       - name: On Failure
-        if: always()
-        run: gh pr edit "$NUMBER" --add-label "$LABELS"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
-          LABELS: breaking-change
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: breaking-change
       - name: On Success
         if: success()
         shell: bash

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/checkout@v4
         name: checkout full rep
         with:
           fetch-depth: 0
@@ -24,10 +27,12 @@ jobs:
       - name: Install cargo-semver-checks
         shell: bash
         run: |
-          cargo install cargo-semver-checks --locked
-      - name: Run check
-        shell: bash
-        run: |
           git rev-parse HEAD
-          cargo semver-checks  --baseline-rev $(git rev-parse main)
-
+          git log
+          git rev-parse main
+      #     cargo install cargo-semver-checks --locked
+      # - name: Run check
+      #   shell: bash
+      #   run: |
+      #     git rev-parse HEAD
+      #     cargo semver-checks  --baseline-rev $(git rev-parse main)

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           git rev-parse HEAD
           git log
-          git rev-parse main
+          echo ${{ github.event.pull_request.head.sha }}
       #     cargo install cargo-semver-checks --locked
       # - name: Run check
       #   shell: bash

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -7,7 +7,7 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  check_pr:
+  check_if_pr_breaks_semver:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -17,13 +17,14 @@ jobs:
           profile: default
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Get main branch SHA and install cargo-semver-checks
         shell: bash
         run: |
           echo "main_sha=$(git rev-parse main)" >> "$GITHUB_ENV"
           cargo install cargo-semver-checks --locked
       - name: Run check
-        uses: Swatinem/rust-cache@v2
         shell: bash
         run: |
           cargo cargo semver-checks  --baseline-rev ${{ env.main_sha }}
+

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -10,7 +10,8 @@ jobs:
   check_if_pr_breaks_semver:
     runs-on: ubuntu-latest
     permissions:
-      issues: write # needed for adding label
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         name: checkout full rep

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -28,14 +28,14 @@ jobs:
       - name: Run check
         shell: bash
         run: |
-          cargo semver-checks --baseline-rev ${{ github.event.pull_request.base.sha }}
-      - name: On success
+          cargo semver-checks --all-features --baseline-rev ${{ github.event.pull_request.base.sha }}
+      - name: On Success
         if: success()
-        shell: bash
-        run: |
-          echo "semver check is okay"
-      - name: On success
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: breaking-change
+      - name: On Failure
         if: failure()
-        shell: bash
-        run: |
-          echo "semver check is NOT okay"
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: breaking-change

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           cargo install cargo-semver-checks --locked
       - name: Run check
+        continue-on-error: true # don't fail the whole check if this step fails
         shell: bash
         run: |
           cargo semver-checks --all-features --baseline-rev ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -6,13 +6,12 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   check_if_pr_breaks_semver:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         name: checkout full rep
@@ -34,10 +33,13 @@ jobs:
         run: |
           cargo semver-checks --all-features --baseline-rev ${{ github.event.pull_request.base.sha }}
       - name: On Failure
-        if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: breaking-change
+        if: always()
+        run: gh pr edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: breaking-change
       - name: On Success
         if: success()
         shell: bash

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -18,13 +18,12 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2
-      - name: Get main branch SHA and install cargo-semver-checks
+      - name: Install cargo-semver-checks
         shell: bash
         run: |
-          echo "main_sha=$(git rev-parse main)" >> "$GITHUB_ENV"
           cargo install cargo-semver-checks --locked
       - name: Run check
         shell: bash
         run: |
-          cargo cargo semver-checks  --baseline-rev ${{ env.main_sha }}
+          cargo semver-checks  --baseline-rev ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   check_if_pr_breaks_semver:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # needed for adding label
     steps:
       - uses: actions/checkout@v4
         name: checkout full rep

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -28,5 +28,6 @@ jobs:
       - name: Run check
         shell: bash
         run: |
-          cargo semver-checks  --baseline-rev ${{ github.event.pull_request.head.sha }}
+          git rev-parse HEAD
+          cargo semver-checks  --baseline-rev $(git rev-parse main)
 

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -10,7 +10,7 @@ jobs:
   check_if_pr_breaks_semver:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write # needed for adding label
+      issues: write # needed for adding label
     steps:
       - uses: actions/checkout@v4
         name: checkout full rep
@@ -31,13 +31,13 @@ jobs:
         shell: bash
         run: |
           cargo semver-checks --all-features --baseline-rev ${{ github.event.pull_request.base.sha }}
-      - name: On Success
-        if: success()
+      - name: On Failure
+        if: failure()
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: breaking-change
-      - name: On Failure
-        if: failure()
+      - name: On Success
+        if: success()
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: breaking-change

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -27,9 +27,7 @@ jobs:
       - name: Install cargo-semver-checks
         shell: bash
         run: |
-          git rev-parse HEAD
-          git log
-          echo ${{ github.event.pull_request.head.sha }}
+          echo ${{ github.event.pull_request.base.sha }}
       #     cargo install cargo-semver-checks --locked
       # - name: Run check
       #   shell: bash

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -36,7 +36,7 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
     /// Max number of batches to read ahead while executing [Self::read_parquet_files()].
     ///
     /// Defaults to 10.
-    pub fn with_readahead_x(mut self, readahead: usize) -> Self {
+    pub fn with_readahead(mut self, readahead: usize) -> Self {
         self.readahead = readahead;
         self
     }

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -36,7 +36,7 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
     /// Max number of batches to read ahead while executing [Self::read_parquet_files()].
     ///
     /// Defaults to 10.
-    pub fn with_readahead(mut self, readahead: usize) -> Self {
+    pub fn with_readahead_x(mut self, readahead: usize) -> Self {
         self.readahead = readahead;
         self
     }


### PR DESCRIPTION
Adding a check that will run `cargo semver-checks` against each PR. 

This implements a check for PRs that don't bump the crate version. The check will be run between the `HEAD` of the PR and `main`. So any changes introduced in the PR vs main that break semver are picked up, and the PR will be labeled with `breaking-change`.

Currently can't test the actual adding of a label because (probably) the check needs to be in the main repo, rather than in a PR branch, to be allowed to get write access to the repo. 

So sadly to actually test this we'll need to merge and see if it works. (hooray github actions dev workflow)