### PR TITLE
fix 'unreachable' warnings in ParsedLogPath

### DIFF
--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -42,7 +42,9 @@ enum LogPathFileType {
 #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
 struct ParsedLogPath<Location: AsUrl = FileMeta> {
     pub location: Location,
+    #[allow(unused)]
     pub filename: String,
+    #[allow(unused)]
     pub extension: String,
     pub version: Version,
     pub file_type: LogPathFileType,
@@ -73,6 +75,8 @@ impl AsUrl for FileMeta {
 
 impl<Location: AsUrl> ParsedLogPath<Location> {
     // NOTE: We can't actually impl TryFrom because Option<T> is a foreign struct even if T is local.
+    #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
+    #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
     pub fn try_from(location: Location) -> DeltaResult<Option<ParsedLogPath<Location>>> {
         let url = location.as_url();
         let filename = url
@@ -144,10 +148,14 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
         }))
     }
 
+    #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
+    #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
     pub fn is_commit(&self) -> bool {
         matches!(self.file_type, LogPathFileType::Commit)
     }
 
+    #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
+    #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
     pub fn is_checkpoint(&self) -> bool {
         // TODO: Include UuidCheckpoint once we actually support v2 checkpoints
         matches!(
@@ -156,6 +164,9 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
         )
     }
 
+    #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
+    #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
+    #[allow(dead_code)]
     pub fn is_unknown(&self) -> bool {
         // TODO: Stop treating UuidCheckpoint as unknown once we support v2 checkpoints
         matches!(

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -77,7 +77,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
     // NOTE: We can't actually impl TryFrom because Option<T> is a foreign struct even if T is local.
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
-    pub fn try_from(location: Location) -> DeltaResult<Option<ParsedLogPath<Location>>> {
+    fn try_from(location: Location) -> DeltaResult<Option<ParsedLogPath<Location>>> {
         let url = location.as_url();
         let filename = url
             .path_segments()
@@ -150,13 +150,13 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
 
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
-    pub fn is_commit(&self) -> bool {
+    fn is_commit(&self) -> bool {
         matches!(self.file_type, LogPathFileType::Commit)
     }
 
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
-    pub fn is_checkpoint(&self) -> bool {
+    fn is_checkpoint(&self) -> bool {
         // TODO: Include UuidCheckpoint once we actually support v2 checkpoints
         matches!(
             self.file_type,
@@ -166,8 +166,8 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
 
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
-    #[allow(dead_code)]
-    pub fn is_unknown(&self) -> bool {
+    #[allow(dead_code)] // currently only used in tests, which don't "count"
+    fn is_unknown(&self) -> bool {
         // TODO: Stop treating UuidCheckpoint as unknown once we support v2 checkpoints
         matches!(
             self.file_type,


### PR DESCRIPTION
warnings happened before when we did `cargo t -p delta_kernel`. this PR just uses developer-visibility and adds a few `#[allow(unused)]`/ dead code
```
   Compiling delta_kernel v0.3.1 (/Users/zach.schuermann/dev/delta-kernel-rs/kernel)
warning: fields `filename` and `extension` are never read
  --> kernel/src/path.rs:45:9
   |
43 | struct ParsedLogPath<Location: AsUrl = FileMeta> {
   |        ------------- fields in this struct
44 |     pub location: Location,
45 |     pub filename: String,
   |         ^^^^^^^^
46 |     pub extension: String,
   |         ^^^^^^^^^
   |
   = note: `ParsedLogPath` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default

warning: method `is_unknown` is never used
   --> kernel/src/path.rs:159:12
    |
74  | impl<Location: AsUrl> ParsedLogPath<Location> {
    | --------------------------------------------- method in this implementation
...
159 |     pub fn is_unknown(&self) -> bool {
    |            ^^^^^^^^^^

warning: unreachable `pub` item
  --> kernel/src/path.rs:76:5
   |
76 |     pub fn try_from(location: Location) -> DeltaResult<Option<ParsedLogPath<Location>>> {
   |     ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     help: consider restricting its visibility: `pub(crate)`
   |
note: the lint level is defined here
  --> kernel/src/lib.rs:46:5
   |
46 |     unreachable_pub,
   |     ^^^^^^^^^^^^^^^

warning: unreachable `pub` item
   --> kernel/src/path.rs:147:5
    |
147 |     pub fn is_commit(&self) -> bool {
    |     ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     help: consider restricting its visibility: `pub(crate)`

warning: unreachable `pub` item
   --> kernel/src/path.rs:151:5
    |
151 |     pub fn is_checkpoint(&self) -> bool {
    |     ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     help: consider restricting its visibility: `pub(crate)`

warning: unreachable `pub` item
   --> kernel/src/path.rs:159:5
    |
159 |     pub fn is_unknown(&self) -> bool {
    |     ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     help: consider restricting its visibility: `pub(crate)`

warning: `delta_kernel` (lib) generated 6 warnings (run `cargo fix --lib -p delta_kernel` to apply 4 suggestions)
warning: `delta_kernel` (lib test) generated 4 warnings (4 duplicates)
```