### PR TITLE
[refactor] Make StructType and DataType::struct_type more general

### DIFF
--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -26,9 +26,9 @@ pub fn derive_schema(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
         impl crate::actions::schemas::ToDataType for #struct_ident {
             fn to_data_type() -> crate::schema::DataType {
                 use crate::actions::schemas::{ToDataType, GetStructField, GetNullableContainerStructField};
-                crate::schema::StructType::new(vec![
+                crate::schema::DataType::struct_type([
                     #schema_fields
-                ]).into()
+                ])
             }
         }
     };

--- a/kernel/examples/inspect-table/src/main.rs
+++ b/kernel/examples/inspect-table/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
             println!("{:#?}", files);
         }
         Commands::Actions { forward } => {
-            let action_types = vec![
+            let action_types = [
                 //ActionType::CommitInfo,
                 ActionType::Metadata,
                 ActionType::Protocol,
@@ -109,8 +109,7 @@ fn main() {
                 action_types
                     .iter()
                     .map(|a| a.schema_field())
-                    .cloned()
-                    .collect(),
+                    .cloned(),
             ));
 
             let batches = snapshot

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -92,20 +92,17 @@ fn try_main() -> DeltaResult<()> {
 
     let read_schema_opt = cli
         .columns
-        .map(|cols| {
+        .map(|cols| -> DeltaResult<_> {
             let table_schema = snapshot.schema();
-            let selected_fields = cols
-                .iter()
-                .map(|col| {
-                    table_schema
-                        .field(col)
-                        .cloned()
-                        .ok_or(delta_kernel::Error::Generic(format!(
-                            "Table has no such column: {col}"
-                        )))
-                })
-                .try_collect();
-            selected_fields.map(|selected_fields| Arc::new(Schema::new(selected_fields)))
+            let selected_fields = cols.iter().map(|col| {
+                table_schema
+                    .field(col)
+                    .cloned()
+                    .ok_or(delta_kernel::Error::Generic(format!(
+                        "Table has no such column: {col}"
+                    )))
+            });
+            Schema::try_new(selected_fields).map(Arc::new)
         })
         .transpose()?;
     let scan = snapshot

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -23,7 +23,7 @@ pub(crate) const PROTOCOL_NAME: &str = "protocol";
 pub(crate) const TRANSACTION_NAME: &str = "txn";
 
 static LOG_SCHEMA: LazyLock<StructType> = LazyLock::new(|| {
-    StructType::new(vec![
+    StructType::new([
         Option::<Add>::get_struct_field(ADD_NAME),
         Option::<Remove>::get_struct_field(REMOVE_NAME),
         Option::<Metadata>::get_struct_field(METADATA_NAME),
@@ -261,15 +261,15 @@ mod tests {
             .project(&["metaData"])
             .expect("Couldn't get metaData field");
 
-        let expected = Arc::new(StructType::new(vec![StructField::new(
+        let expected = Arc::new(StructType::new([StructField::new(
             "metaData",
-            StructType::new(vec![
+            StructType::new([
                 StructField::new("id", DataType::STRING, false),
                 StructField::new("name", DataType::STRING, true),
                 StructField::new("description", DataType::STRING, true),
                 StructField::new(
                     "format",
-                    StructType::new(vec![
+                    StructType::new([
                         StructField::new("provider", DataType::STRING, false),
                         StructField::new(
                             "options",
@@ -303,9 +303,9 @@ mod tests {
             .project(&["add"])
             .expect("Couldn't get add field");
 
-        let expected = Arc::new(StructType::new(vec![StructField::new(
+        let expected = Arc::new(StructType::new([StructField::new(
             "add",
-            StructType::new(vec![
+            StructType::new([
                 StructField::new("path", DataType::STRING, false),
                 StructField::new(
                     "partitionValues",
@@ -350,13 +350,13 @@ mod tests {
     fn deletion_vector_field() -> StructField {
         StructField::new(
             "deletionVector",
-            DataType::Struct(Box::new(StructType::new(vec![
+            DataType::struct_type([
                 StructField::new("storageType", DataType::STRING, false),
                 StructField::new("pathOrInlineDv", DataType::STRING, false),
                 StructField::new("offset", DataType::INTEGER, true),
                 StructField::new("sizeInBytes", DataType::INTEGER, false),
                 StructField::new("cardinality", DataType::LONG, false),
-            ]))),
+            ]),
             true,
         )
     }
@@ -366,9 +366,9 @@ mod tests {
         let schema = get_log_schema()
             .project(&["remove"])
             .expect("Couldn't get remove field");
-        let expected = Arc::new(StructType::new(vec![StructField::new(
+        let expected = Arc::new(StructType::new([StructField::new(
             "remove",
-            StructType::new(vec![
+            StructType::new([
                 StructField::new("path", DataType::STRING, false),
                 StructField::new("deletionTimestamp", DataType::LONG, true),
                 StructField::new("dataChange", DataType::BOOLEAN, false),
@@ -391,9 +391,9 @@ mod tests {
             .project(&["txn"])
             .expect("Couldn't get transaction field");
 
-        let expected = Arc::new(StructType::new(vec![StructField::new(
+        let expected = Arc::new(StructType::new([StructField::new(
             "txn",
-            StructType::new(vec![
+            StructType::new([
                 StructField::new("appId", DataType::STRING, false),
                 StructField::new("version", DataType::LONG, false),
                 StructField::new("lastUpdated", DataType::LONG, true),

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -142,12 +142,12 @@ impl TryFrom<&ArrowSchema> for StructType {
     type Error = ArrowError;
 
     fn try_from(arrow_schema: &ArrowSchema) -> Result<Self, ArrowError> {
-        let new_fields: Result<Vec<StructField>, _> = arrow_schema
-            .fields()
-            .iter()
-            .map(|field| field.as_ref().try_into())
-            .collect();
-        Ok(StructType::new(new_fields?))
+        StructType::try_new(
+            arrow_schema
+                .fields()
+                .iter()
+                .map(|field| field.as_ref().try_into()),
+        )
     }
 }
 
@@ -211,13 +211,7 @@ impl TryFrom<&ArrowDataType> for DataType {
                 Ok(DataType::TIMESTAMP)
             }
             ArrowDataType::Struct(fields) => {
-                let converted_fields: Result<Vec<StructField>, _> = fields
-                    .iter()
-                    .map(|field| field.as_ref().try_into())
-                    .collect();
-                Ok(DataType::Struct(Box::new(StructType::new(
-                    converted_fields?,
-                ))))
+                DataType::try_struct_type(fields.iter().map(|field| field.as_ref().try_into()))
             }
             ArrowDataType::List(field) => Ok(DataType::Array(Box::new(ArrayType::new(
                 (*field).data_type().try_into()?,

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -442,7 +442,7 @@ mod tests {
         let field = Arc::new(Field::new("item", DataType::Int32, true));
         let arr_field = Arc::new(Field::new("item", DataType::List(field.clone()), true));
 
-        let schema = Schema::new(vec![arr_field.clone()]);
+        let schema = Schema::new([arr_field.clone()]);
 
         let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
@@ -472,7 +472,7 @@ mod tests {
     fn test_bad_right_type_array() {
         let values = Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
         let field = Arc::new(Field::new("item", DataType::Int32, true));
-        let schema = Schema::new(vec![field.clone()]);
+        let schema = Schema::new([field.clone()]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(values.clone())]).unwrap();
 
         let in_op = Expression::binary(
@@ -493,7 +493,7 @@ mod tests {
     #[test]
     fn test_literal_type_array() {
         let field = Arc::new(Field::new("item", DataType::Int32, true));
-        let schema = Schema::new(vec![field.clone()]);
+        let schema = Schema::new([field.clone()]);
         let batch = RecordBatch::new_empty(Arc::new(schema));
 
         let in_op = Expression::binary(
@@ -517,7 +517,7 @@ mod tests {
         let field = Arc::new(Field::new("item", DataType::Int32, true));
         let arr_field = Arc::new(Field::new("item", DataType::List(field.clone()), true));
 
-        let schema = Schema::new(vec![arr_field.clone()]);
+        let schema = Schema::new([arr_field.clone()]);
 
         let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
@@ -545,7 +545,7 @@ mod tests {
         let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0, 3, 6, 9]));
         let field = Arc::new(Field::new("item", DataType::Utf8, true));
         let arr_field = Arc::new(Field::new("item", DataType::List(field.clone()), true));
-        let schema = Schema::new(vec![arr_field.clone()]);
+        let schema = Schema::new([arr_field.clone()]);
         let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
 

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -451,7 +451,7 @@ fn get_indices(
                     // we just want to transparently recurse into lists, need to transform the kernel
                     // list data type into a schema
                     if let DataType::Array(array_type) = requested_field.data_type() {
-                        let requested_schema = StructType::new(vec![StructField::new(
+                        let requested_schema = StructType::new([StructField::new(
                             list_field.name().clone(), // so we find it in the inner call
                             array_type.element_type.clone(),
                             array_type.contains_null,
@@ -900,7 +900,7 @@ mod tests {
 
     #[test]
     fn simple_mask_indices() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new("s", DataType::STRING, true),
             StructField::new("i2", DataType::INTEGER, true),
@@ -924,7 +924,7 @@ mod tests {
 
     #[test]
     fn ensure_data_types_fails_correctly() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new("s", DataType::INTEGER, true),
         ]));
@@ -935,7 +935,7 @@ mod tests {
         let res = get_requested_indices(&requested_schema, &parquet_schema);
         assert!(res.is_err());
 
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new("s", DataType::STRING, true),
         ]));
@@ -950,7 +950,7 @@ mod tests {
 
     #[test]
     fn mask_with_map() {
-        let requested_schema = Arc::new(StructType::new(vec![StructField::new(
+        let requested_schema = Arc::new(StructType::new([StructField::new(
             "map",
             DataType::Map(Box::new(MapType::new(
                 DataType::INTEGER,
@@ -977,7 +977,7 @@ mod tests {
 
     #[test]
     fn simple_reorder_indices() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new("s", DataType::STRING, true),
             StructField::new("i2", DataType::INTEGER, true),
@@ -1001,7 +1001,7 @@ mod tests {
 
     #[test]
     fn simple_nullable_field_missing() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new("s", DataType::STRING, true),
             StructField::new("i2", DataType::INTEGER, true),
@@ -1024,11 +1024,11 @@ mod tests {
 
     #[test]
     fn nested_indices() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new(
                 "nested",
-                StructType::new(vec![
+                StructType::new([
                     StructField::new("int32", DataType::INTEGER, false),
                     StructField::new("string", DataType::STRING, false),
                 ]),
@@ -1054,10 +1054,10 @@ mod tests {
 
     #[test]
     fn nested_indices_reorder() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new(
                 "nested",
-                StructType::new(vec![
+                StructType::new([
                     StructField::new("string", DataType::STRING, false),
                     StructField::new("int32", DataType::INTEGER, false),
                 ]),
@@ -1084,11 +1084,11 @@ mod tests {
 
     #[test]
     fn nested_indices_mask_inner() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new(
                 "nested",
-                StructType::new(vec![StructField::new("int32", DataType::INTEGER, false)]),
+                StructType::new([StructField::new("int32", DataType::INTEGER, false)]),
                 false,
             ),
             StructField::new("j", DataType::INTEGER, false),
@@ -1108,7 +1108,7 @@ mod tests {
 
     #[test]
     fn simple_list_mask() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new("list", ArrayType::new(DataType::INTEGER, false), false),
             StructField::new("j", DataType::INTEGER, false),
@@ -1140,7 +1140,7 @@ mod tests {
 
     #[test]
     fn list_skip_earlier_element() {
-        let requested_schema = Arc::new(StructType::new(vec![StructField::new(
+        let requested_schema = Arc::new(StructType::new([StructField::new(
             "list",
             ArrayType::new(DataType::INTEGER, false),
             false,
@@ -1167,12 +1167,12 @@ mod tests {
 
     #[test]
     fn nested_indices_list() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new(
                 "list",
                 ArrayType::new(
-                    StructType::new(vec![
+                    StructType::new([
                         StructField::new("int32", DataType::INTEGER, false),
                         StructField::new("string", DataType::STRING, false),
                     ])
@@ -1219,7 +1219,7 @@ mod tests {
 
     #[test]
     fn nested_indices_unselected_list() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new("j", DataType::INTEGER, false),
         ]));
@@ -1252,13 +1252,12 @@ mod tests {
 
     #[test]
     fn nested_indices_list_mask_inner() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new(
                 "list",
                 ArrayType::new(
-                    StructType::new(vec![StructField::new("int32", DataType::INTEGER, false)])
-                        .into(),
+                    StructType::new([StructField::new("int32", DataType::INTEGER, false)]).into(),
                     false,
                 ),
                 false,
@@ -1298,12 +1297,12 @@ mod tests {
 
     #[test]
     fn nested_indices_list_mask_inner_reorder() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new(
                 "list",
                 ArrayType::new(
-                    StructType::new(vec![
+                    StructType::new([
                         StructField::new("string", DataType::STRING, false),
                         StructField::new("int2", DataType::INTEGER, false),
                     ])
@@ -1351,11 +1350,11 @@ mod tests {
 
     #[test]
     fn skipped_struct() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("i", DataType::INTEGER, false),
             StructField::new(
                 "nested",
-                StructType::new(vec![
+                StructType::new([
                     StructField::new("int32", DataType::INTEGER, false),
                     StructField::new("string", DataType::STRING, false),
                 ]),
@@ -1529,7 +1528,7 @@ mod tests {
 
     #[test]
     fn no_matches() {
-        let requested_schema = Arc::new(StructType::new(vec![
+        let requested_schema = Arc::new(StructType::new([
             StructField::new("s", DataType::STRING, true),
             StructField::new("i2", DataType::INTEGER, true),
         ]));
@@ -1552,7 +1551,7 @@ mod tests {
 
     #[test]
     fn empty_requested_schema() {
-        let requested_schema = Arc::new(StructType::new(vec![]));
+        let requested_schema = Arc::new(StructType::new([]));
         let parquet_schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("i", ArrowDataType::Int32, false),
             ArrowField::new("s", ArrowDataType::Utf8, true),

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -142,7 +142,7 @@ impl Scalar {
             Self::Decimal(_, precision, scale) => DataType::decimal_unchecked(*precision, *scale),
             Self::Null(data_type) => data_type.clone(),
             Self::Struct(data) => DataType::struct_type(data.fields.clone()),
-            Self::Array(data) => DataType::array_type(data.tpe.clone()),
+            Self::Array(data) => data.tpe.clone().into(),
         }
     }
 

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -181,7 +181,7 @@ impl DataSkippingFilter {
         predicate: &Option<Expr>,
     ) -> Option<Self> {
         static PREDICATE_SCHEMA: LazyLock<DataType> = LazyLock::new(|| {
-            DataType::struct_type(vec![StructField::new("predicate", DataType::BOOLEAN, true)])
+            DataType::struct_type([StructField::new("predicate", DataType::BOOLEAN, true)])
         });
         static STATS_EXPR: LazyLock<Expr> = LazyLock::new(|| Expr::column("add.stats"));
         static FILTER_EXPR: LazyLock<Expr> =
@@ -207,22 +207,20 @@ impl DataSkippingFilter {
             return None;
         }
 
-        let stats_schema = Arc::new(StructType::new(vec![
-            StructField::new("numRecords", DataType::LONG, true),
-            StructField::new("tightBounds", DataType::BOOLEAN, true),
-            StructField::new(
-                "nullCount",
-                StructType::new(
-                    data_fields
-                        .iter()
-                        .map(|data_field| StructField::new(&data_field.name, DataType::LONG, true))
-                        .collect(),
+        let stats_schema =
+            Arc::new(StructType::new([
+                StructField::new("numRecords", DataType::LONG, true),
+                StructField::new("tightBounds", DataType::BOOLEAN, true),
+                StructField::new(
+                    "nullCount",
+                    StructType::new(data_fields.iter().map(|data_field| {
+                        StructField::new(&data_field.name, DataType::LONG, true)
+                    })),
+                    true,
                 ),
-                true,
-            ),
-            StructField::new("minValues", StructType::new(data_fields.clone()), true),
-            StructField::new("maxValues", StructType::new(data_fields), true),
-        ]));
+                StructField::new("minValues", StructType::new(data_fields.clone()), true),
+                StructField::new("maxValues", StructType::new(data_fields), true),
+            ]));
 
         // Skipping happens in several steps:
         //
@@ -284,7 +282,7 @@ impl DataSkippingFilter {
 
         // visit the engine's selection vector to produce a Vec<bool>
         let mut visitor = SelectionVectorVisitor::default();
-        let schema = StructType::new(vec![StructField::new("output", DataType::BOOLEAN, false)]);
+        let schema = StructType::new([StructField::new("output", DataType::BOOLEAN, false)]);
         selection_vector
             .as_ref()
             .extract(Arc::new(schema), &mut visitor)?;

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -81,14 +81,14 @@ impl DataVisitor for AddRemoveVisitor {
 // for `scan_row_schema` in scan/mod.rs! You'll also need to update ScanFileVisitor as the
 // indexes will be off
 pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| {
-    Arc::new(StructType::new(vec![
+    Arc::new(StructType::new([
         StructField::new("path", DataType::STRING, false),
         StructField::new("size", DataType::LONG, true),
         StructField::new("modificationTime", DataType::LONG, true),
         StructField::new("stats", DataType::STRING, true),
         StructField::new(
             "deletionVector",
-            StructType::new(vec![
+            StructType::new([
                 StructField::new("storageType", DataType::STRING, false),
                 StructField::new("pathOrInlineDv", DataType::STRING, false),
                 StructField::new("offset", DataType::INTEGER, true),
@@ -99,7 +99,7 @@ pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| 
         ),
         StructField::new(
             "fileConstantValues",
-            StructType::new(vec![StructField::new(
+            StructType::new([StructField::new(
                 "partitionValues",
                 MapType::new(DataType::STRING, DataType::STRING, false),
                 true,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -581,7 +581,7 @@ pub(crate) mod test_utils {
     ) {
         let engine = SyncEngine::new();
         // doesn't matter here
-        let table_schema = Arc::new(StructType::new(vec![StructField::new(
+        let table_schema = Arc::new(StructType::new([StructField::new(
             "foo",
             crate::schema::DataType::STRING,
             false,

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -180,27 +180,29 @@ pub struct StructType {
 }
 
 impl StructType {
-    pub fn new(fields: Vec<StructField>) -> Self {
+    pub fn new(fields: impl IntoIterator<Item = StructField>) -> Self {
         Self {
             type_name: "struct".into(),
             fields: fields.into_iter().map(|f| (f.name.clone(), f)).collect(),
         }
     }
 
+    pub fn try_new<E>(fields: impl IntoIterator<Item = Result<StructField, E>>) -> Result<Self, E> {
+        let fields: Vec<_> = fields.into_iter().try_collect()?;
+        Ok(Self::new(fields))
+    }
+
     /// Get a [`StructType`] containing [`StructField`]s of the given names. The order of fields in
     /// the returned schema will match the order passed to this function, which can be different
     /// from this order in this schema. Returns an Err if a specified field doesn't exist.
     pub fn project_as_struct(&self, names: &[impl AsRef<str>]) -> DeltaResult<StructType> {
-        let fields = names
-            .iter()
-            .map(|name| {
-                self.fields
-                    .get(name.as_ref())
-                    .cloned()
-                    .ok_or_else(|| Error::missing_column(name.as_ref()))
-            })
-            .try_collect()?;
-        Ok(Self::new(fields))
+        let fields = names.iter().map(|name| {
+            self.fields
+                .get(name.as_ref())
+                .cloned()
+                .ok_or_else(|| Error::missing_column(name.as_ref()))
+        });
+        Self::try_new(fields)
     }
 
     /// Get a [`SchemaRef`] containing [`StructField`]s of the given names. The order of fields in
@@ -335,7 +337,7 @@ impl MapType {
 
     /// Create a schema assuming the map is stored as a struct with the specified key and value field names
     pub fn as_struct_schema(&self, key_name: String, val_name: String) -> Schema {
-        StructType::new(vec![
+        StructType::new([
             StructField::new(key_name, self.key_type.clone(), false),
             StructField::new(val_name, self.value_type.clone(), self.value_contains_null),
         ])
@@ -503,12 +505,13 @@ impl DataType {
         Self::decimal(precision, scale).unwrap()
     }
 
-    pub fn struct_type(fields: Vec<StructField>) -> Self {
-        DataType::Struct(Box::new(StructType::new(fields)))
+    pub fn struct_type(fields: impl IntoIterator<Item = StructField>) -> Self {
+        StructType::new(fields).into()
     }
-
-    pub fn array_type(elements: ArrayType) -> Self {
-        DataType::Array(Box::new(elements))
+    pub fn try_struct_type<E>(
+        fields: impl IntoIterator<Item = Result<StructField, E>>,
+    ) -> Result<Self, E> {
+        Ok(StructType::try_new(fields)?.into())
     }
 
     pub fn as_primitive_opt(&self) -> Option<&PrimitiveType> {

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -539,8 +539,7 @@ fn read_table_data(
             let table_schema = snapshot.schema();
             let selected_fields = select_cols
                 .iter()
-                .map(|col| table_schema.field(col).cloned().unwrap())
-                .collect();
+                .map(|col| table_schema.field(col).cloned().unwrap());
             Arc::new(Schema::new(selected_fields))
         });
         let scan = snapshot


### PR DESCRIPTION
Constructing new `StructType` instances has historically been more verbose than necessary because they require a `Vec<StructField>`. Update the various constructors to accept `impl IntoIterator` instead, and simplify call sites to take advantage.