### PR TITLE
Safer FFI string slice handling

### DIFF
--- a/ffi/examples/read-table/arrow.c
+++ b/ffi/examples/read-table/arrow.c
@@ -212,7 +212,8 @@ void c_read_parquet_file(
   ExternResultHandleExclusiveFileReadResultIterator read_res =
     read_parquet_file(context->engine, &meta, context->read_schema);
   if (read_res.tag != OkHandleExclusiveFileReadResultIterator) {
-    printf("Couldn't read data\n");
+    print_error("Couldn't read data.", (Error*) read_res.err);
+    free_error((Error*)read_res.err);
     return;
   }
   if (selection_vector.len > 0) {

--- a/ffi/src/engine_funcs.rs
+++ b/ffi/src/engine_funcs.rs
@@ -103,20 +103,20 @@ pub unsafe extern "C" fn read_parquet_file(
 ) -> ExternResult<Handle<ExclusiveFileReadResultIterator>> {
     let engine = unsafe { engine.clone_as_arc() };
     let physical_schema = unsafe { physical_schema.clone_as_arc() };
-    let path = unsafe { String::try_from_slice(&file.path) };
+    let path = unsafe { TryFromStringSlice::try_from_slice(&file.path) };
     let res = read_parquet_file_impl(engine.clone(), path, file, physical_schema);
     res.into_extern_result(&engine.as_ref())
 }
 
 fn read_parquet_file_impl(
     extern_engine: Arc<dyn ExternEngine>,
-    path: DeltaResult<String>,
+    path: DeltaResult<&str>,
     file: &FileMeta,
     physical_schema: Arc<Schema>,
 ) -> DeltaResult<Handle<ExclusiveFileReadResultIterator>> {
     let engine = extern_engine.engine();
     let parquet_handler = engine.get_parquet_handler();
-    let location = Url::parse(&path?)?;
+    let location = Url::parse(path?)?;
     let delta_fm = delta_kernel::FileMeta {
         location,
         last_modified: file.last_modified,

--- a/ffi/src/expressions/engine.rs
+++ b/ffi/src/expressions/engine.rs
@@ -141,12 +141,12 @@ pub unsafe extern "C" fn visit_expression_column(
     name: KernelStringSlice,
     allocate_error: AllocateErrorFn,
 ) -> ExternResult<usize> {
-    let name = unsafe { String::try_from_slice(&name) };
+    let name = unsafe { TryFromStringSlice::try_from_slice(&name) };
     visit_expression_column_impl(state, name).into_extern_result(&allocate_error)
 }
 fn visit_expression_column_impl(
     state: &mut KernelExpressionVisitorState,
-    name: DeltaResult<String>,
+    name: DeltaResult<&str>,
 ) -> DeltaResult<usize> {
     // TODO: FIXME: This is incorrect if any field name in the column path contains a period.
     let name = ColumnName::new(name?.split('.')).into();

--- a/ffi/src/expressions/kernel.rs
+++ b/ffi/src/expressions/kernel.rs
@@ -275,12 +275,8 @@ pub unsafe extern "C" fn visit_expression(
                 call!(visitor, visit_literal_double, sibling_list_id, *val)
             }
             Scalar::String(val) => {
-                call!(
-                    visitor,
-                    visit_literal_string,
-                    sibling_list_id,
-                    kernel_string_slice!(val)
-                )
+                let val = kernel_string_slice!(val);
+                call!(visitor, visit_literal_string, sibling_list_id, val)
             }
             Scalar::Boolean(val) => call!(visitor, visit_literal_bool, sibling_list_id, *val),
             Scalar::Timestamp(val) => {
@@ -328,12 +324,8 @@ pub unsafe extern "C" fn visit_expression(
             }
             Expression::Column(name) => {
                 let name = name.as_str();
-                call!(
-                    visitor,
-                    visit_column,
-                    sibling_list_id,
-                    kernel_string_slice!(name)
-                )
+                let name = kernel_string_slice!(name);
+                call!(visitor, visit_column, sibling_list_id, name)
             }
             Expression::Struct(exprs) => {
                 visit_expression_struct_expr(visitor, exprs, sibling_list_id)

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -7,7 +7,7 @@ use std::default::Default;
 use std::os::raw::{c_char, c_void};
 use std::ptr::NonNull;
 use std::sync::Arc;
-use tracing::{debug, warn};
+use tracing::debug;
 use url::Url;
 
 use delta_kernel::snapshot::Snapshot;
@@ -646,21 +646,7 @@ pub unsafe extern "C" fn set_builder_option(
     let key = unsafe { String::try_from_slice(&key) };
     let value = unsafe { String::try_from_slice(&value) };
     // TODO: Return ExternalError if key or value is invalid? (builder has an error allocator)
-    let key = match key {
-        Ok(key) => key,
-        Err(err) => {
-            warn!("Ignoring invalid option key: {err}");
-            return;
-        }
-    };
-    let value = match value {
-        Ok(value) => value,
-        Err(err) => {
-            warn!("Ignoring invalid option value: {err}");
-            return;
-        }
-    };
-    builder.set_option(key, value);
+    builder.set_option(key.unwrap(), value.unwrap());
 }
 
 /// Consume the builder and return a `default` engine. After calling, the passed pointer is _no

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -73,83 +73,48 @@ impl Iterator for EngineIterator {
 /// Intentionally not Copy, Clone, Send, nor Sync.
 ///
 /// Whoever instantiates the struct must ensure it does not outlive the data it points to. The
-/// compiler cannot help us here, because raw pointers don't have lifetimes. Meanwhile, the callee
-/// must assume that the slice is only valid until the function returns, and must not retain any
-/// references to the slice or its data that might outlive the function call.
+/// compiler cannot help us here, because raw pointers don't have lifetimes. A good rule of thumb is
+/// to always use the [`kernel_string_slice`] macro to create string slices, and to avoid returning
+/// a string slice from a code block or function.
+///
+/// Meanwhile, the callee must assume that the slice is only valid until the function returns, and
+/// must not retain any references to the slice or its data that might outlive the function call.
 #[repr(C)]
 pub struct KernelStringSlice {
     ptr: *const c_char,
     len: usize,
 }
-
-/// It is not safe to create a kernel string slice directly from a reference, because the compiler
-/// has no way to track lifetimes on the resulting raw pointers. We can't "just" add an explicit
-/// lifetime to the `KernelStringSlice` itself, because that struct has to cross the FFI boundary
-/// where lifetimes mean nothing. To help the compiler out, we define `IntoKernelStringSlice` whose
-/// explicit lifetime matches that of its input, and all kernel rust code that passes string slices
-/// across the FFI boundary converts it `Into` a `KernelStringSlice` as a function argument. That
-/// way, the compiler can prove the `KernelStringSlice` remains valid until the function returns.
-///
-/// For example, this is the intended (safe) usage:
-///
-/// ```
-/// # use delta_kernel_ffi::{IntoKernelStringSlice, KernelStringSlice};
-/// fn wants_slice(slice: KernelStringSlice) { }
-/// let msg = String::from("hello");
-/// wants_slice(IntoKernelStringSlice::from(&msg).into());
-/// ```
-///
-/// While the compiler would correctly reject this unsafe usage that would immediately drop the
-/// unnamed temporary string before the slice could be used:
-///
-/// ```fail_compile
-/// # use delta_kernel_ffi::{IntoKernelStringSlice, KernelStringSlice};
-/// fn wants_slice(slice: KernelStringSlice) { }
-/// wants_slice(IntoKernelStringSlice::from(&String::from("hello")).into());
-/// ```
-///
-/// Without the extra layer of indirection, the compiler could not detect the problem.
-pub(crate) struct IntoKernelStringSlice<'a> {
-    inner: KernelStringSlice,
-    _lifetime: std::marker::PhantomData<&'a ()>,
-}
-
-// We can construct a `KernelStringSlice` from anything that acts like a Rust string slice. The user
-// of this trait is still responsible to ensure the result doesn't outlive the input data tho --
-// especially if it crosses an FFI boundary to or from external code.
-impl<'a> From<&'a [u8]> for IntoKernelStringSlice<'a> {
-    fn from(s: &'a [u8]) -> Self {
+impl KernelStringSlice {
+    /// Creates a new string slice from a source string. This method is dangerous and can easily
+    /// lead to use-after-free scenarios. The [`kernel_string_slice`] macro should be preferred as a
+    /// much safer alternative.
+    ///
+    /// # Safety
+    ///
+    /// Caller affirms that the source will outlive the new slice created from it. The compiler
+    /// cannot help as raw pointers do not have lifetimes that the compiler verify.
+    unsafe pub(crate) fn new_unsafe(source: impl AsRef<str>) -> Self {
+        let source = source.as_ref().as_bytes();
         Self {
-            inner: KernelStringSlice {
-                ptr: s.as_ptr().cast(),
-                len: s.len(),
-            },
-            _lifetime: std::marker::PhantomData,
+            ptr: source.as_ptr().cast(),
+            len: source.len(),
         }
     }
 }
-impl<'a> From<&'a str> for IntoKernelStringSlice<'a> {
-    fn from(s: &'a str) -> Self {
-        IntoKernelStringSlice::from(s.as_bytes())
-    }
+
+/// Creates a new [`KernelStringSlice`] from a source object (which must be an identifier, to ensure
+/// it is not immediately dropped). This is the safest way to create a kernel string slice.
+macro_rules! kernel_string_slice {
+    ( $source:ident ) => {
+        // Safety: A named source cannot immediately go out of scope. Any dangerous situations will
+        // arise from the _use_ of this string slice, not from its creation.
+        #[allow(unused_unsafe)]
+        unsafe {
+            $crate::KernelStringSlice::new_unsafe($source)
+        }
+    };
 }
-impl<'a> From<&'a String> for IntoKernelStringSlice<'a> {
-    fn from(s: &'a String) -> Self {
-        IntoKernelStringSlice::from(s.as_bytes())
-    }
-}
-// We intentionally do not implement `From` because the intended idiom is:
-// ```
-// let slice = IntoKernelStringSlice::from(...);
-// function_wanting_a_slice(slice.into());
-// ```
-// Even `Into` allows usages other than the known-safe one, but `From` would allow even more.
-#[allow(clippy::from_over_into)]
-impl<'a> Into<KernelStringSlice> for IntoKernelStringSlice<'a> {
-    fn into(self) -> KernelStringSlice {
-        self.inner
-    }
-}
+pub(crate) use kernel_string_slice;
 
 trait TryFromStringSlice<'a>: Sized {
     unsafe fn try_from_slice(slice: &'a KernelStringSlice) -> DeltaResult<Self>;
@@ -536,8 +501,7 @@ impl<T> IntoExternResult<T> for DeltaResult<T> {
             Ok(ok) => ExternResult::Ok(ok),
             Err(err) => {
                 let msg = format!("{}", err);
-                let msg = IntoKernelStringSlice::from(msg.as_bytes());
-                let err = unsafe { alloc.allocate_error(err.into(), msg.into()) };
+                let err = unsafe { alloc.allocate_error(err.into(), kernel_string_slice!(msg)) };
                 ExternResult::Err(err)
             }
         }
@@ -830,7 +794,7 @@ pub unsafe extern "C" fn snapshot_table_root(
 ) -> NullableCvoid {
     let snapshot = unsafe { snapshot.as_ref() };
     let table_root = snapshot.table_root().to_string();
-    allocate_fn(IntoKernelStringSlice::from(&table_root).into())
+    allocate_fn(kernel_string_slice!(table_root))
 }
 
 type StringIter = dyn Iterator<Item = String> + Send;
@@ -858,7 +822,7 @@ fn string_slice_next_impl(
 ) -> bool {
     let data = unsafe { data.as_mut() };
     if let Some(data) = data.next() {
-        (engine_visitor)(engine_context, IntoKernelStringSlice::from(&data).into());
+        (engine_visitor)(engine_context, kernel_string_slice!(data));
         true
     } else {
         false

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -75,7 +75,15 @@ impl Iterator for EngineIterator {
 /// Whoever instantiates the struct must ensure it does not outlive the data it points to. The
 /// compiler cannot help us here, because raw pointers don't have lifetimes. A good rule of thumb is
 /// to always use the [`kernel_string_slice`] macro to create string slices, and to avoid returning
-/// a string slice from a code block or function (since the move risks over-extending its lifetime).
+/// a string slice from a code block or function (since the move risks over-extending its lifetime):
+///
+/// ```ignore
+/// # // Ignored because this code is pub(crate) and doc tests cannot compile it
+/// let dangling_slice = {
+///     let tmp = String::from("tmp");
+///     kernel_string_slice!(tmp)
+/// }
+/// ```
 ///
 /// Meanwhile, the callee must assume that the slice is only valid until the function returns, and
 /// must not retain any references to the slice or its data that might outlive the function call.
@@ -96,8 +104,9 @@ impl KernelStringSlice {
     /// verify. Thus, e.g., the following incorrect code would compile and leave `s` dangling,
     /// because the unnamed string arg is dropped as soon as the statement finishes executing.
     ///
-    /// ```
-    /// let s = KernelStringSlice::new_unsafe(String::new("bad").as_str());
+    /// ```ignore
+    /// # // Ignored because this code is pub(crate) and doc tests cannot compile it
+    /// let s = KernelStringSlice::new_unsafe(String::from("bad").as_str());
     /// ```
     pub(crate) unsafe fn new_unsafe(source: &str) -> Self {
         let source = source.as_bytes();

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -17,8 +17,8 @@ use crate::expressions::engine::{
     unwrap_kernel_expression, EnginePredicate, KernelExpressionVisitorState,
 };
 use crate::{
-    AllocateStringFn, ExclusiveEngineData, ExternEngine, ExternResult, IntoExternResult,
-    IntoKernelStringSlice, KernelBoolSlice, KernelRowIndexArray, KernelStringSlice, NullableCvoid,
+    kernel_string_slice, AllocateStringFn, ExclusiveEngineData, ExternEngine, ExternResult,
+    IntoExternResult, KernelBoolSlice, KernelRowIndexArray, KernelStringSlice, NullableCvoid,
     SharedExternEngine, SharedSnapshot, StringIter, StringSliceIterator, TryFromStringSlice,
 };
 
@@ -369,7 +369,7 @@ pub unsafe extern "C" fn get_from_map(
     };
     map.values
         .get(string_key)
-        .and_then(|v| allocate_fn(IntoKernelStringSlice::from(v).into()))
+        .and_then(|v| allocate_fn(kernel_string_slice!(v)))
 }
 
 /// Get a selection vector out of a [`DvInfo`] struct
@@ -444,7 +444,7 @@ fn rust_callback(
     });
     (context.callback)(
         context.engine_context,
-        IntoKernelStringSlice::from(path).into(),
+        kernel_string_slice!(path),
         size,
         stats.as_ref(),
         &dv_info,

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -18,8 +18,8 @@ use crate::expressions::engine::{
 };
 use crate::{
     AllocateStringFn, ExclusiveEngineData, ExternEngine, ExternResult, IntoExternResult,
-    KernelBoolSlice, KernelRowIndexArray, KernelStringSlice, NullableCvoid, SharedExternEngine,
-    SharedSnapshot, StringIter, StringSliceIterator, TryFromStringSlice,
+    IntoKernelStringSlice, KernelBoolSlice, KernelRowIndexArray, KernelStringSlice, NullableCvoid,
+    SharedExternEngine, SharedSnapshot, StringIter, StringSliceIterator, TryFromStringSlice,
 };
 
 use super::handle::Handle;
@@ -369,7 +369,7 @@ pub unsafe extern "C" fn get_from_map(
     };
     map.values
         .get(string_key)
-        .and_then(|v| allocate_fn(v.into()))
+        .and_then(|v| allocate_fn(IntoKernelStringSlice::from(v).into()))
 }
 
 /// Get a selection vector out of a [`DvInfo`] struct
@@ -444,7 +444,7 @@ fn rust_callback(
     });
     (context.callback)(
         context.engine_context,
-        path.into(),
+        IntoKernelStringSlice::from(path).into(),
         size,
         stats.as_ref(),
         &dv_info,

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -10,7 +10,7 @@ use delta_kernel::schema::Schema;
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::{DeltaResult, EngineData, Error};
 use delta_kernel_ffi_macros::handle_descriptor;
-use tracing::{debug, warn};
+use tracing::debug;
 use url::Url;
 
 use crate::expressions::engine::{
@@ -365,17 +365,10 @@ pub unsafe extern "C" fn get_from_map(
     key: KernelStringSlice,
     allocate_fn: AllocateStringFn,
 ) -> NullableCvoid {
-    // TODO: Return ExternResult to caller instead of None?
+    // TODO: Return ExternResult to caller instead of panicking?
     let string_key = unsafe { TryFromStringSlice::try_from_slice(&key) };
-    let string_key = match string_key {
-        Ok(string_key) => string_key,
-        Err(err) => {
-            warn!("Invalid map key: {err}");
-            return None;
-        }
-    };
     map.values
-        .get(string_key)
+        .get(string_key.unwrap())
         .and_then(|v| allocate_fn(kernel_string_slice!(v)))
 }
 
@@ -483,8 +476,6 @@ pub unsafe extern "C" fn visit_scan_data(
         engine_context,
         callback,
     };
-    // TODO: return ExternResult to caller instead of ignoring it?
-    if let Err(e) = visit_scan_files(data, selection_vec, context_wrapper, rust_callback) {
-        warn!("Error visiting scan data: {e}");
-    }
+    // TODO: return ExternResult to caller instead of panicking?
+    visit_scan_files(data, selection_vec, context_wrapper, rust_callback).unwrap();
 }

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -1,6 +1,6 @@
 use std::os::raw::c_void;
 
-use crate::{handle::Handle, KernelStringSlice, SharedSnapshot};
+use crate::{handle::Handle, IntoKernelStringSlice, KernelStringSlice, SharedSnapshot};
 use delta_kernel::schema::{ArrayType, DataType, MapType, PrimitiveType, StructType};
 /// The `EngineSchemaVisitor` defines a visitor system to allow engines to build their own
 /// representation of a schema from a particular schema within kernel.
@@ -170,7 +170,12 @@ pub unsafe extern "C" fn visit_schema(
     ) {
         macro_rules! call {
             ( $visitor_fn:ident $(, $extra_args:expr) *) => {
-                (visitor.$visitor_fn)(visitor.data, sibling_list_id, name.into() $(, $extra_args) *)
+                (visitor.$visitor_fn)(
+                    visitor.data,
+                    sibling_list_id,
+                    IntoKernelStringSlice::from(name).into()
+                    $(, $extra_args) *
+                )
             };
         }
         match data_type {

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -1,6 +1,6 @@
 use std::os::raw::c_void;
 
-use crate::{handle::Handle, IntoKernelStringSlice, KernelStringSlice, SharedSnapshot};
+use crate::{handle::Handle, kernel_string_slice, KernelStringSlice, SharedSnapshot};
 use delta_kernel::schema::{ArrayType, DataType, MapType, PrimitiveType, StructType};
 /// The `EngineSchemaVisitor` defines a visitor system to allow engines to build their own
 /// representation of a schema from a particular schema within kernel.
@@ -173,7 +173,7 @@ pub unsafe extern "C" fn visit_schema(
                 (visitor.$visitor_fn)(
                     visitor.data,
                     sibling_list_id,
-                    IntoKernelStringSlice::from(name).into()
+                    kernel_string_slice!(name)
                     $(, $extra_args) *
                 )
             };


### PR DESCRIPTION
## What changes are proposed in this pull request?

It is easy to create a use-after-free condition when creating kernel string slices from rust strings -- the raw pointers have no lifetime tracking that would allow the compiler to help. Thus, code like this would compile and produce a use-after-free at runtime:
```rust
expects_string_slice(KernelStringSlice::from(&String::from("free me!")))
```
The temporary `String` is freed as soon as `KernelStringSlice::from` returns, and the resulting `KernelStringSlice` is already invalid before `expects_string_slice` receives it. More pernicious cases may not involve any syntactically obvious borrowing:
```rust
expects_string_slice(String::from("free me!").as_str().into())
```
At that point, it's 100% up to the human to recognize the danger and avoid it by materializing the temporary string.

We can't "just" add an explicit lifetime parameter to `KernelStringSlice`, because lifetimes are meaningless when crossing the FFI boundary. Instead, we define a new `kernel_string_slice` macro, which only accepts identifiers as input:
```rust
// Fails to compile - macro rejects input
expects_string_slice(kernel_string_slice!(String::from("free me!").as_str()))

// First line fails to compile - the new string immediately goes out of scope
let s = String::from("free me!").as_str();
expects_string_slice(kernel_string_slice!(s))

// Compiles -- the new string stays in scope
let s = String::from("free me!");
expects_string_slice(kernel_string_slice!(s))
```

How does it work? Named inputs are guaranteed to at least live long enough to create the slice; any dangerous situations must arise from the subsequent _use_ of that slice, such as returning it from the function or code block that owns the source memory (which results in a move that could over-extend the slice lifetime).

Note: There is nothing magical about the macro. It merely enforces the discipline that the input be named, which allows the compiler to verify all lifetimes leading up to the macro invocation.

While we're at it -- add an `impl TryFromStringSlice for &str`, which supports the common case where the caller doesn't need an owned string.

### This PR affects the following public APIs

Removed the (very dangerous) `impl From` for `KernelStringSlice`, and added an `unsafe` constructor instead. Also restrict both the constructor and the macro to crate visibility for now. We can consider a public export if/when the need arises.

## How was this change tested?

Refactor. Compilation + existing tests cover it.