### PR TITLE
Fixing semver check

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,6 +1,13 @@
 name: semver-checks
 
-on: [pull_request_target]
+# Trigger when a PR is opened or changed
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
 
 env:
   CARGO_TERM_COLOR: always
@@ -10,6 +17,7 @@ jobs:
   check_if_pr_breaks_semver:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,6 +1,6 @@
 name: semver-checks
 
-on: [pull_request]
+on: [pull_request_target]
 
 env:
   CARGO_TERM_COLOR: always

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -37,7 +37,7 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
     ///
     /// Defaults to 10.
     pub fn with_readahead(mut self, readahead: usize) -> Self {
-        self.readahead = readahead;
+        //self.readahead = readahead;
         self
     }
 }

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -36,7 +36,7 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
     /// Max number of batches to read ahead while executing [Self::read_parquet_files()].
     ///
     /// Defaults to 10.
-    pub fn with_readahead_x(mut self, readahead: usize) -> Self {
+    pub fn with_readahead(mut self, readahead: usize) -> Self {
         self.readahead = readahead;
         self
     }

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -36,8 +36,8 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
     /// Max number of batches to read ahead while executing [Self::read_parquet_files()].
     ///
     /// Defaults to 10.
-    pub fn with_readahead(mut self, readahead: usize) -> Self {
-        //self.readahead = readahead;
+    pub fn with_readahead_x(mut self, readahead: usize) -> Self {
+        self.readahead = readahead;
         self
     }
 }


### PR DESCRIPTION
We actually need to use `pull_request_target`. This is how delta-rs [does it](https://github.com/delta-io/delta-rs/blob/main/.github/workflows/dev_pr.yml) and is also what github support suggests.

We do take a risk that if someone exploits `cargo semver-checks` they could execute code against our repo. That doesn't seem like a high risk.

The check won't run here as in this case we really do need it to be merged to main.