### PR TITLE
[Chore] Use helpers to simplify expression handling code

### DIFF
--- a/ffi/src/expressions.rs
+++ b/ffi/src/expressions.rs
@@ -5,7 +5,7 @@ use crate::{
     ReferenceSet, TryFromStringSlice,
 };
 use delta_kernel::{
-    expressions::{BinaryOperator, Expression, Scalar, UnaryOperator},
+    expressions::{BinaryOperator, Expression, UnaryOperator},
     DeltaResult,
 };
 
@@ -56,12 +56,10 @@ fn visit_expression_binary(
     a: usize,
     b: usize,
 ) -> usize {
-    let left = unwrap_kernel_expression(state, a).map(Box::new);
-    let right = unwrap_kernel_expression(state, b).map(Box::new);
+    let left = unwrap_kernel_expression(state, a);
+    let right = unwrap_kernel_expression(state, b);
     match left.zip(right) {
-        Some((left, right)) => {
-            wrap_expression(state, Expression::BinaryOperation { op, left, right })
-        }
+        Some((left, right)) => wrap_expression(state, Expression::binary(op, left, right)),
         None => 0, // invalid child => invalid node
     }
 }
@@ -182,10 +180,7 @@ fn visit_expression_literal_string_impl(
     state: &mut KernelExpressionVisitorState,
     value: DeltaResult<String>,
 ) -> DeltaResult<usize> {
-    Ok(wrap_expression(
-        state,
-        Expression::Literal(Scalar::from(value?)),
-    ))
+    Ok(wrap_expression(state, Expression::literal(value?)))
 }
 
 // We need to get parse.expand working to be able to macro everything below, see issue #255

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -59,7 +59,7 @@ impl DeletionVectorDescriptor {
                 let path_len = self.path_or_inline_dv.len();
                 require!(
                     path_len >= 20,
-                    Error::deletion_vector("Invalid length {path_len}, must be >= 20",)
+                    Error::deletion_vector("Invalid length {path_len}, must be >= 20")
                 );
                 let prefix_len = path_len - 20;
                 let decoded = z85::decode(&self.path_or_inline_dv[prefix_len..])

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -513,7 +513,7 @@ mod tests {
                 app_id: "myApp2".to_string(),
                 version: 4,
                 last_updated: Some(1670892998177),
-            },)
+            })
         );
         assert_eq!(
             actual.remove("myApp"),

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -213,27 +213,21 @@ impl TryFrom<&ArrowDataType> for DataType {
             ArrowDataType::Struct(fields) => {
                 DataType::try_struct_type(fields.iter().map(|field| field.as_ref().try_into()))
             }
-            ArrowDataType::List(field) => Ok(DataType::Array(Box::new(ArrayType::new(
-                (*field).data_type().try_into()?,
-                (*field).is_nullable(),
-            )))),
-            ArrowDataType::LargeList(field) => Ok(DataType::Array(Box::new(ArrayType::new(
-                (*field).data_type().try_into()?,
-                (*field).is_nullable(),
-            )))),
-            ArrowDataType::FixedSizeList(field, _) => Ok(DataType::Array(Box::new(
-                ArrayType::new((*field).data_type().try_into()?, (*field).is_nullable()),
-            ))),
+            ArrowDataType::List(field) => {
+                Ok(ArrayType::new((*field).data_type().try_into()?, (*field).is_nullable()).into())
+            }
+            ArrowDataType::LargeList(field) => {
+                Ok(ArrayType::new((*field).data_type().try_into()?, (*field).is_nullable()).into())
+            }
+            ArrowDataType::FixedSizeList(field, _) => {
+                Ok(ArrayType::new((*field).data_type().try_into()?, (*field).is_nullable()).into())
+            }
             ArrowDataType::Map(field, _) => {
                 if let ArrowDataType::Struct(struct_fields) = field.data_type() {
                     let key_type = DataType::try_from(struct_fields[0].data_type())?;
                     let value_type = DataType::try_from(struct_fields[1].data_type())?;
                     let value_type_nullable = struct_fields[1].is_nullable();
-                    Ok(DataType::Map(Box::new(MapType::new(
-                        key_type,
-                        value_type,
-                        value_type_nullable,
-                    ))))
+                    Ok(MapType::new(key_type, value_type, value_type_nullable).into())
                 } else {
                     panic!("DataType::Map should contain a struct field child");
                 }

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -590,23 +590,23 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
         let column = Expression::column("a");
 
-        let expression = column.clone().add(Expression::literal(1));
+        let expression = column.clone().add(1);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![2, 3, 4]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = column.clone().sub(Expression::literal(1));
+        let expression = column.clone().sub(1);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![0, 1, 2]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = column.clone().mul(Expression::literal(2));
+        let expression = column.clone().mul(2);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![2, 4, 6]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
         // TODO handle type casting
-        let expression = column.div(Expression::literal(1));
+        let expression = column.div(1);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![1, 2, 3]));
         assert_eq!(results.as_ref(), expected.as_ref())
@@ -649,34 +649,33 @@ mod tests {
         let values = Int32Array::from(vec![1, 2, 3]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
         let column = Expression::column("a");
-        let lit = Expression::literal(2);
 
-        let expression = column.clone().lt(lit.clone());
+        let expression = column.clone().lt(2);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![true, false, false]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = column.clone().lt_eq(lit.clone());
+        let expression = column.clone().lt_eq(2);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![true, true, false]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = column.clone().gt(lit.clone());
+        let expression = column.clone().gt(2);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![false, false, true]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = column.clone().gt_eq(lit.clone());
+        let expression = column.clone().gt_eq(2);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![false, true, true]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = column.clone().eq(lit.clone());
+        let expression = column.clone().eq(2);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![false, true, false]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = column.clone().ne(lit.clone());
+        let expression = column.clone().ne(2);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![true, false, true]));
         assert_eq!(results.as_ref(), expected.as_ref());
@@ -706,7 +705,7 @@ mod tests {
         let expected = Arc::new(BooleanArray::from(vec![false, false]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = column_a.clone().and(Expression::literal(true));
+        let expression = column_a.clone().and(true);
         let results =
             evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN))
                 .unwrap();
@@ -720,7 +719,7 @@ mod tests {
         let expected = Arc::new(BooleanArray::from(vec![true, true]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = column_a.clone().or(Expression::literal(false));
+        let expression = column_a.clone().or(false);
         let results =
             evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN))
                 .unwrap();

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -447,17 +447,9 @@ mod tests {
         let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
 
-        let not_op = Expression::binary(
-            BinaryOperator::NotIn,
-            Expression::literal(5),
-            Expression::column("item"),
-        );
+        let not_op = Expression::binary(BinaryOperator::NotIn, 5, Expression::column("item"));
 
-        let in_op = Expression::binary(
-            BinaryOperator::NotIn,
-            Expression::literal(5),
-            Expression::column("item"),
-        );
+        let in_op = Expression::binary(BinaryOperator::NotIn, 5, Expression::column("item"));
 
         let result = evaluate_expression(&not_op, &batch, None).unwrap();
         let expected = BooleanArray::from(vec![true, false, true]);
@@ -475,11 +467,7 @@ mod tests {
         let schema = Schema::new([field.clone()]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(values.clone())]).unwrap();
 
-        let in_op = Expression::binary(
-            BinaryOperator::NotIn,
-            Expression::literal(5),
-            Expression::column("item"),
-        );
+        let in_op = Expression::binary(BinaryOperator::NotIn, 5, Expression::column("item"));
 
         let in_result = evaluate_expression(&in_op, &batch, None);
 
@@ -498,11 +486,11 @@ mod tests {
 
         let in_op = Expression::binary(
             BinaryOperator::NotIn,
-            Expression::literal(5),
-            Expression::literal(Scalar::Array(ArrayData::new(
+            5,
+            Scalar::Array(ArrayData::new(
                 ArrayType::new(DeltaDataTypes::INTEGER, false),
                 vec![Scalar::Integer(1), Scalar::Integer(2)],
-            ))),
+            )),
         );
 
         let in_result = evaluate_expression(&in_op, &batch, None).unwrap();
@@ -549,17 +537,10 @@ mod tests {
         let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
 
-        let str_not_op = Expression::binary(
-            BinaryOperator::NotIn,
-            Expression::literal("bye"),
-            Expression::column("item"),
-        );
+        let str_not_op =
+            Expression::binary(BinaryOperator::NotIn, "bye", Expression::column("item"));
 
-        let str_in_op = Expression::binary(
-            BinaryOperator::In,
-            Expression::literal("hi"),
-            Expression::column("item"),
-        );
+        let str_in_op = Expression::binary(BinaryOperator::In, "hi", Expression::column("item"));
 
         let result = evaluate_expression(&str_in_op, &batch, None).unwrap();
         let expected = BooleanArray::from(vec![true, true, true]);
@@ -609,23 +590,23 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
         let column = Expression::column("a");
 
-        let expression = Box::new(column.clone().add(Expression::Literal(Scalar::Integer(1))));
+        let expression = column.clone().add(Expression::literal(1));
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![2, 3, 4]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column.clone().sub(Expression::Literal(Scalar::Integer(1))));
+        let expression = column.clone().sub(Expression::literal(1));
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![0, 1, 2]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column.clone().mul(Expression::Literal(Scalar::Integer(2))));
+        let expression = column.clone().mul(Expression::literal(2));
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![2, 4, 6]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
         // TODO handle type casting
-        let expression = Box::new(column.div(Expression::Literal(Scalar::Integer(1))));
+        let expression = column.div(Expression::literal(1));
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![1, 2, 3]));
         assert_eq!(results.as_ref(), expected.as_ref())
@@ -646,17 +627,17 @@ mod tests {
         let column_a = Expression::column("a");
         let column_b = Expression::column("b");
 
-        let expression = Box::new(column_a.clone().add(column_b.clone()));
+        let expression = column_a.clone().add(column_b.clone());
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![2, 4, 6]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column_a.clone().sub(column_b.clone()));
+        let expression = column_a.clone().sub(column_b.clone());
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![0, 0, 0]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column_a.clone().mul(column_b));
+        let expression = column_a.clone().mul(column_b);
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(Int32Array::from(vec![1, 4, 9]));
         assert_eq!(results.as_ref(), expected.as_ref());
@@ -668,34 +649,34 @@ mod tests {
         let values = Int32Array::from(vec![1, 2, 3]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
         let column = Expression::column("a");
-        let lit = Expression::Literal(Scalar::Integer(2));
+        let lit = Expression::literal(2);
 
-        let expression = Box::new(column.clone().lt(lit.clone()));
+        let expression = column.clone().lt(lit.clone());
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![true, false, false]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column.clone().lt_eq(lit.clone()));
+        let expression = column.clone().lt_eq(lit.clone());
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![true, true, false]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column.clone().gt(lit.clone()));
+        let expression = column.clone().gt(lit.clone());
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![false, false, true]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column.clone().gt_eq(lit.clone()));
+        let expression = column.clone().gt_eq(lit.clone());
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![false, true, true]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column.clone().eq(lit.clone()));
+        let expression = column.clone().eq(lit.clone());
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![false, true, false]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column.clone().ne(lit.clone()));
+        let expression = column.clone().ne(lit.clone());
         let results = evaluate_expression(&expression, &batch, None).unwrap();
         let expected = Arc::new(BooleanArray::from(vec![true, false, true]));
         assert_eq!(results.as_ref(), expected.as_ref());
