### PR TITLE
misc docs and renames

### DIFF
--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -167,7 +167,7 @@ impl DeletionVectorDescriptor {
         }
     }
 
-    /// Materialize the row indexes of the deletion vector as a Vec<u64> in which each element
+    /// Materialize the row indexes of the deletion vector as a `Vec<u64>` in which each element
     /// represents a row index that is deleted from the table.
     pub fn row_indexes(
         &self,

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -205,21 +205,21 @@ fn evaluate_expression(
                     .cloned()
             }
         }
-        (Struct(fields), Some(DataType::Struct(schema))) => {
+        (Struct(fields), Some(DataType::Struct(output_schema))) => {
             let columns = fields
                 .iter()
-                .zip(schema.fields())
+                .zip(output_schema.fields())
                 .map(|(expr, field)| evaluate_expression(expr, batch, Some(field.data_type())));
             let output_cols: Vec<Arc<dyn Array>> = columns.try_collect()?;
             let output_fields: Vec<ArrowField> = output_cols
                 .iter()
-                .zip(schema.fields())
-                .map(|(array, input_field)| -> DeltaResult<_> {
-                    ensure_data_types(input_field.data_type(), array.data_type())?;
+                .zip(output_schema.fields())
+                .map(|(output_col, output_field)| -> DeltaResult<_> {
+                    ensure_data_types(output_field.data_type(), output_col.data_type())?;
                     Ok(ArrowField::new(
-                        input_field.name(),
-                        array.data_type().clone(),
-                        array.is_nullable(),
+                        output_field.name(),
+                        output_col.data_type().clone(),
+                        output_col.is_nullable(),
                     ))
                 })
                 .try_collect()?;

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -40,38 +40,37 @@ pub struct DefaultEngine<E: TaskExecutor> {
 impl<E: TaskExecutor> DefaultEngine<E> {
     /// Create a new [`DefaultEngine`] instance
     ///
-    /// The `path` parameter is used to determine the type of storage used.
+    /// # Parameters
     ///
-    /// The `task_executor` is used to spawn async IO tasks. See [executor::TaskExecutor].
-    pub fn try_new<I, K, V>(path: &Url, options: I, task_executor: Arc<E>) -> DeltaResult<Self>
+    /// - `table_root`: The URL of the table within storage.
+    /// - `options`: key/value pairs of options to pass to the object store.
+    /// - `task_executor`: Used to spawn async IO tasks. See [executor::TaskExecutor].
+    pub fn try_new<K, V>(
+        table_root: &Url,
+        options: impl IntoIterator<Item = (K, V)>,
+        task_executor: Arc<E>,
+    ) -> DeltaResult<Self>
     where
-        I: IntoIterator<Item = (K, V)>,
         K: AsRef<str>,
         V: Into<String>,
     {
-        let (store, prefix) = parse_url_opts(path, options)?;
-        let store = Arc::new(store);
-        Ok(Self {
-            file_system: Arc::new(ObjectStoreFileSystemClient::new(
-                store.clone(),
-                prefix,
-                task_executor.clone(),
-            )),
-            json: Arc::new(DefaultJsonHandler::new(
-                store.clone(),
-                task_executor.clone(),
-            )),
-            parquet: Arc::new(DefaultParquetHandler::new(store.clone(), task_executor)),
-            store,
-            expression: Arc::new(ArrowExpressionHandler {}),
-        })
+        // table root is the path of the table in the ObjectStore
+        let (store, table_root) = parse_url_opts(table_root, options)?;
+        Ok(Self::new(Arc::new(store), table_root, task_executor))
     }
 
-    pub fn new(store: Arc<DynObjectStore>, prefix: Path, task_executor: Arc<E>) -> Self {
+    /// Create a new [`DefaultEngine`] instance
+    ///
+    /// # Parameters
+    ///
+    /// - `store`: The object store to use.
+    /// - `table_root_path`: The root path of the table within storage.
+    /// - `task_executor`: Used to spawn async IO tasks. See [executor::TaskExecutor].
+    pub fn new(store: Arc<DynObjectStore>, table_root: Path, task_executor: Arc<E>) -> Self {
         Self {
             file_system: Arc::new(ObjectStoreFileSystemClient::new(
                 store.clone(),
-                prefix,
+                table_root,
                 task_executor.clone(),
             )),
             json: Arc::new(DefaultJsonHandler::new(

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -1,13 +1,14 @@
 use std::{fs::File, io::BufReader};
 
-use crate::{
-    engine::arrow_utils::parse_json as arrow_parse_json, schema::SchemaRef, DeltaResult,
-    EngineData, Expression, FileDataReadResultIterator, FileMeta, JsonHandler,
-};
 use arrow_schema::SchemaRef as ArrowSchemaRef;
 
 use super::read_files;
 use crate::engine::arrow_data::ArrowEngineData;
+use crate::engine::arrow_utils::parse_json as arrow_parse_json;
+use crate::schema::SchemaRef;
+use crate::{
+    DeltaResult, EngineData, Expression, FileDataReadResultIterator, FileMeta, JsonHandler,
+};
 
 pub(crate) struct SyncJsonHandler;
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -67,7 +67,7 @@ impl StructData {
             require!(
                 f.is_nullable() || !a.is_null(),
                 Error::invalid_struct_data(format!(
-                    "Value for non-nullable field {:?} cannto be null, got {}",
+                    "Value for non-nullable field {:?} cannot be null, got {}",
                     f.name(),
                     a
                 ))

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -119,10 +119,14 @@ impl ScanBuilder {
 /// A vector of this type is returned from calling [`Scan::execute`]. Each [`ScanResult`] contains
 /// the raw [`EngineData`] as read by the engines [`crate::ParquetHandler`], and a boolean
 /// mask. Rows can be dropped from a scan due to deletion vectors, so we communicate back both
-/// EngineData and information regarding whether a row should be included or not See the docs below
-/// for [`ScanResult::mask`] for details on the mask.
+/// EngineData and information regarding whether a row should be included or not (via an internal
+/// mask). See the docs below for [`ScanResult::full_mask`] for details on the mask.
 pub struct ScanResult {
-    /// Raw engine data as read from the disk for a particular file included in the query
+    /// Raw engine data as read from the disk for a particular file included in the query. Note
+    /// that this data may include data that should be filtered out based on the mask given by
+    /// [`full_mask`].
+    ///
+    /// [`full_mask`]: #method.full_mask
     pub raw_data: DeltaResult<Box<dyn EngineData>>,
     /// Raw row mask.
     // TODO(nick) this should be allocated by the engine
@@ -137,6 +141,8 @@ impl ScanResult {
     /// you are using the default engine and plan to call arrow's `filter_record_batch`, you _need_
     /// to extend the mask to the full length of the batch or arrow will drop the extra
     /// rows. Calling [`full_mask`] instead avoids this risk entirely, at the cost of a copy.
+    ///
+    /// [`full_mask`]: #method.full_mask
     pub fn raw_mask(&self) -> Option<&Vec<bool>> {
         self.raw_mask.as_ref()
     }


### PR DESCRIPTION
ran across a handful of things during transaction implementation. moving those out into a separate PR so we don't pollute the (already large) transaction PR