### PR TITLE
Fix broken sync json parsing and harmonize file reading

### DIFF
--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -5,19 +5,16 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::task::{ready, Poll};
 
-use arrow_array::{new_null_array, Array, RecordBatch, StringArray, StructArray};
 use arrow_json::ReaderBuilder;
 use arrow_schema::SchemaRef as ArrowSchemaRef;
-use arrow_select::concat::concat_batches;
 use bytes::{Buf, Bytes};
 use futures::{StreamExt, TryStreamExt};
-use itertools::Itertools;
 use object_store::path::Path;
 use object_store::{DynObjectStore, GetResultPayload};
 
 use super::executor::TaskExecutor;
 use super::file_stream::{FileOpenFuture, FileOpener, FileStream};
-use crate::engine::arrow_data::ArrowEngineData;
+use crate::engine::arrow_utils::parse_json as arrow_parse_json;
 use crate::schema::SchemaRef;
 use crate::{
     DeltaResult, EngineData, Error, Expression, FileDataReadResultIterator, FileMeta, JsonHandler,
@@ -62,57 +59,13 @@ impl<E: TaskExecutor> DefaultJsonHandler<E> {
     }
 }
 
-fn hack_parse(
-    stats_schema: &ArrowSchemaRef,
-    json_string: Option<&str>,
-) -> DeltaResult<RecordBatch> {
-    match json_string {
-        Some(s) => Ok(ReaderBuilder::new(stats_schema.clone())
-            .build(BufReader::new(s.as_bytes()))?
-            .next()
-            .transpose()?
-            .ok_or(Error::missing_data("Expected data"))?),
-        None => Ok(RecordBatch::try_new(
-            stats_schema.clone(),
-            stats_schema
-                .fields
-                .iter()
-                .map(|field| new_null_array(field.data_type(), 1))
-                .collect(),
-        )?),
-    }
-}
-
 impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
     fn parse_json(
         &self,
         json_strings: Box<dyn EngineData>,
         output_schema: SchemaRef,
     ) -> DeltaResult<Box<dyn EngineData>> {
-        let json_strings: RecordBatch = ArrowEngineData::try_from_engine_data(json_strings)?.into();
-        // TODO(nick): this is pretty terrible
-        let struct_array: StructArray = json_strings.into();
-        let json_strings = struct_array
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| {
-                Error::generic("Expected json_strings to be a StringArray, found something else")
-            })?;
-        let output_schema: ArrowSchemaRef = Arc::new(output_schema.as_ref().try_into()?);
-        if json_strings.is_empty() {
-            return Ok(Box::new(ArrowEngineData::new(RecordBatch::new_empty(
-                output_schema,
-            ))));
-        }
-        let output: Vec<_> = json_strings
-            .iter()
-            .map(|json_string| hack_parse(&output_schema, json_string))
-            .try_collect()?;
-        Ok(Box::new(ArrowEngineData::new(concat_batches(
-            &output_schema,
-            output.iter(),
-        )?)))
+        arrow_parse_json(json_strings, output_schema)
     }
 
     fn read_json_files(
@@ -220,13 +173,14 @@ impl FileOpener for JsonOpener {
 mod tests {
     use std::path::PathBuf;
 
-    use arrow::array::AsArray;
+    use arrow::array::{AsArray, RecordBatch, StringArray};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use itertools::Itertools;
     use object_store::{local::LocalFileSystem, ObjectStore};
 
     use super::*;
     use crate::{
+        engine::arrow_data::ArrowEngineData,
         actions::get_log_schema, engine::default::executor::tokio::TokioBackgroundExecutor,
     };
 

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -1,39 +1,30 @@
 use std::{
     fs::File,
-    io::{BufReader, Cursor},
-    sync::Arc,
+    io::BufReader,
 };
 
 use crate::{
-    schema::SchemaRef, utils::require, DeltaResult, EngineData, Error, Expression,
+    engine::arrow_utils::parse_json as arrow_parse_json,
+    schema::SchemaRef, DeltaResult, EngineData, Expression,
     FileDataReadResultIterator, FileMeta, JsonHandler,
 };
-use arrow_array::{cast::AsArray, RecordBatch};
-use arrow_json::ReaderBuilder;
-use arrow_schema::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
-use arrow_select::concat::concat_batches;
-use itertools::Itertools;
-use tracing::debug;
-use url::Url;
+use arrow_schema::SchemaRef as ArrowSchemaRef;
 
+use super::read_files;
 use crate::engine::arrow_data::ArrowEngineData;
 
 pub(crate) struct SyncJsonHandler;
 
-fn try_create_from_json(schema: SchemaRef, location: Url) -> DeltaResult<ArrowEngineData> {
-    let arrow_schema: ArrowSchema = (&*schema).try_into()?;
-    debug!("Reading {:#?} with schema: {:#?}", location, arrow_schema);
-    let file = File::open(
-        location
-            .to_file_path()
-            .map_err(|_| Error::generic("can only read local files"))?,
-    )?;
-    let mut json =
-        arrow_json::ReaderBuilder::new(Arc::new(arrow_schema)).build(BufReader::new(file))?;
-    let data = json
-        .next()
-        .ok_or(Error::generic("No data found reading json file"))?;
-    Ok(ArrowEngineData::new(data?))
+fn try_create_from_json(
+    file: File,
+    _schema: SchemaRef,
+    arrow_schema: ArrowSchemaRef,
+    _predicate: Option<&Expression>,
+) -> DeltaResult<impl Iterator<Item = DeltaResult<ArrowEngineData>>> {
+    let json = arrow_json::ReaderBuilder::new(arrow_schema)
+        .build(BufReader::new(file))?
+        .map(|data| Ok(ArrowEngineData::new(data?)));
+    Ok(json)
 }
 
 impl JsonHandler for SyncJsonHandler {
@@ -43,18 +34,7 @@ impl JsonHandler for SyncJsonHandler {
         schema: SchemaRef,
         predicate: Option<Expression>,
     ) -> DeltaResult<FileDataReadResultIterator> {
-        debug!("Reading json files: {files:#?} with predicate {predicate:#?}");
-        if files.is_empty() {
-            return Ok(Box::new(std::iter::empty()));
-        }
-        let res: Vec<_> = files
-            .iter()
-            .map(|file| {
-                try_create_from_json(schema.clone(), file.location.clone())
-                    .map(|d| Box::new(d) as _)
-            })
-            .collect();
-        Ok(Box::new(res.into_iter()))
+        read_files(files, schema, predicate, try_create_from_json)
     }
 
     fn parse_json(
@@ -62,37 +42,6 @@ impl JsonHandler for SyncJsonHandler {
         json_strings: Box<dyn EngineData>,
         output_schema: SchemaRef,
     ) -> DeltaResult<Box<dyn EngineData>> {
-        // TODO: This is taken from the default engine as it's the same. We should share an
-        // implementation at some point
-        let json_strings: RecordBatch = ArrowEngineData::try_from_engine_data(json_strings)?.into();
-        require!(
-            json_strings.num_columns() == 1,
-            Error::missing_column("Expected single column")
-        );
-        let json_strings =
-            json_strings
-                .column(0)
-                .as_string_opt::<i32>()
-                .ok_or(Error::unexpected_column_type(
-                    "Expected column to be String",
-                ))?;
-
-        let data: Vec<_> = json_strings
-            .into_iter()
-            .filter_map(|d| {
-                d.map(|dd| {
-                    let mut data = dd.as_bytes().to_vec();
-                    data.extend("\n".as_bytes());
-                    data
-                })
-            })
-            .flatten()
-            .collect();
-
-        let schema: ArrowSchemaRef = Arc::new(output_schema.as_ref().try_into()?);
-        let batches: Vec<_> = ReaderBuilder::new(schema.clone())
-            .build(Cursor::new(data))?
-            .try_collect()?;
-        Ok(Box::new(ArrowEngineData::new(concat_batches(&schema, &batches)?)) as _)
+        arrow_parse_json(json_strings, output_schema)
     }
 }

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -1,9 +1,14 @@
 //! A simple, single threaded, [`Engine`] that can only read from the local filesystem
 
 use super::arrow_expression::ArrowExpressionHandler;
-use crate::{Engine, ExpressionHandler, FileSystemClient, JsonHandler, ParquetHandler};
+use crate::{DeltaResult, Engine, Error, ExpressionHandler, FileDataReadResultIterator, FileMeta, FileSystemClient, JsonHandler, ParquetHandler, SchemaRef, Expression};
+use crate::engine::arrow_data::ArrowEngineData;
 
+use arrow_schema::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
+use itertools::Itertools;
+use std::fs::File;
 use std::sync::Arc;
+use tracing::debug;
 
 mod fs_client;
 pub(crate) mod json;
@@ -47,4 +52,37 @@ impl Engine for SyncEngine {
     fn get_json_handler(&self) -> Arc<dyn JsonHandler> {
         self.json_handler.clone()
     }
+}
+
+fn read_files<F, I>(
+    files: &[FileMeta],
+    schema: SchemaRef,
+    predicate: Option<Expression>,
+    mut try_create_from_file: F
+) -> DeltaResult<FileDataReadResultIterator>
+where
+    I: Iterator<Item = DeltaResult<ArrowEngineData>> + Send + 'static,
+    F: FnMut(File, SchemaRef, ArrowSchemaRef, Option<&Expression>) -> DeltaResult<I> + Send + 'static,
+{
+    debug!("Reading files: {files:#?} with predicate {predicate:#?}");
+    if files.is_empty() {
+        return Ok(Box::new(std::iter::empty()));
+    }
+    let arrow_schema = Arc::new(ArrowSchema::try_from(&*schema)?);
+    let files = files.to_vec();
+    let result = files
+        .into_iter()
+        // Produces Iterator<DeltaResult<Iterator<DeltaResult<ArrowEngineData>>>>
+        .map(move |file| {
+            debug!("Reading {:#?} with schema: {:#?}", file.location, arrow_schema);
+            let path = file.location
+                .to_file_path()
+                .map_err(|_| Error::generic("can only read local files"))?;
+            try_create_from_file(File::open(path)?, schema.clone(), arrow_schema.clone(), predicate.as_ref())
+        })
+        // Flatten to Iterator<DeltaResult<DeltaResult<ArrowEngineData>>>
+        .flatten_ok()
+        // Double unpack and map Iterator<DeltaResult<Box<EngineData>>>
+        .map(|data| Ok(Box::new(ArrowEngineData::new(data??.into())) as _));
+    Ok(Box::new(result))
 }

--- a/kernel/src/engine/sync/parquet.rs
+++ b/kernel/src/engine/sync/parquet.rs
@@ -1,22 +1,22 @@
 use std::fs::File;
 
+use arrow_schema::SchemaRef as ArrowSchemaRef;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatchReaderBuilder};
-use tracing::debug;
-use url::Url;
 
+use super::read_files;
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::arrow_utils::{generate_mask, get_requested_indices, reorder_struct_array};
 use crate::schema::SchemaRef;
-use crate::{DeltaResult, Error, Expression, FileDataReadResultIterator, FileMeta, ParquetHandler};
+use crate::{DeltaResult, Expression, FileDataReadResultIterator, FileMeta, ParquetHandler};
 
 pub(crate) struct SyncParquetHandler;
 
-fn try_create_from_parquet(schema: SchemaRef, location: Url) -> DeltaResult<ArrowEngineData> {
-    let file = File::open(
-        location
-            .to_file_path()
-            .map_err(|_| Error::generic("can only read local files"))?,
-    )?;
+fn try_create_from_parquet(
+    file: File,
+    schema: SchemaRef,
+    _arrow_schema: ArrowSchemaRef,
+    _predicate: Option<&Expression>,
+) -> DeltaResult<impl Iterator<Item = DeltaResult<ArrowEngineData>>> {
     let metadata = ArrowReaderMetadata::load(&file, Default::default())?;
     let parquet_schema = metadata.schema();
     let mut builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
@@ -25,12 +25,10 @@ fn try_create_from_parquet(schema: SchemaRef, location: Url) -> DeltaResult<Arro
     {
         builder = builder.with_projection(mask);
     }
-    let mut reader = builder.build()?;
-    let data = reader
-        .next()
-        .ok_or_else(|| Error::generic("No data found reading parquet file"))?;
-    let reordered = reorder_struct_array(data?.into(), &requested_ordering).map(Into::into)?;
-    Ok(ArrowEngineData::new(reordered))
+    Ok(builder.build()?.map(move |data| {
+        let reordered = reorder_struct_array(data?.into(), &requested_ordering)?;
+        Ok(ArrowEngineData::new(reordered.into()))
+    }))
 }
 
 impl ParquetHandler for SyncParquetHandler {
@@ -40,13 +38,6 @@ impl ParquetHandler for SyncParquetHandler {
         schema: SchemaRef,
         predicate: Option<Expression>,
     ) -> DeltaResult<FileDataReadResultIterator> {
-        debug!("Reading parquet files: {files:#?} with schema {schema:#?} and predicate {predicate:#?}");
-        if files.is_empty() {
-            return Ok(Box::new(std::iter::empty()));
-        }
-        let locations: Vec<_> = files.iter().map(|file| file.location.clone()).collect();
-        Ok(Box::new(locations.into_iter().map(move |location| {
-            try_create_from_parquet(schema.clone(), location).map(|d| Box::new(d) as _)
-        })))
+        read_files(files, schema, predicate, try_create_from_parquet)
     }
 }

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -268,15 +268,19 @@ impl DataSkippingFilter {
     pub(crate) fn apply(&self, actions: &dyn EngineData) -> DeltaResult<Vec<bool>> {
         // retrieve and parse stats from actions data
         let stats = self.select_stats_evaluator.evaluate(actions)?;
+        assert_eq!(stats.length(), actions.length());
         let parsed_stats = self
             .json_handler
             .parse_json(stats, self.stats_schema.clone())?;
+        assert_eq!(parsed_stats.length(), actions.length());
 
         // evaluate the predicate on the parsed stats, then convert to selection vector
         let skipping_predicate = self.skipping_evaluator.evaluate(&*parsed_stats)?;
+        assert_eq!(skipping_predicate.length(), actions.length());
         let selection_vector = self
             .filter_evaluator
             .evaluate(skipping_predicate.as_ref())?;
+        assert_eq!(selection_vector.length(), actions.length());
 
         // visit the engine's selection vector to produce a Vec<bool>
         let mut visitor = SelectionVectorVisitor::default();

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -191,6 +191,7 @@ impl LogReplayScanner {
             None => vec![false; actions.length()],
         };
 
+        assert_eq!(selection_vector.len(), actions.length(), "selection vector: {}, actions: {}", selection_vector.len(), actions.length());
         let adds = self.setup_batch_process(filter_vector, actions, is_log_batch)?;
 
         for (add, index) in adds.into_iter() {

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -522,32 +522,36 @@ fn read_table_data(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path = std::fs::canonicalize(PathBuf::from(path))?;
     let url = url::Url::from_directory_path(path).unwrap();
-    let engine = DefaultEngine::try_new(
+    let default_engine = DefaultEngine::try_new(
         &url,
         std::iter::empty::<(&str, &str)>(),
         Arc::new(TokioBackgroundExecutor::new()),
     )?;
+    let sync_engine = delta_kernel::engine::sync::SyncEngine::new();
 
-    let table = Table::new(url);
-    let snapshot = table.snapshot(&engine, None)?;
+    let engines: &[&dyn Engine] = &[&sync_engine, &default_engine];
+    for &engine in engines {
+        let table = Table::new(url.clone());
+        let snapshot = table.snapshot(engine, None)?;
 
-    let read_schema = select_cols.map(|select_cols| {
-        let table_schema = snapshot.schema();
-        let selected_fields = select_cols
-            .iter()
-            .map(|col| table_schema.field(col).cloned().unwrap())
-            .collect();
-        Arc::new(Schema::new(selected_fields))
-    });
-    let scan = snapshot
-        .into_scan_builder()
-        .with_schema_opt(read_schema)
-        .with_predicate_opt(predicate)
-        .build()?;
+        let read_schema = select_cols.map(|select_cols| {
+            let table_schema = snapshot.schema();
+            let selected_fields = select_cols
+                .iter()
+                .map(|col| table_schema.field(col).cloned().unwrap())
+                .collect();
+            Arc::new(Schema::new(selected_fields))
+        });
+        let scan = snapshot
+            .into_scan_builder()
+            .with_schema_opt(read_schema)
+            .with_predicate_opt(predicate.clone())
+            .build()?;
 
-    sort_lines!(expected);
-    read_with_execute(&engine, &scan, &expected)?;
-    read_with_scan_data(table.location(), &engine, &scan, &expected)?;
+        sort_lines!(expected);
+        read_with_execute(engine, &scan, &expected)?;
+        read_with_scan_data(table.location(), engine, &scan, &expected)?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
It turned out the sync reader was not being exercised by basic read tests. Enabling it exposed a broken json parsing algo that had already been fixed in the default reader.

Factor out the json parsing to a shared function that both engines can use.

While we're at it, factor out sync reader logic that both parquet and json readers can use.

Update the basic read unit tests to use both readers.

Fixes https://github.com/delta-incubator/delta-kernel-rs/issues/372