### PR TITLE
remove log_replay_iter and process_batch in scan::log_replay

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -35,10 +35,6 @@ delta-rs
 https://github.com/delta-io/delta-rs/
 Licence: Apache-2.0
 
-either
-https://github.com/bluss/either
-Licence: MIT OR Apache-2.0
-
 fix-hidden-lifetime-bug
 https://github.com/danielhenrymantilla/fix-hidden-lifetime-bug.rs
 Licence: Zlib OR MIT OR Apache-2.0

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -17,7 +17,6 @@ all-features = true
 [dependencies]
 bytes = "1.7"
 chrono = { version = "0.4" }
-either = "1.13"
 fix-hidden-lifetime-bug = "0.2"
 indexmap = "2.5.0"
 itertools = "0.13"

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -2,7 +2,6 @@ use std::clone::Clone;
 use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 
-use either::Either;
 use tracing::debug;
 
 use super::data_skipping::DataSkippingFilter;
@@ -119,46 +118,6 @@ impl LogReplayScanner {
         }
     }
 
-    /// Extract Add actions from a single batch. This will filter out rows that
-    /// don't match the predicate and Add actions that have corresponding Remove
-    /// actions in the log.
-    fn process_batch(
-        &mut self,
-        actions: &dyn EngineData,
-        is_log_batch: bool,
-    ) -> DeltaResult<Vec<Add>> {
-        // apply data skipping to get back a selection vector for actions that passed skipping
-        // note: None implies all files passed data skipping.
-        let selection_vector = self
-            .filter
-            .as_ref()
-            .map(|filter| filter.apply(actions))
-            .transpose()?;
-
-        let adds = self.setup_batch_process(selection_vector, actions, is_log_batch)?;
-
-        adds.into_iter()
-            .filter_map(|(add, _)| {
-                // Note: each (add.path + add.dv_unique_id()) pair has a
-                // unique Add + Remove pair in the log. For example:
-                // https://github.com/delta-io/delta/blob/master/spark/src/test/resources/delta/table-with-dv-large/_delta_log/00000000000000000001.json
-                if !self.seen.contains(&(add.path.clone(), add.dv_unique_id())) {
-                    debug!("Found file: {}, is log {}", &add.path, is_log_batch);
-                    if is_log_batch {
-                        // Remember file actions from this batch so we can ignore duplicates
-                        // as we process batches from older commit and/or checkpoint files. We
-                        // don't need to track checkpoint batches because they are already the
-                        // oldest actions and can never replace anything.
-                        self.seen.insert((add.path.clone(), add.dv_unique_id()));
-                    }
-                    Some(Ok(add))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
     fn get_add_transform_expr(&self) -> Expression {
         Expression::Struct(vec![
             Expression::column("add.path"),
@@ -259,27 +218,6 @@ impl LogReplayScanner {
 
         Ok(visitor.adds)
     }
-}
-
-/// Given an iterator of (engine_data, bool) tuples and a predicate, returns an iterator of `Adds`.
-/// The boolean flag indicates whether the record batch is a log or checkpoint batch.
-pub fn log_replay_iter(
-    engine: &dyn Engine,
-    action_iter: impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send,
-    table_schema: &SchemaRef,
-    predicate: &Option<Expression>,
-) -> impl Iterator<Item = DeltaResult<Add>> {
-    let mut log_scanner = LogReplayScanner::new(engine, table_schema, predicate);
-
-    action_iter.flat_map(move |actions| match actions {
-        Ok((batch, is_log_batch)) => {
-            match log_scanner.process_batch(batch.as_ref(), is_log_batch) {
-                Ok(adds) => Either::Left(adds.into_iter().map(Ok)),
-                Err(err) => Either::Right(std::iter::once(Err(err))),
-            }
-        }
-        Err(err) => Either::Right(std::iter::once(Err(err))),
-    })
 }
 
 /// Given an iterator of (engine_data, bool) tuples and a predicate, returns an iterator of


### PR DESCRIPTION
as titled, leftover code we can clean up. and remove dependency on `either`!