@@ -718,32 +699,28 @@ mod tests {
         let column_a = Expression::column("a");
         let column_b = Expression::column("b");
 
-        let expression = Box::new(column_a.clone().and(column_b.clone()));
+        let expression = column_a.clone().and(column_b.clone());
         let results =
             evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN))
                 .unwrap();
         let expected = Arc::new(BooleanArray::from(vec![false, false]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column_a.clone().and(Expression::literal(true)));
+        let expression = column_a.clone().and(Expression::literal(true));
         let results =
             evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN))
                 .unwrap();
         let expected = Arc::new(BooleanArray::from(vec![true, false]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(column_a.clone().or(column_b));
+        let expression = column_a.clone().or(column_b);
         let results =
             evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN))
                 .unwrap();
         let expected = Arc::new(BooleanArray::from(vec![true, true]));
         assert_eq!(results.as_ref(), expected.as_ref());
 
-        let expression = Box::new(
-            column_a
-                .clone()
-                .or(Expression::literal(Scalar::Boolean(false))),
-        );
+        let expression = column_a.clone().or(Expression::literal(false));
         let results =
             evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN))
                 .unwrap();

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -952,11 +952,7 @@ mod tests {
     fn mask_with_map() {
         let requested_schema = Arc::new(StructType::new([StructField::new(
             "map",
-            DataType::Map(Box::new(MapType::new(
-                DataType::INTEGER,
-                DataType::STRING,
-                false,
-            ))),
+            MapType::new(DataType::INTEGER, DataType::STRING, false),
             false,
         )]));
         let parquet_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new_map(

--- a/kernel/src/engine/parquet_stats_skipping/tests.rs
+++ b/kernel/src/engine/parquet_stats_skipping/tests.rs
@@ -854,34 +854,34 @@ fn test_sql_where() {
     // Constrast normal vs SQL WHERE semantics - comparison inside AND
     expect_eq!(
         AllNullTestFilter.apply_expr(
-            &Expression::and_from([NULL, Expression::lt(col.clone(), val.clone()),]),
+            &Expression::and(NULL, Expression::lt(col.clone(), val.clone())),
             false
         ),
         None,
         "{NULL} AND {col} < {val}"
     );
     expect_eq!(
-        AllNullTestFilter.apply_sql_where(&Expression::and_from([
+        AllNullTestFilter.apply_sql_where(&Expression::and(
             NULL,
             Expression::lt(col.clone(), val.clone()),
-        ])),
+        )),
         Some(false),
         "WHERE {NULL} AND {col} < {val}"
     );
 
     expect_eq!(
         AllNullTestFilter.apply_expr(
-            &Expression::and_from([TRUE, Expression::lt(col.clone(), val.clone()),]),
+            &Expression::and(TRUE, Expression::lt(col.clone(), val.clone())),
             false
         ),
         None, // NULL (from the NULL check) is stronger than TRUE
         "{TRUE} AND {col} < {val}"
     );
     expect_eq!(
-        AllNullTestFilter.apply_sql_where(&Expression::and_from([
+        AllNullTestFilter.apply_sql_where(&Expression::and(
             TRUE,
             Expression::lt(col.clone(), val.clone()),
-        ])),
+        )),
         Some(false), // FALSE (from the NULL check) is stronger than TRUE
         "WHERE {TRUE} AND {col} < {val}"
     );
@@ -889,20 +889,20 @@ fn test_sql_where() {
     // Contrast normal vs. SQL WHERE semantics - comparison inside AND inside AND
     expect_eq!(
         AllNullTestFilter.apply_expr(
-            &Expression::and_from([
+            &Expression::and(
                 TRUE,
-                Expression::and_from([NULL, Expression::lt(col.clone(), val.clone()),]),
-            ]),
+                Expression::and(NULL, Expression::lt(col.clone(), val.clone())),
+            ),
             false,
         ),
         None,
         "{TRUE} AND ({NULL} AND {col} < {val})"
     );
     expect_eq!(
-        AllNullTestFilter.apply_sql_where(&Expression::and_from([
+        AllNullTestFilter.apply_sql_where(&Expression::and(
             TRUE,
-            Expression::and_from([NULL, Expression::lt(col.clone(), val.clone()),]),
-        ])),
+            Expression::and(NULL, Expression::lt(col.clone(), val.clone())),
+        )),
         Some(false),
         "WHERE {TRUE} AND ({NULL} AND {col} < {val})"
     );
@@ -910,20 +910,20 @@ fn test_sql_where() {
     // Semantics are the same for comparison inside OR inside AND
     expect_eq!(
         AllNullTestFilter.apply_expr(
-            &Expression::or_from([
+            &Expression::or(
                 FALSE,
-                Expression::and_from([NULL, Expression::lt(col.clone(), val.clone()),]),
-            ]),
+                Expression::and(NULL, Expression::lt(col.clone(), val.clone())),
+            ),
             false,
         ),
         None,
         "{FALSE} OR ({NULL} AND {col} < {val})"
     );
     expect_eq!(
-        AllNullTestFilter.apply_sql_where(&Expression::or_from([
+        AllNullTestFilter.apply_sql_where(&Expression::or(
             FALSE,
-            Expression::and_from([NULL, Expression::lt(col.clone(), val.clone()),]),
-        ])),
+            Expression::and(NULL, Expression::lt(col.clone(), val.clone())),
+        )),
         None,
         "WHERE {FALSE} OR ({NULL} AND {col} < {val})"
     );

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -234,7 +234,7 @@ impl Expression {
     }
 
     /// Create a new struct expression
-    pub fn struct_expr(exprs: impl IntoIterator<Item = Self>) -> Self {
+    pub fn struct_from(exprs: impl IntoIterator<Item = Self>) -> Self {
         Self::Struct(exprs.into_iter().collect())
     }
 

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -134,6 +134,13 @@ pub enum Expression {
     Column(String),
     /// A struct computed from a Vec of expressions
     Struct(Vec<Expression>),
+    /// A unary operation.
+    UnaryOperation {
+        /// The operator.
+        op: UnaryOperator,
+        /// The expression.
+        expr: Box<Expression>,
+    },
     /// A binary operation.
     BinaryOperation {
         /// The operator.
@@ -142,13 +149,6 @@ pub enum Expression {
         left: Box<Expression>,
         /// The right-hand side of the operation.
         right: Box<Expression>,
-    },
-    /// A unary operation.
-    UnaryOperation {
-        /// The operator.
-        op: UnaryOperator,
-        /// The expression.
-        expr: Box<Expression>,
     },
     VariadicOperation {
         /// The operator.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -286,57 +286,57 @@ impl Expression {
     }
 
     /// Create a new expression `self == other`
-    pub fn eq(self, other: Self) -> Self {
+    pub fn eq(self, other: impl Into<Self>) -> Self {
         Self::binary(BinaryOperator::Equal, self, other)
     }
 
     /// Create a new expression `self != other`
-    pub fn ne(self, other: Self) -> Self {
+    pub fn ne(self, other: impl Into<Self>) -> Self {
         Self::binary(BinaryOperator::NotEqual, self, other)
     }
 
     /// Create a new expression `self <= other`
-    pub fn le(self, other: Self) -> Self {
+    pub fn le(self, other: impl Into<Self>) -> Self {
         Self::binary(BinaryOperator::LessThanOrEqual, self, other)
     }
 
     /// Create a new expression `self < other`
-    pub fn lt(self, other: Self) -> Self {
+    pub fn lt(self, other: impl Into<Self>) -> Self {
         Self::binary(BinaryOperator::LessThan, self, other)
     }
 
     /// Create a new expression `self >= other`
-    pub fn ge(self, other: Self) -> Self {
+    pub fn ge(self, other: impl Into<Self>) -> Self {
         Self::binary(BinaryOperator::GreaterThanOrEqual, self, other)
     }
 
     /// Create a new expression `self > other`
-    pub fn gt(self, other: Self) -> Self {
+    pub fn gt(self, other: impl Into<Self>) -> Self {
         Self::binary(BinaryOperator::GreaterThan, self, other)
     }
 
     /// Create a new expression `self >= other`
-    pub fn gt_eq(self, other: Self) -> Self {
+    pub fn gt_eq(self, other: impl Into<Self>) -> Self {
         Self::binary(BinaryOperator::GreaterThanOrEqual, self, other)
     }
 
     /// Create a new expression `self <= other`
-    pub fn lt_eq(self, other: Self) -> Self {
+    pub fn lt_eq(self, other: impl Into<Self>) -> Self {
         Self::binary(BinaryOperator::LessThanOrEqual, self, other)
     }
 
     /// Create a new expression `self AND other`
-    pub fn and(self, other: Self) -> Self {
-        Self::and_from([self, other])
+    pub fn and(self, other: impl Into<Self>) -> Self {
+        Self::and_from([self, other.into()])
     }
 
     /// Create a new expression `self OR other`
-    pub fn or(self, other: Self) -> Self {
-        Self::or_from([self, other])
+    pub fn or(self, other: impl Into<Self>) -> Self {
+        Self::or_from([self, other.into()])
     }
 
     /// Create a new expression `DISTINCT(self, other)`
-    pub fn distinct(self, other: Self) -> Self {
+    pub fn distinct(self, other: impl Into<Self>) -> Self {
         Self::binary(BinaryOperator::Distinct, self, other)
     }
 
@@ -374,34 +374,34 @@ impl std::ops::Not for Expression {
     }
 }
 
-impl std::ops::Add<Expression> for Expression {
+impl<R: Into<Expression>> std::ops::Add<R> for Expression {
     type Output = Self;
 
-    fn add(self, rhs: Expression) -> Self::Output {
+    fn add(self, rhs: R) -> Self::Output {
         Self::binary(BinaryOperator::Plus, self, rhs)
     }
 }
 
-impl std::ops::Sub<Expression> for Expression {
+impl<R: Into<Expression>> std::ops::Sub<R> for Expression {
     type Output = Self;
 
-    fn sub(self, rhs: Expression) -> Self {
+    fn sub(self, rhs: R) -> Self {
         Self::binary(BinaryOperator::Minus, self, rhs)
     }
 }
 
-impl std::ops::Mul<Expression> for Expression {
+impl<R: Into<Expression>> std::ops::Mul<R> for Expression {
     type Output = Self;
 
-    fn mul(self, rhs: Expression) -> Self {
+    fn mul(self, rhs: R) -> Self {
         Self::binary(BinaryOperator::Multiply, self, rhs)
     }
 }
 
-impl std::ops::Div<Expression> for Expression {
+impl<R: Into<Expression>> std::ops::Div<R> for Expression {
     type Output = Self;
 
-    fn div(self, rhs: Expression) -> Self {
+    fn div(self, rhs: R) -> Self {
         Self::binary(BinaryOperator::Divide, self, rhs)
     }
 }
@@ -415,38 +415,26 @@ mod tests {
         let col_ref = Expr::column("x");
         let cases = [
             (col_ref.clone(), "Column(x)"),
-            (col_ref.clone().eq(Expr::literal(2)), "Column(x) = 2"),
+            (col_ref.clone().eq(2), "Column(x) = 2"),
+            ((col_ref.clone() - 4).lt(10), "Column(x) - 4 < 10"),
+            ((col_ref.clone() + 4) / 10 * 42, "Column(x) + 4 / 10 * 42"),
             (
-                (col_ref.clone() - Expr::literal(4)).lt(Expr::literal(10)),
-                "Column(x) - 4 < 10",
-            ),
-            (
-                (col_ref.clone() + Expr::literal(4)) / Expr::literal(10) * Expr::literal(42),
-                "Column(x) + 4 / 10 * 42",
-            ),
-            (
-                col_ref
-                    .clone()
-                    .gt_eq(Expr::literal(2))
-                    .and(col_ref.clone().lt_eq(Expr::literal(10))),
+                col_ref.clone().gt_eq(2).and(col_ref.clone().lt_eq(10)),
                 "AND(Column(x) >= 2, Column(x) <= 10)",
             ),
             (
                 Expr::and_from([
-                    col_ref.clone().gt_eq(Expr::literal(2)),
-                    col_ref.clone().lt_eq(Expr::literal(10)),
-                    col_ref.clone().lt_eq(Expr::literal(100)),
+                    col_ref.clone().gt_eq(2),
+                    col_ref.clone().lt_eq(10),
+                    col_ref.clone().lt_eq(100),
                 ]),
                 "AND(Column(x) >= 2, Column(x) <= 10, Column(x) <= 100)",
             ),
             (
-                col_ref
-                    .clone()
-                    .gt(Expr::literal(2))
-                    .or(col_ref.clone().lt(Expr::literal(10))),
+                col_ref.clone().gt(2).or(col_ref.clone().lt(10)),
                 "OR(Column(x) > 2, Column(x) < 10)",
             ),
-            (col_ref.eq(Expr::literal("foo")), "Column(x) = 'foo'"),
+            (col_ref.eq("foo"), "Column(x) = 'foo'"),
         ];
 
         for (expr, expected) in cases {

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -249,7 +249,7 @@ impl DataSkippingFilter {
 
         let skipping_evaluator = engine.get_expression_handler().get_evaluator(
             stats_schema.clone(),
-            Expr::struct_expr([as_data_skipping_predicate(predicate)?]),
+            Expr::struct_from([as_data_skipping_predicate(predicate)?]),
             PREDICATE_SCHEMA.clone(),
         );
 

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -17,8 +17,8 @@ use crate::{Engine, EngineData, ExpressionEvaluator, JsonHandler};
 /// by the default for tightBounds being true, so we have to check if it's EITHER `null` OR `true`
 fn get_tight_null_expr(null_col: String) -> Expr {
     Expr::and(
-        Expr::distinct(Expr::column("tightBounds"), Expr::literal(false)),
-        Expr::gt(Expr::column(null_col), Expr::literal(0i64)),
+        Expr::distinct(Expr::column("tightBounds"), false),
+        Expr::gt(Expr::column(null_col), 0i64),
     )
 }
 
@@ -28,7 +28,7 @@ fn get_tight_null_expr(null_col: String) -> Expr {
 /// doesn't help us)
 fn get_wide_null_expr(null_col: String) -> Expr {
     Expr::and(
-        Expr::eq(Expr::column("tightBounds"), Expr::literal(false)),
+        Expr::eq(Expr::column("tightBounds"), false),
         Expr::eq(Expr::column("numRecords"), Expr::column(null_col)),
     )
 }
@@ -38,7 +38,7 @@ fn get_wide_null_expr(null_col: String) -> Expr {
 /// the default for tightBounds being true, so we have to check if it's EITHER `null` OR `true`
 fn get_tight_not_null_expr(null_col: String) -> Expr {
     Expr::and(
-        Expr::distinct(Expr::column("tightBounds"), Expr::literal(false)),
+        Expr::distinct(Expr::column("tightBounds"), false),
         Expr::lt(Expr::column(null_col), Expr::column("numRecords")),
     )
 }
@@ -49,7 +49,7 @@ fn get_tight_not_null_expr(null_col: String) -> Expr {
 /// there is a possibility of a NOT null
 fn get_wide_not_null_expr(null_col: String) -> Expr {
     Expr::and(
-        Expr::eq(Expr::column("tightBounds"), Expr::literal(false)),
+        Expr::eq(Expr::column("tightBounds"), false),
         Expr::ne(Expr::column("numRecords"), Expr::column(null_col)),
     )
 }
@@ -126,14 +126,14 @@ fn as_data_skipping_predicate(expr: &Expr) -> Option<Expr> {
                 }
                 NotEqual => {
                     return Some(Expr::or(
-                        Expr::gt(Column(format!("minValues.{}", col)), Literal(val.clone())),
-                        Expr::lt(Column(format!("maxValues.{}", col)), Literal(val.clone())),
+                        Expr::gt(Column(format!("minValues.{}", col)), val.clone()),
+                        Expr::lt(Column(format!("maxValues.{}", col)), val.clone()),
                     ));
                 }
                 _ => return None, // unsupported operation
             };
             let col = format!("{}.{}", stats_col, col);
-            Some(Expr::binary(op, Column(col), Literal(val.clone())))
+            Some(Expr::binary(op, Column(col), val.clone()))
         }
         // push down Not by inverting everything below it
         UnaryOperation { op: Not, expr } => as_inverted_data_skipping_predicate(expr),
@@ -186,11 +186,10 @@ impl DataSkippingFilter {
         });
         static STATS_EXPR: LazyLock<Expr> = LazyLock::new(|| Expr::column("add.stats"));
         static FILTER_EXPR: LazyLock<Expr> =
-            LazyLock::new(|| Expr::column("predicate").distinct(Expr::literal(false)));
+            LazyLock::new(|| Expr::column("predicate").distinct(false));
 
-        let predicate = match predicate {
-            Some(predicate) => predicate,
-            None => return None,
+        let Some(predicate) = predicate else {
+            return None;
         };
 
         debug!("Creating a data skipping filter for {}", &predicate);

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -496,7 +496,7 @@ fn transform_to_logical_internal(
                         partition_values.get(name),
                         field.data_type(),
                     )?;
-                    Ok::<Expression, Error>(Expression::Literal(value_expression))
+                    Ok::<Expression, Error>(value_expression.into())
                 }
                 ColumnType::Selected(field_name) => Ok(Expression::column(field_name)),
             })

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -905,7 +905,7 @@ fn not_and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn invalid_skips_none_predicates() -> Result<(), Box<dyn std::error::Error>> {
-    let empty_struct = Expression::struct_expr(vec![]);
+    let empty_struct = Expression::struct_from(vec![]);
     let cases = vec![
         (
             Expression::literal(3i64),

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -339,11 +339,7 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
         (NotEqual, 8, vec![&batch2, &batch1]),
     ];
     for (op, value, expected_batches) in test_cases {
-        let predicate = Expression::BinaryOperation {
-            op,
-            left: Box::new(Expression::column("id")),
-            right: Box::new(Expression::literal(value)),
-        };
+        let predicate = Expression::binary(op, Expression::column("id"), value);
         let scan = snapshot
             .clone()
             .scan_builder()

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -654,27 +654,27 @@ fn table_for_numbers(nums: Vec<u32>) -> Vec<String> {
 fn predicate_on_number() -> Result<(), Box<dyn std::error::Error>> {
     let cases = vec![
         (
-            Expression::column("number").lt(Expression::literal(4i64)),
+            Expression::column("number").lt(4i64),
             table_for_numbers(vec![1, 2, 3]),
         ),
         (
-            Expression::column("number").le(Expression::literal(4i64)),
+            Expression::column("number").le(4i64),
             table_for_numbers(vec![1, 2, 3, 4]),
         ),
         (
-            Expression::column("number").gt(Expression::literal(4i64)),
+            Expression::column("number").gt(4i64),
             table_for_numbers(vec![5, 6]),
         ),
         (
-            Expression::column("number").ge(Expression::literal(4i64)),
+            Expression::column("number").ge(4i64),
             table_for_numbers(vec![4, 5, 6]),
         ),
         (
-            Expression::column("number").eq(Expression::literal(4i64)),
+            Expression::column("number").eq(4i64),
             table_for_numbers(vec![4]),
         ),
         (
-            Expression::column("number").ne(Expression::literal(4i64)),
+            Expression::column("number").ne(4i64),
             table_for_numbers(vec![1, 2, 3, 5, 6]),
         ),
     ];
@@ -694,27 +694,27 @@ fn predicate_on_number() -> Result<(), Box<dyn std::error::Error>> {
 fn predicate_on_number_not() -> Result<(), Box<dyn std::error::Error>> {
     let cases = vec![
         (
-            Expression::not(Expression::column("number").lt(Expression::literal(4i64))),
+            Expression::not(Expression::column("number").lt(4i64)),
             table_for_numbers(vec![4, 5, 6]),
         ),
         (
-            Expression::not(Expression::column("number").le(Expression::literal(4i64))),
+            Expression::not(Expression::column("number").le(4i64)),
             table_for_numbers(vec![5, 6]),
         ),
         (
-            Expression::not(Expression::column("number").gt(Expression::literal(4i64))),
+            Expression::not(Expression::column("number").gt(4i64)),
             table_for_numbers(vec![1, 2, 3, 4]),
         ),
         (
-            Expression::not(Expression::column("number").ge(Expression::literal(4i64))),
+            Expression::not(Expression::column("number").ge(4i64)),
             table_for_numbers(vec![1, 2, 3]),
         ),
         (
-            Expression::not(Expression::column("number").eq(Expression::literal(4i64))),
+            Expression::not(Expression::column("number").eq(4i64)),
             table_for_numbers(vec![1, 2, 3, 5, 6]),
         ),
         (
-            Expression::not(Expression::column("number").ne(Expression::literal(4i64))),
+            Expression::not(Expression::column("number").ne(4i64)),
             table_for_numbers(vec![4]),
         ),
     ];
@@ -822,30 +822,26 @@ fn and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
     let cases = vec![
         (
             Expression::column("number")
-                .gt(Expression::literal(4i64))
-                .and(Expression::column("a_float").gt(Expression::literal(5.5))),
+                .gt(4i64)
+                .and(Expression::column("a_float").gt(5.5)),
             table_for_numbers(vec![6]),
         ),
         (
             Expression::column("number")
-                .gt(Expression::literal(4i64))
-                .and(Expression::not(
-                    Expression::column("a_float").gt(Expression::literal(5.5)),
-                )),
+                .gt(4i64)
+                .and(Expression::not(Expression::column("a_float").gt(5.5))),
             table_for_numbers(vec![5]),
         ),
         (
             Expression::column("number")
-                .gt(Expression::literal(4i64))
-                .or(Expression::column("a_float").gt(Expression::literal(5.5))),
+                .gt(4i64)
+                .or(Expression::column("a_float").gt(5.5)),
             table_for_numbers(vec![5, 6]),
         ),
         (
             Expression::column("number")
-                .gt(Expression::literal(4i64))
-                .or(Expression::not(
-                    Expression::column("a_float").gt(Expression::literal(5.5)),
-                )),
+                .gt(4i64)
+                .or(Expression::not(Expression::column("a_float").gt(5.5))),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
     ];
@@ -866,36 +862,32 @@ fn not_and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
         (
             Expression::not(
                 Expression::column("number")
-                    .gt(Expression::literal(4i64))
-                    .and(Expression::column("a_float").gt(Expression::literal(5.5))),
+                    .gt(4i64)
+                    .and(Expression::column("a_float").gt(5.5)),
             ),
             table_for_numbers(vec![1, 2, 3, 4, 5]),
         ),
         (
             Expression::not(
                 Expression::column("number")
-                    .gt(Expression::literal(4i64))
-                    .and(Expression::not(
-                        Expression::column("a_float").gt(Expression::literal(5.5)),
-                    )),
+                    .gt(4i64)
+                    .and(Expression::not(Expression::column("a_float").gt(5.5))),
             ),
             table_for_numbers(vec![1, 2, 3, 4, 6]),
         ),
         (
             Expression::not(
                 Expression::column("number")
-                    .gt(Expression::literal(4i64))
-                    .or(Expression::column("a_float").gt(Expression::literal(5.5))),
+                    .gt(4i64)
+                    .or(Expression::column("a_float").gt(5.5)),
             ),
             table_for_numbers(vec![1, 2, 3, 4]),
         ),
         (
             Expression::not(
                 Expression::column("number")
-                    .gt(Expression::literal(4i64))
-                    .or(Expression::not(
-                        Expression::column("a_float").gt(Expression::literal(5.5)),
-                    )),
+                    .gt(4i64)
+                    .or(Expression::not(Expression::column("a_float").gt(5.5))),
             ),
             vec![],
         ),
@@ -913,31 +905,30 @@ fn not_and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn invalid_skips_none_predicates() -> Result<(), Box<dyn std::error::Error>> {
+    let empty_struct = Expression::struct_expr(vec![]);
     let cases = vec![
         (
             Expression::literal(3i64),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
         (
-            Expression::column("number").distinct(Expression::literal(3i64)),
+            Expression::column("number").distinct(3i64),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
         (
-            Expression::column("number").gt(Expression::struct_expr(vec![])),
+            Expression::column("number").gt(empty_struct.clone()),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
         (
-            Expression::column("number").and(Expression::struct_expr(vec![]).is_null()),
+            Expression::column("number").and(empty_struct.clone().is_null()),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
         (
-            Expression::not(Expression::column("number").gt(Expression::struct_expr(vec![]))),
+            Expression::not(Expression::column("number").gt(empty_struct.clone())),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
         (
-            Expression::not(
-                Expression::column("number").and(Expression::struct_expr(vec![]).is_null()),
-            ),
+            Expression::not(Expression::column("number").and(empty_struct.clone().is_null())),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
     ];
@@ -971,10 +962,7 @@ fn with_predicate_and_removes() -> Result<(), Box<dyn std::error::Error>> {
     read_table_data_str(
         "./tests/data/table-with-dv-small/",
         None,
-        Some(Expression::gt(
-            Expression::column("value"),
-            Expression::literal(3),
-        )),
+        Some(Expression::gt(Expression::column("value"), 3)),
         expected,
     )?;
     Ok(())


### PR DESCRIPTION
Kernel provides quite a few helper methods that make it easier to create expressions, but not all call sites take advantage of them. Fix that.

Also update the various binary operation helpers to accept `impl Into<Expression>` as their RHS arg, which allows further simplifications.