### PR TITLE
[chore] replace panic with .to_compiler_error in macros

### DIFF
--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -109,7 +109,7 @@ fn gen_schema_fields(data: &Data) -> TokenStream {
                     quote_spanned! { field.span() => #(#type_path_quoted),* get_struct_field(stringify!(#name))}
                 }
             }
-            _ => Error::new(field.span(), "Can't handle type: {field.ty:?}").to_compile_error()
+            _ => Error::new(field.span(), format!("Can't handle type: {:?}", field.ty)).to_compile_error()
         }
     });
     quote! { #(#schema_fields),* }

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -98,7 +98,10 @@ fn gen_schema_fields(data: &Data) -> TokenStream {
                 if have_schema_null {
                     if let Some(first_ident) = type_path.path.segments.first().map(|seg| &seg.ident) {
                         if first_ident != "HashMap" {
-                           return Error::new(first_ident.span(), "Can only use drop_null_container_values on HashMap fields, not {first_ident:?}").to_compile_error()
+                           return Error::new(
+                                first_ident.span(),
+                                format!("Can only use drop_null_container_values on HashMap fields, not {first_ident}")
+                            ).to_compile_error()
                         }
                     }
                     quote_spanned! { field.span() => #(#type_path_quoted),* get_nullable_container_struct_field(stringify!(#name))}


### PR DESCRIPTION
Replace `panic!` with `to_compiler_error` in macros.

There seem to be no tests for macros, maybe worth adding but probably deserves a separate issue

resolves #348 