### PR TITLE
Define and use a schema transformation trait

### DIFF
--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -226,8 +226,8 @@ impl TryFrom<&ArrowDataType> for DataType {
             ))),
             ArrowDataType::Map(field, _) => {
                 if let ArrowDataType::Struct(struct_fields) = field.data_type() {
-                    let key_type = struct_fields[0].data_type().try_into()?;
-                    let value_type = struct_fields[1].data_type().try_into()?;
+                    let key_type = DataType::try_from(struct_fields[0].data_type())?;
+                    let value_type = DataType::try_from(struct_fields[1].data_type())?;
                     let value_type_nullable = struct_fields[1].is_nullable();
                     Ok(DataType::Map(Box::new(MapType::new(
                         key_type,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -418,10 +418,10 @@ fn get_state_info(
             } else {
                 // Add to read schema, store field so we can build a `Column` expression later
                 // if needed (i.e. if we have partition columns)
-                let physical_name = logical_field.physical_name(column_mapping_mode)?;
-                let physical_field = logical_field.with_name(physical_name);
+                let physical_field = logical_field.make_physical(column_mapping_mode)?;
+                let physical_name = physical_field.name.clone();
                 read_fields.push(physical_field);
-                Ok(ColumnType::Selected(physical_name.to_string()))
+                Ok(ColumnType::Selected(physical_name))
             }
         })
         .try_collect()?;


### PR DESCRIPTION
Proper nested column support will require a recursive schema transformation facility of some kind, because it's no longer enough to simply iterate over the top-level fields of a schema. We need to recurse deeper, and through arbitrary schema elements. Rather than allow adhoc schema transformations to proliferate, we introduce a `SchemaTransform` trait and update column mapping and data skipping code to use it. 

We also introduce a schema depth checker, which not only makes a very nice test article (high code coverage), it can also be used in the future to do an early safety check for untrusted schema objects that can prevent stack overflow (which is near-SIGKILL catastrophic event in rust).

The schema transform trait has two sets of provided methods:
* `transform_xxx` - hook point for concrete implementations to directly transform a schema element (no-op by default)
* `recurse_into_xxx` - handles the mechanics of recursing through the schema element's children.

A transform produces one of three outcomes:
1. No-op -- return the input argument as `Some(Cow::Borrowed)`
2. Transformed -- return the result as `Some(Cow::Owned)`
3. Deleted -- return `None`.

Technically, any schema element can be deleted, but struct fields will be the most common target for deletion.

The expected use case that a user who wants to transform e.g. struct fields would implement `transform_struct_field`, and that code can call `recurse_into_struct_field` if deeper recursion is required.

Note: There is no `recurse_into_primitive` method because `DataType::Primitive` is always a leaf in the schema.