### PR TITLE
ColumnName tracks a path of field names instead of a simple string

### DIFF
--- a/ffi/src/expressions/engine.rs
+++ b/ffi/src/expressions/engine.rs
@@ -41,8 +41,8 @@ pub struct EnginePredicate {
         extern "C" fn(predicate: *mut c_void, state: &mut KernelExpressionVisitorState) -> usize,
 }
 
-fn wrap_expression(state: &mut KernelExpressionVisitorState, expr: Expression) -> usize {
-    state.inflight_expressions.insert(expr)
+fn wrap_expression(state: &mut KernelExpressionVisitorState, expr: impl Into<Expression>) -> usize {
+    state.inflight_expressions.insert(expr.into())
 }
 
 pub fn unwrap_kernel_expression(
@@ -149,7 +149,7 @@ fn visit_expression_column_impl(
     name: DeltaResult<String>,
 ) -> DeltaResult<usize> {
     // TODO: FIXME: This is incorrect if any field name in the column path contains a period.
-    let name = ColumnName::new(name?.split('.')).into();
+    let name = ColumnName::from_naive_str_split(name?);
     Ok(wrap_expression(state, name))
 }
 
@@ -184,7 +184,7 @@ fn visit_expression_literal_string_impl(
     state: &mut KernelExpressionVisitorState,
     value: DeltaResult<String>,
 ) -> DeltaResult<usize> {
-    Ok(wrap_expression(state, Expression::literal(value?)))
+    Ok(wrap_expression(state, value?))
 }
 
 // We need to get parse.expand working to be able to macro everything below, see issue #255
@@ -194,7 +194,7 @@ pub extern "C" fn visit_expression_literal_int(
     state: &mut KernelExpressionVisitorState,
     value: i32,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, value)
 }
 
 #[no_mangle]
@@ -202,7 +202,7 @@ pub extern "C" fn visit_expression_literal_long(
     state: &mut KernelExpressionVisitorState,
     value: i64,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, value)
 }
 
 #[no_mangle]
@@ -210,7 +210,7 @@ pub extern "C" fn visit_expression_literal_short(
     state: &mut KernelExpressionVisitorState,
     value: i16,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, value)
 }
 
 #[no_mangle]
@@ -218,7 +218,7 @@ pub extern "C" fn visit_expression_literal_byte(
     state: &mut KernelExpressionVisitorState,
     value: i8,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, value)
 }
 
 #[no_mangle]
@@ -226,7 +226,7 @@ pub extern "C" fn visit_expression_literal_float(
     state: &mut KernelExpressionVisitorState,
     value: f32,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, value)
 }
 
 #[no_mangle]
@@ -234,7 +234,7 @@ pub extern "C" fn visit_expression_literal_double(
     state: &mut KernelExpressionVisitorState,
     value: f64,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, value)
 }
 
 #[no_mangle]
@@ -242,5 +242,5 @@ pub extern "C" fn visit_expression_literal_bool(
     state: &mut KernelExpressionVisitorState,
     value: bool,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, value)
 }

--- a/ffi/src/expressions/kernel.rs
+++ b/ffi/src/expressions/kernel.rs
@@ -321,7 +321,13 @@ pub unsafe extern "C" fn visit_expression(
                 visit_expression_scalar(visitor, scalar, sibling_list_id)
             }
             Expression::Column(name) => {
-                call!(visitor, visit_column, sibling_list_id, name.as_str().into())
+                // TODO: Support nested columns properly!
+                call!(
+                    visitor,
+                    visit_column,
+                    sibling_list_id,
+                    name.to_string_lossy().into()
+                )
             }
             Expression::Struct(exprs) => {
                 visit_expression_struct_expr(visitor, exprs, sibling_list_id)

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -2,9 +2,8 @@ use std::sync::{Arc, LazyLock};
 
 use crate::actions::visitors::SetTransactionVisitor;
 use crate::actions::{get_log_schema, SetTransaction, SET_TRANSACTION_NAME};
-use crate::expressions::column_expr;
 use crate::snapshot::Snapshot;
-use crate::{DeltaResult, Engine, EngineData, ExpressionRef, SchemaRef};
+use crate::{DeltaResult, Engine, EngineData, Expression as Expr, ExpressionRef, SchemaRef};
 
 pub use crate::actions::visitors::SetTransactionMap;
 pub struct SetTransactionScanner {
@@ -53,8 +52,11 @@ impl SetTransactionScanner {
         // checkpoint part when patitioned by `add.path` like the Delta spec requires. There's no
         // point filtering by a particular app id, even if we have one, because app ids are all in
         // the a single checkpoint part having large min/max range (because they're usually uuids).
-        static META_PREDICATE: LazyLock<Option<ExpressionRef>> =
-            LazyLock::new(|| Some(Arc::new(column_expr!("txn.appId").is_not_null())));
+        static META_PREDICATE: LazyLock<Option<ExpressionRef>> = LazyLock::new(|| {
+            Some(Arc::new(
+                Expr::column([SET_TRANSACTION_NAME, "appId"]).is_not_null(),
+            ))
+        });
         self.snapshot
             .log_segment
             .replay(engine, schema.clone(), schema, META_PREDICATE.clone())

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -1,12 +1,12 @@
 //! An implementation of parquet row group skipping using data skipping predicates over footer stats.
-use crate::engine::parquet_stats_skipping::{col_name_to_path, ParquetStatsSkippingFilter};
-use crate::expressions::{Expression, Scalar};
+use crate::engine::parquet_stats_skipping::ParquetStatsSkippingFilter;
+use crate::expressions::{ColumnName, Expression, Scalar};
 use crate::schema::{DataType, PrimitiveType};
 use chrono::{DateTime, Days};
 use parquet::arrow::arrow_reader::ArrowReaderBuilder;
 use parquet::file::metadata::RowGroupMetaData;
 use parquet::file::statistics::Statistics;
-use parquet::schema::types::{ColumnDescPtr, ColumnPath};
+use parquet::schema::types::ColumnDescPtr;
 use std::collections::{HashMap, HashSet};
 use tracing::debug;
 
@@ -41,7 +41,7 @@ impl<T> ParquetRowGroupSkipping for ArrowReaderBuilder<T> {
 /// corresponding field index, for O(1) stats lookups.
 struct RowGroupFilter<'a> {
     row_group: &'a RowGroupMetaData,
-    field_indices: HashMap<ColumnPath, usize>,
+    field_indices: HashMap<ColumnName, usize>,
 }
 
 impl<'a> RowGroupFilter<'a> {
@@ -59,7 +59,7 @@ impl<'a> RowGroupFilter<'a> {
     }
 
     /// Returns `None` if the column doesn't exist and `Some(None)` if the column has no stats.
-    fn get_stats(&self, col: &ColumnPath) -> Option<Option<&Statistics>> {
+    fn get_stats(&self, col: &ColumnName) -> Option<Option<&Statistics>> {
         self.field_indices
             .get(col)
             .map(|&i| self.row_group.column(i).statistics())
@@ -93,7 +93,7 @@ impl<'a> ParquetStatsSkippingFilter for RowGroupFilter<'a> {
     // NOTE: This code is highly redundant with [`get_max_stat_value`] below, but parquet
     // ValueStatistics<T> requires T to impl a private trait, so we can't factor out any kind of
     // helper method. And macros are hard enough to read that it's not worth defining one.
-    fn get_min_stat_value(&self, col: &ColumnPath, data_type: &DataType) -> Option<Scalar> {
+    fn get_min_stat_value(&self, col: &ColumnName, data_type: &DataType) -> Option<Scalar> {
         use PrimitiveType::*;
         let value = match (data_type.as_primitive_opt()?, self.get_stats(col)??) {
             (String, Statistics::ByteArray(s)) => s.min_opt()?.as_utf8().ok()?.into(),
@@ -135,7 +135,7 @@ impl<'a> ParquetStatsSkippingFilter for RowGroupFilter<'a> {
         Some(value)
     }
 
-    fn get_max_stat_value(&self, col: &ColumnPath, data_type: &DataType) -> Option<Scalar> {
+    fn get_max_stat_value(&self, col: &ColumnName, data_type: &DataType) -> Option<Scalar> {
         use PrimitiveType::*;
         let value = match (data_type.as_primitive_opt()?, self.get_stats(col)??) {
             (String, Statistics::ByteArray(s)) => s.max_opt()?.as_utf8().ok()?.into(),
@@ -177,7 +177,7 @@ impl<'a> ParquetStatsSkippingFilter for RowGroupFilter<'a> {
         Some(value)
     }
 
-    fn get_nullcount_stat_value(&self, col: &ColumnPath) -> Option<i64> {
+    fn get_nullcount_stat_value(&self, col: &ColumnName) -> Option<i64> {
         // NOTE: Stats for any given column are optional, which may produce a NULL nullcount. But if
         // the column itself is missing, then we know all values are implied to be NULL.
         //
@@ -221,13 +221,13 @@ impl<'a> ParquetStatsSkippingFilter for RowGroupFilter<'a> {
 pub(crate) fn compute_field_indices(
     fields: &[ColumnDescPtr],
     expression: &Expression,
-) -> HashMap<ColumnPath, usize> {
-    fn do_recurse(expression: &Expression, cols: &mut HashSet<ColumnPath>) {
+) -> HashMap<ColumnName, usize> {
+    fn do_recurse(expression: &Expression, cols: &mut HashSet<ColumnName>) {
         use Expression::*;
         let mut recurse = |expr| do_recurse(expr, cols); // simplifies the call sites below
         match expression {
             Literal(_) => {}
-            Column(name) => cols.extend([col_name_to_path(name)]), // returns `()`, unlike `insert`
+            Column(name) => cols.extend([name.clone()]), // returns `()`, unlike `insert`
             Struct(fields) => fields.iter().for_each(recurse),
             UnaryOperation { expr, .. } => recurse(expr),
             BinaryOperation { left, right, .. } => [left, right].iter().for_each(|e| recurse(e)),
@@ -245,6 +245,10 @@ pub(crate) fn compute_field_indices(
     fields
         .iter()
         .enumerate()
-        .filter_map(|(i, f)| requested_columns.take(f.path()).map(|path| (path, i)))
+        .filter_map(|(i, f)| {
+            requested_columns
+                .take(f.path().parts())
+                .map(|path| (path, i))
+        })
         .collect()
 }

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::expressions::column_expr;
+use crate::expressions::{column_name, column_expr};
 use crate::Expression;
 use parquet::arrow::arrow_reader::ArrowReaderMetadata;
 use std::fs::File;
@@ -62,57 +62,57 @@ fn test_get_stat_values() {
 
     // Only the BOOL column has any nulls
     assert_eq!(
-        filter.get_nullcount_stat_value(&col_name_to_path("bool")),
+        filter.get_nullcount_stat_value(&column_name!("bool")),
         Some(3)
     );
     assert_eq!(
-        filter.get_nullcount_stat_value(&col_name_to_path("varlen.utf8")),
+        filter.get_nullcount_stat_value(&column_name!("varlen.utf8")),
         Some(0)
     );
 
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("varlen.utf8"), &DataType::STRING),
+        filter.get_min_stat_value(&column_name!("varlen.utf8"), &DataType::STRING),
         Some("a".into())
     );
 
     // CHEAT: Interpret the decimal128 column's fixed-length binary as a string
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.decimals.decimal128"),
+            &column_name!("numeric.decimals.decimal128"),
             &DataType::STRING
         ),
         Some("\0\0\0\0\0\0\0\0\0\0\0\0+x".into())
     );
 
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("numeric.ints.int64"), &DataType::LONG),
+        filter.get_min_stat_value(&column_name!("numeric.ints.int64"), &DataType::LONG),
         Some(1000000000i64.into())
     );
 
     // type widening!
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("numeric.ints.int32"), &DataType::LONG),
+        filter.get_min_stat_value(&column_name!("numeric.ints.int32"), &DataType::LONG),
         Some(1000000i64.into())
     );
 
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("numeric.ints.int32"), &DataType::INTEGER),
+        filter.get_min_stat_value(&column_name!("numeric.ints.int32"), &DataType::INTEGER),
         Some(1000000i32.into())
     );
 
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("numeric.ints.int16"), &DataType::SHORT),
+        filter.get_min_stat_value(&column_name!("numeric.ints.int16"), &DataType::SHORT),
         Some(1000i16.into())
     );
 
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("numeric.ints.int8"), &DataType::BYTE),
+        filter.get_min_stat_value(&column_name!("numeric.ints.int8"), &DataType::BYTE),
         Some(0i8.into())
     );
 
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.floats.float64"),
+            &column_name!("numeric.floats.float64"),
             &DataType::DOUBLE
         ),
         Some(1147f64.into())
@@ -121,7 +121,7 @@ fn test_get_stat_values() {
     // type widening!
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.floats.float32"),
+            &column_name!("numeric.floats.float32"),
             &DataType::DOUBLE
         ),
         Some(139f64.into())
@@ -129,26 +129,26 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.floats.float32"),
+            &column_name!("numeric.floats.float32"),
             &DataType::FLOAT
         ),
         Some(139f32.into())
     );
 
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("bool"), &DataType::BOOLEAN),
+        filter.get_min_stat_value(&column_name!("bool"), &DataType::BOOLEAN),
         Some(false.into())
     );
 
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("varlen.binary"), &DataType::BINARY),
+        filter.get_min_stat_value(&column_name!("varlen.binary"), &DataType::BINARY),
         Some([].as_slice().into())
     );
 
     // CHEAT: Interpret the decimal128 column's fixed-len array as binary
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.decimals.decimal128"),
+            &column_name!("numeric.decimals.decimal128"),
             &DataType::BINARY
         ),
         Some(
@@ -160,7 +160,7 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.decimals.decimal32"),
+            &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(8, 3).unwrap()
         ),
         Some(Scalar::Decimal(11032, 8, 3))
@@ -168,7 +168,7 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.decimals.decimal64"),
+            &column_name!("numeric.decimals.decimal64"),
             &DataType::decimal(16, 3).unwrap()
         ),
         Some(Scalar::Decimal(11064, 16, 3))
@@ -177,7 +177,7 @@ fn test_get_stat_values() {
     // type widening!
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.decimals.decimal32"),
+            &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(16, 3).unwrap()
         ),
         Some(Scalar::Decimal(11032, 16, 3))
@@ -185,7 +185,7 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.decimals.decimal128"),
+            &column_name!("numeric.decimals.decimal128"),
             &DataType::decimal(32, 3).unwrap()
         ),
         Some(Scalar::Decimal(11128, 32, 3))
@@ -194,7 +194,7 @@ fn test_get_stat_values() {
     // type widening!
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.decimals.decimal64"),
+            &column_name!("numeric.decimals.decimal64"),
             &DataType::decimal(32, 3).unwrap()
         ),
         Some(Scalar::Decimal(11064, 32, 3))
@@ -203,26 +203,26 @@ fn test_get_stat_values() {
     // type widening!
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("numeric.decimals.decimal32"),
+            &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(32, 3).unwrap()
         ),
         Some(Scalar::Decimal(11032, 32, 3))
     );
 
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("chrono.date32"), &DataType::DATE),
+        filter.get_min_stat_value(&column_name!("chrono.date32"), &DataType::DATE),
         Some(PrimitiveType::Date.parse_scalar("1971-01-01").unwrap())
     );
 
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("chrono.timestamp"), &DataType::TIMESTAMP),
+        filter.get_min_stat_value(&column_name!("chrono.timestamp"), &DataType::TIMESTAMP),
         None // Timestamp defaults to 96-bit, which doesn't get stats
     );
 
     // CHEAT: Interpret the timestamp_ntz column as a normal timestamp
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("chrono.timestamp_ntz"),
+            &column_name!("chrono.timestamp_ntz"),
             &DataType::TIMESTAMP
         ),
         Some(
@@ -234,7 +234,7 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_min_stat_value(
-            &col_name_to_path("chrono.timestamp_ntz"),
+            &column_name!("chrono.timestamp_ntz"),
             &DataType::TIMESTAMP_NTZ
         ),
         Some(
@@ -246,7 +246,10 @@ fn test_get_stat_values() {
 
     // type widening!
     assert_eq!(
-        filter.get_min_stat_value(&col_name_to_path("chrono.date32"), &DataType::TIMESTAMP_NTZ),
+        filter.get_min_stat_value(
+            &column_name!("chrono.date32"),
+            &DataType::TIMESTAMP_NTZ
+        ),
         Some(
             PrimitiveType::TimestampNtz
                 .parse_scalar("1971-01-01 00:00:00.000000")
@@ -255,48 +258,48 @@ fn test_get_stat_values() {
     );
 
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("varlen.utf8"), &DataType::STRING),
+        filter.get_max_stat_value(&column_name!("varlen.utf8"), &DataType::STRING),
         Some("e".into())
     );
 
     // CHEAT: Interpret the decimal128 column's fixed-length binary as a string
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.decimals.decimal128"),
+            &column_name!("numeric.decimals.decimal128"),
             &DataType::STRING
         ),
         Some("\0\0\0\0\0\0\0\0\0\0\0\0;\u{18}".into())
     );
 
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("numeric.ints.int64"), &DataType::LONG),
+        filter.get_max_stat_value(&column_name!("numeric.ints.int64"), &DataType::LONG),
         Some(1000000004i64.into())
     );
 
     // type widening!
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("numeric.ints.int32"), &DataType::LONG),
+        filter.get_max_stat_value(&column_name!("numeric.ints.int32"), &DataType::LONG),
         Some(1000004i64.into())
     );
 
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("numeric.ints.int32"), &DataType::INTEGER),
+        filter.get_max_stat_value(&column_name!("numeric.ints.int32"), &DataType::INTEGER),
         Some(1000004.into())
     );
 
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("numeric.ints.int16"), &DataType::SHORT),
+        filter.get_max_stat_value(&column_name!("numeric.ints.int16"), &DataType::SHORT),
         Some(1004i16.into())
     );
 
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("numeric.ints.int8"), &DataType::BYTE),
+        filter.get_max_stat_value(&column_name!("numeric.ints.int8"), &DataType::BYTE),
         Some(4i8.into())
     );
 
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.floats.float64"),
+            &column_name!("numeric.floats.float64"),
             &DataType::DOUBLE
         ),
         Some(1125899906842747f64.into())
@@ -305,7 +308,7 @@ fn test_get_stat_values() {
     // type widening!
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.floats.float32"),
+            &column_name!("numeric.floats.float32"),
             &DataType::DOUBLE
         ),
         Some(1048699f64.into())
@@ -313,26 +316,26 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.floats.float32"),
+            &column_name!("numeric.floats.float32"),
             &DataType::FLOAT
         ),
         Some(1048699f32.into())
     );
 
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("bool"), &DataType::BOOLEAN),
+        filter.get_max_stat_value(&column_name!("bool"), &DataType::BOOLEAN),
         Some(true.into())
     );
 
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("varlen.binary"), &DataType::BINARY),
+        filter.get_max_stat_value(&column_name!("varlen.binary"), &DataType::BINARY),
         Some([0, 0, 0, 0].as_slice().into())
     );
 
     // CHEAT: Interpret the decimal128 columns' fixed-len array as binary
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.decimals.decimal128"),
+            &column_name!("numeric.decimals.decimal128"),
             &DataType::BINARY
         ),
         Some(
@@ -344,7 +347,7 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.decimals.decimal32"),
+            &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(8, 3).unwrap()
         ),
         Some(Scalar::Decimal(15032, 8, 3))
@@ -352,7 +355,7 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.decimals.decimal64"),
+            &column_name!("numeric.decimals.decimal64"),
             &DataType::decimal(16, 3).unwrap()
         ),
         Some(Scalar::Decimal(15064, 16, 3))
@@ -361,7 +364,7 @@ fn test_get_stat_values() {
     // type widening!
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.decimals.decimal32"),
+            &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(16, 3).unwrap()
         ),
         Some(Scalar::Decimal(15032, 16, 3))
@@ -369,7 +372,7 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.decimals.decimal128"),
+            &column_name!("numeric.decimals.decimal128"),
             &DataType::decimal(32, 3).unwrap()
         ),
         Some(Scalar::Decimal(15128, 32, 3))
@@ -378,7 +381,7 @@ fn test_get_stat_values() {
     // type widening!
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.decimals.decimal64"),
+            &column_name!("numeric.decimals.decimal64"),
             &DataType::decimal(32, 3).unwrap()
         ),
         Some(Scalar::Decimal(15064, 32, 3))
@@ -387,26 +390,26 @@ fn test_get_stat_values() {
     // type widening!
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("numeric.decimals.decimal32"),
+            &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(32, 3).unwrap()
         ),
         Some(Scalar::Decimal(15032, 32, 3))
     );
 
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("chrono.date32"), &DataType::DATE),
+        filter.get_max_stat_value(&column_name!("chrono.date32"), &DataType::DATE),
         Some(PrimitiveType::Date.parse_scalar("1971-01-05").unwrap())
     );
 
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("chrono.timestamp"), &DataType::TIMESTAMP),
+        filter.get_max_stat_value(&column_name!("chrono.timestamp"), &DataType::TIMESTAMP),
         None // Timestamp defaults to 96-bit, which doesn't get stats
     );
 
     // CHEAT: Interpret the timestamp_ntz column as a normal timestamp
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("chrono.timestamp_ntz"),
+            &column_name!("chrono.timestamp_ntz"),
             &DataType::TIMESTAMP
         ),
         Some(
@@ -418,7 +421,7 @@ fn test_get_stat_values() {
 
     assert_eq!(
         filter.get_max_stat_value(
-            &col_name_to_path("chrono.timestamp_ntz"),
+            &column_name!("chrono.timestamp_ntz"),
             &DataType::TIMESTAMP_NTZ
         ),
         Some(
@@ -430,7 +433,10 @@ fn test_get_stat_values() {
 
     // type widening!
     assert_eq!(
-        filter.get_max_stat_value(&col_name_to_path("chrono.date32"), &DataType::TIMESTAMP_NTZ),
+        filter.get_max_stat_value(
+            &column_name!("chrono.date32"),
+            &DataType::TIMESTAMP_NTZ
+        ),
         Some(
             PrimitiveType::TimestampNtz
                 .parse_scalar("1971-01-05 00:00:00.000000")

--- a/kernel/src/engine/parquet_stats_skipping/tests.rs
+++ b/kernel/src/engine/parquet_stats_skipping/tests.rs
@@ -1,19 +1,19 @@
 use super::*;
-use crate::expressions::{column_expr, ArrayData, StructData};
+use crate::expressions::{column_expr, column_name, ArrayData, StructData};
 use crate::schema::ArrayType;
 use crate::DataType;
 
 struct UnimplementedTestFilter;
 impl ParquetStatsSkippingFilter for UnimplementedTestFilter {
-    fn get_min_stat_value(&self, _col: &ColumnPath, _data_type: &DataType) -> Option<Scalar> {
+    fn get_min_stat_value(&self, _col: &ColumnName, _data_type: &DataType) -> Option<Scalar> {
         unimplemented!()
     }
 
-    fn get_max_stat_value(&self, _col: &ColumnPath, _data_type: &DataType) -> Option<Scalar> {
+    fn get_max_stat_value(&self, _col: &ColumnName, _data_type: &DataType) -> Option<Scalar> {
         unimplemented!()
     }
 
-    fn get_nullcount_stat_value(&self, _col: &ColumnPath) -> Option<i64> {
+    fn get_nullcount_stat_value(&self, _col: &ColumnName) -> Option<i64> {
         unimplemented!()
     }
 
@@ -313,15 +313,15 @@ impl MinMaxTestFilter {
     }
 }
 impl ParquetStatsSkippingFilter for MinMaxTestFilter {
-    fn get_min_stat_value(&self, _col: &ColumnPath, data_type: &DataType) -> Option<Scalar> {
+    fn get_min_stat_value(&self, _col: &ColumnName, data_type: &DataType) -> Option<Scalar> {
         Self::get_stat_value(&self.min, data_type)
     }
 
-    fn get_max_stat_value(&self, _col: &ColumnPath, data_type: &DataType) -> Option<Scalar> {
+    fn get_max_stat_value(&self, _col: &ColumnName, data_type: &DataType) -> Option<Scalar> {
         Self::get_stat_value(&self.max, data_type)
     }
 
-    fn get_nullcount_stat_value(&self, _col: &ColumnPath) -> Option<i64> {
+    fn get_nullcount_stat_value(&self, _col: &ColumnName) -> Option<i64> {
         unimplemented!()
     }
 
@@ -715,15 +715,15 @@ impl NullCountTestFilter {
     }
 }
 impl ParquetStatsSkippingFilter for NullCountTestFilter {
-    fn get_min_stat_value(&self, _col: &ColumnPath, _data_type: &DataType) -> Option<Scalar> {
+    fn get_min_stat_value(&self, _col: &ColumnName, _data_type: &DataType) -> Option<Scalar> {
         unimplemented!()
     }
 
-    fn get_max_stat_value(&self, _col: &ColumnPath, _data_type: &DataType) -> Option<Scalar> {
+    fn get_max_stat_value(&self, _col: &ColumnName, _data_type: &DataType) -> Option<Scalar> {
         unimplemented!()
     }
 
-    fn get_nullcount_stat_value(&self, _col: &ColumnPath) -> Option<i64> {
+    fn get_nullcount_stat_value(&self, _col: &ColumnName) -> Option<i64> {
         self.nullcount
     }
 
@@ -771,17 +771,20 @@ fn test_bool_col() {
     const FALSE: Scalar = Boolean(false);
     for inverted in [false, true] {
         expect_eq!(
-            MinMaxTestFilter::new(TRUE.into(), TRUE.into()).apply_column("x", inverted),
+            MinMaxTestFilter::new(TRUE.into(), TRUE.into())
+                .apply_column(&column_name!("x"), inverted),
             Some(!inverted),
             "x as boolean (min: TRUE, max: TRUE, inverted: {inverted})"
         );
         expect_eq!(
-            MinMaxTestFilter::new(FALSE.into(), TRUE.into()).apply_column("x", inverted),
+            MinMaxTestFilter::new(FALSE.into(), TRUE.into())
+                .apply_column(&column_name!("x"), inverted),
             Some(true),
             "x as boolean (min: FALSE, max: TRUE, inverted: {inverted})"
         );
         expect_eq!(
-            MinMaxTestFilter::new(FALSE.into(), FALSE.into()).apply_column("x", inverted),
+            MinMaxTestFilter::new(FALSE.into(), FALSE.into())
+                .apply_column(&column_name!("x"), inverted),
             Some(inverted),
             "x as boolean (min: FALSE, max: FALSE, inverted: {inverted})"
         );
@@ -790,15 +793,15 @@ fn test_bool_col() {
 
 struct AllNullTestFilter;
 impl ParquetStatsSkippingFilter for AllNullTestFilter {
-    fn get_min_stat_value(&self, _col: &ColumnPath, _data_type: &DataType) -> Option<Scalar> {
+    fn get_min_stat_value(&self, _col: &ColumnName, _data_type: &DataType) -> Option<Scalar> {
         None
     }
 
-    fn get_max_stat_value(&self, _col: &ColumnPath, _data_type: &DataType) -> Option<Scalar> {
+    fn get_max_stat_value(&self, _col: &ColumnName, _data_type: &DataType) -> Option<Scalar> {
         None
     }
 
-    fn get_nullcount_stat_value(&self, _col: &ColumnPath) -> Option<i64> {
+    fn get_nullcount_stat_value(&self, _col: &ColumnName) -> Option<i64> {
         Some(self.get_rowcount_stat_value())
     }
 

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -3,19 +3,36 @@ use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 /// A (possibly nested) column name.
-// TODO: Track name as a path rather than a single string
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct ColumnName {
-    path: String,
+    path: Vec<String>,
 }
 
 impl ColumnName {
     /// Constructs a new column name from an iterator of field names. The field names are joined
     /// together to make a single path.
-    pub fn new(path: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        let path: Vec<_> = path.into_iter().map(Into::into).collect();
-        let path = path.join(".");
-        Self { path }
+    pub fn new<A, T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = A>,
+        Self: FromIterator<A>,
+    {
+        iter.into_iter().collect()
+    }
+
+    /// Naively splits a string at dots to create a column name.
+    ///
+    /// This method is _NOT_ recommended for production use, as it does not attempt to interpret
+    /// special characters in field names. For example, many systems would interpret the field name
+    /// `"a.b".c` as equivalent to `ColumnName::new(["\"a.b\"", "c"])` (two fields), but this method
+    /// would return the equivalent of `ColumnName::new(["\"a", "b\"", "c"])` (three fields).
+    pub fn from_naive_str_split(name: impl AsRef<str>) -> Self {
+        Self::new(name.as_ref().split('.'))
+    }
+
+    /// Naively converts a column name into a string by joining its fields with dots. This is a
+    /// potentially lossy conversion if any field name contains a dot or other special characters.
+    pub fn to_string_lossy(&self) -> String {
+        self.path.join(".")
     }
 
     /// Joins this column with another, concatenating their fields into a single nested column path.
@@ -36,12 +53,12 @@ impl ColumnName {
     }
 
     /// The path of field names for this column name
-    pub fn path(&self) -> &String {
+    pub fn path(&self) -> &[String] {
         &self.path
     }
 
     /// Consumes this column name and returns the path of field names.
-    pub fn into_inner(self) -> String {
+    pub fn into_inner(self) -> Vec<String> {
         self.path
     }
 }
@@ -49,41 +66,47 @@ impl ColumnName {
 /// Creates a new column name from a path of field names. Each field name is taken as-is, and may
 /// contain arbitrary characters (including periods, spaces, etc.).
 impl<A: Into<String>> FromIterator<A> for ColumnName {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = A>,
-    {
-        Self::new(iter)
+    fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
+        let path = iter.into_iter().map(|s| s.into()).collect();
+        Self { path }
     }
 }
 
 /// Creates a new column name by joining multiple column names together.
 impl FromIterator<ColumnName> for ColumnName {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = ColumnName>,
-    {
-        Self::new(iter.into_iter().map(ColumnName::into_inner))
+    fn from_iter<T: IntoIterator<Item = ColumnName>>(iter: T) -> Self {
+        let path = iter.into_iter().flat_map(|c| c.into_iter()).collect();
+        Self { path }
+    }
+}
+
+impl IntoIterator for ColumnName {
+    type Item = String;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.path.into_iter()
     }
 }
 
 impl Display for ColumnName {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        (**self).fmt(f)
+        // TODO: Handle non-simple field names better?
+        f.write_str(&self.to_string_lossy())
     }
 }
 
 impl Deref for ColumnName {
-    type Target = String;
+    type Target = [String];
 
-    fn deref(&self) -> &String {
+    fn deref(&self) -> &[String] {
         &self.path
     }
 }
 
 // Allows searching collections of `ColumnName` without an owned key value
-impl Borrow<String> for ColumnName {
-    fn borrow(&self) -> &String {
+impl Borrow<[String]> for ColumnName {
+    fn borrow(&self) -> &[String] {
         self
     }
 }
@@ -94,8 +117,8 @@ impl Borrow<String> for ColumnName {
 //
 // [1] https://doc.rust-lang.org/std/cmp/trait.Eq.html#impl-Eq-for-%26A
 // [2] https://doc.rust-lang.org/std/hash/trait.Hash.html#impl-Hash-for-%26T
-impl Borrow<String> for &ColumnName {
-    fn borrow(&self) -> &String {
+impl Borrow<[String]> for &ColumnName {
+    fn borrow(&self) -> &[String] {
         self
     }
 }
@@ -103,6 +126,131 @@ impl Borrow<String> for &ColumnName {
 impl Hash for ColumnName {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         (**self).hash(hasher)
+    }
+}
+
+/// A wrapper for `ColumnName` that pretty-prints the column name with fields delimited by periods
+/// and enclosed in square brackets, e.g. `column_name!("a.b.c")` would print as `"[a].[b].[c]"`.
+// TODO: Marked as test-only for now, as a demonstration. Should this be Display for ColumnName, so
+// `ColumnName::new(["a", "b.c", "d"])` would print as `"a.[b.c].d"` instead of merely `"a.b.c.d"`?
+#[cfg(test)]
+struct FancyColumnName(ColumnName);
+
+#[cfg(test)]
+impl Display for FancyColumnName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut delim = None;
+        for s in self.0.iter() {
+            use std::fmt::Write as _;
+
+            // Only emit the period delimiter after the first iteration
+            if let Some(d) = delim {
+                f.write_char(d)?;
+            } else {
+                delim = Some('.');
+            }
+
+            if s.is_empty() || s.contains(|c: char| !c.is_ascii_alphanumeric() && c != '_') {
+                // Special situation detected. For safety, surround the field name with brackets
+                // (with proper escaping if the field name itself contains brackets).
+                f.write_char('[')?;
+                for c in s.chars() {
+                    match c {
+                        ']' => f.write_str("]]")?,
+                        _ => f.write_char(c)?,
+                    }
+                }
+                f.write_char(']')?;
+            } else {
+                // The fild name contains no special characters, so emit it as-is.
+                f.write_str(s)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+use crate::error::{DeltaResult, Error};
+
+/// Parses a column name from a string. Field names are separated by dots. Field names enclosed in
+/// square brackets may contain arbitrary characters, including periods and spaces. To include a
+/// literal square bracket in a field name, escape it by doubling it, e.g. `"[foo]]bar]"` would
+/// parse as `foo]bar`.
+// TODO: Marked as test-only for now, as a demonstration. Should we officially support it?
+#[cfg(test)]
+impl std::str::FromStr for ColumnName {
+    type Err = Error;
+
+    fn from_str(s: &str) -> DeltaResult<Self> {
+        column_name_from_str(s)
+    }
+}
+
+/// See `impl FromStr for ColumnName`.
+#[cfg(test)]
+fn column_name_from_str(s: &str) -> DeltaResult<ColumnName> {
+    type Chars<'a> = std::iter::Peekable<std::str::Chars<'a>>;
+
+    fn parse_simple(chars: &mut Chars<'_>) -> DeltaResult<(String, bool)> {
+        let mut name = String::new();
+        let mut allow_digits = false; // first character cannot be a digit
+        for c in chars {
+            match c {
+                '_' | 'a'..='z' | 'A'..='Z' => name.push(c),
+                '0'..='9' if allow_digits => name.push(c),
+                '.' => return Ok((name, false)),
+                _ => {
+                    return Err(Error::generic(format!(
+                        "Invalid character '{c}' in unescaped field name"
+                    )))
+                }
+            };
+            allow_digits = true;
+        }
+        Ok((name, true)) // EOF
+    }
+
+    fn parse_escaped(chars: &mut Chars<'_>) -> DeltaResult<(String, bool)> {
+        let mut name = String::new();
+        while let Some(c) = chars.next() {
+            match c {
+                ']' => match chars.next() {
+                    Some(']') => name.push(']'), // escaped delimiter (keep going)
+                    Some('.') => return Ok((name, false)),
+                    Some(c) => {
+                        return Err(Error::generic(format!(
+                            "Invalid character '{c}' after field name"
+                        )))
+                    }
+                    None => return Ok((name, true)), // EOF
+                },
+                _ => name.push(c),
+            }
+        }
+        Err(Error::generic("Unterminated escape sequence in field name"))
+    }
+
+    // Ambiguous case: The empty string `""`could reasonably parse as either `ColumnName::new([""])`
+    // or `ColumnName::new([])`. However, `ColumnName::new([""]).to_string()` is `"[]"` and
+    // `ColumnName::new([]).to_string()` is `""`, so we choose the latter because it produces a
+    // lossless round trip from `ColumnName` to  `String` and back.
+    let mut chars = s.chars().peekable();
+    if chars.peek().is_none() {
+        return Ok(ColumnName::new(&[] as &[String]));
+    }
+
+    let mut path = vec![];
+    loop {
+        let (field_name, done) = if chars.next_if_eq(&'[').is_none() {
+            parse_simple(&mut chars)?
+        } else {
+            parse_escaped(&mut chars)?
+        };
+        path.push(field_name);
+        if done {
+            return Ok(ColumnName::new(path));
+        }
     }
 }
 
@@ -228,7 +376,7 @@ mod test {
         );
         assert_eq!(
             joined_column_name!(nested, "b"),
-            ColumnName::new(["x.y", "b"])
+            ColumnName::new(["x", "y", "b"])
         );
 
         assert_eq!(
@@ -237,7 +385,7 @@ mod test {
         );
         assert_eq!(
             joined_column_name!("a", &nested),
-            ColumnName::new(["a", "x.y"])
+            ColumnName::new(["a", "x", "y"])
         );
     }
 
@@ -247,23 +395,115 @@ mod test {
         let nested = column_name!("x.y");
 
         // path()
-        assert_eq!(simple.path(), "x");
-        assert_eq!(nested.path(), "x.y");
+        assert_eq!(simple.path(), ["x"]);
+        assert_eq!(nested.path(), ["x", "y"]);
 
         // into_inner()
-        assert_eq!(simple.clone().into_inner(), "x");
-        assert_eq!(nested.clone().into_inner(), "x.y");
+        assert_eq!(simple.clone().into_inner(), ["x"]);
+        assert_eq!(nested.clone().into_inner(), ["x", "y"]);
 
         // impl Deref
-        let name: &str = &nested;
-        assert_eq!(name, "x.y");
+        let name: &[String] = &nested;
+        assert_eq!(name, &["x", "y"]);
 
         // impl<A: Into<String>> FromIterator<A>
         let name: ColumnName = ["x", "y"].into_iter().collect();
         assert_eq!(name, nested);
 
         // impl FromIterator<ColumnName>
-        let name: ColumnName = [nested, simple].into_iter().collect();
+        let name: ColumnName = [nested.clone(), simple.clone()].into_iter().collect();
         assert_eq!(name, column_name!("x.y.x"));
+
+        // ColumnName::new
+        let name = ColumnName::new([nested, simple]);
+        assert_eq!(name, column_name!("x.y.x"));
+
+        let name = ColumnName::new(["x", "y"]);
+        assert_eq!(name, column_name!("x.y"));
+
+        // ColumnName::into_iter()
+        let name = column_name!("x.y.z");
+        let name = ColumnName::new(name);
+        assert_eq!(name, column_name!("x.y.z"));
+    }
+
+    #[test]
+    fn test_column_name_from_str() {
+        let cases = [
+            ("", Some(ColumnName::new(&[] as &[String]))), // the ambiguous case!
+            (".", Some(ColumnName::new(["", ""]))),
+            (" ", None),
+            (".a", Some(ColumnName::new(["", "a"]))),
+            ("a.", Some(ColumnName::new(["a", ""]))),
+            ("a..b", Some(ColumnName::new(["a", "", "b"]))),
+            ("[a", None),
+            ("a]", None),
+            ("a[b]", None),
+            ("[a]b", None),
+            ("[a][b]", None),
+            ("a", Some(ColumnName::new(["a"]))),
+            ("[a]", Some(ColumnName::new(["a"]))),
+            ("[ ]", Some(ColumnName::new([" "]))),
+            ("[.]", Some(ColumnName::new(["."]))),
+            ("[.].[.]", Some(ColumnName::new([".", "."]))),
+            ("[ ].[ ]", Some(ColumnName::new([" ", " "]))),
+            ("a.b", Some(ColumnName::new(["a", "b"]))),
+            ("a.[b]", Some(ColumnName::new(["a", "b"]))),
+            ("[a].b", Some(ColumnName::new(["a", "b"]))),
+            ("[a].[b]", Some(ColumnName::new(["a", "b"]))),
+            ("[a].[b].[c]", Some(ColumnName::new(["a", "b", "c"]))),
+            ("[a[].[b]]]", Some(ColumnName::new(["a[", "b]"]))),
+            ("a[.b]]", None),
+        ];
+        for (input, expected_output) in cases {
+            let output: DeltaResult<ColumnName> = input.parse();
+            match (&output, &expected_output) {
+                (Ok(output), Some(expected_output)) => assert_eq!(output, expected_output),
+                (Err(_), None) => {}
+                _ => panic!("Expected {input} to parse as {expected_output:?}, got {output:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_to_string_lossy() {
+        let cases = [
+            ("", ColumnName::new(&[] as &[String])), // ambiguous case!
+            ("a.b.c", ColumnName::new(["a", "b", "c"])),
+            ("a.b_c.d", ColumnName::new(["a", "b_c", "d"])),
+            ("a.b c.d", ColumnName::new(["a", "b c", "d"])),
+            ("a.b.c.d", ColumnName::new(["a", "b.c", "d"])),
+        ];
+        for (expected_output, input) in cases {
+            assert_eq!(input.to_string_lossy(), expected_output);
+        }
+    }
+
+    #[test]
+    fn test_column_name_to_string() {
+        let cases = [
+            ("", ColumnName::new(&[] as &[String])), // the ambiguous case!
+            ("[].[]", ColumnName::new(["", ""])),
+            ("[].a", ColumnName::new(["", "a"])),
+            ("a.[]", ColumnName::new(["a", ""])),
+            ("a.[].b", ColumnName::new(["a", "", "b"])),
+            ("a", ColumnName::new(["a"])),
+            ("[a ]", ColumnName::new(["a "])),
+            ("[ ]", ColumnName::new([" "])),
+            ("[.]", ColumnName::new(["."])),
+            ("[.].[.]", ColumnName::new([".", "."])),
+            ("[ ].[ ]", ColumnName::new([" ", " "])),
+            ("a.b", ColumnName::new(["a", "b"])),
+            ("a.b.c", ColumnName::new(["a", "b", "c"])),
+            ("a.[b.c].d", ColumnName::new(["a", "b.c", "d"])),
+            ("[a[].[b]]]", ColumnName::new(["a[", "b]"])),
+        ];
+        for (expected_output, input) in cases {
+            let output = FancyColumnName(input.clone()).to_string();
+            assert_eq!(output, expected_output);
+
+            let parsed: ColumnName = output.parse().expect(&output);
+            assert_eq!(parsed, input);
+        }
     }
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -231,6 +231,15 @@ impl Expression {
         set
     }
 
+    /// Create a new column name expression from input satisfying `FromIterator for ColumnName`.
+    pub fn column<A, T>(field_names: T) -> Expression
+    where
+        T: IntoIterator<Item = A>,
+        ColumnName: FromIterator<A>,
+    {
+        ColumnName::new(field_names).into()
+    }
+
     /// Create a new expression for a literal value
     pub fn literal(value: impl Into<Scalar>) -> Self {
         Self::Literal(value.into())

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -195,9 +195,11 @@ impl DataSkippingFilter {
 
         // Build the stats read schema by extracting the column names referenced by the predicate,
         // extracting the corresponding field from the table schema, and inserting that field.
+        //
+        // TODO: Support nested column names!
         let data_fields: Vec<_> = table_schema
             .fields()
-            .filter(|field| field_names.contains(&field.name))
+            .filter(|field| field_names.contains([field.name.clone()].as_slice()))
             .cloned()
             .collect();
         if data_fields.is_empty() {

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -11,7 +11,6 @@ use tracing::{debug, warn};
 use url::Url;
 
 use crate::actions::{get_log_schema, Metadata, Protocol, METADATA_NAME, PROTOCOL_NAME};
-use crate::expressions::column_expr;
 use crate::features::{ColumnMappingMode, COLUMN_MAPPING_MODE_KEY};
 use crate::path::ParsedLogPath;
 use crate::scan::ScanBuilder;
@@ -112,8 +111,8 @@ impl LogSegment {
         use Expression as Expr;
         static META_PREDICATE: LazyLock<Option<ExpressionRef>> = LazyLock::new(|| {
             Some(Arc::new(Expr::or(
-                column_expr!("metaData.id").is_not_null(),
-                column_expr!("protocol.minReaderVersion").is_not_null(),
+                Expr::column([METADATA_NAME, "id"]).is_not_null(),
+                Expr::column([PROTOCOL_NAME, "minReaderVersion"]).is_not_null(),
             )))
         });
         // read the same protocol and metadata schema for both commits and checkpoints


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, `ColumnName` tracked a simple string, which could be split at `.` to obtain a path of field names. But this breaks down if a field name contains any special characters that might interfere with the interpretation of a dot character.

To solve this, update `ColumnName` to track an actual path of field names instead. Update all call sites as needed to support the new idiom.

NOTE: This change does _not_ magically make all operations nesting-aware. For example, code that loops over the field names of a `StructType` will continue to see nested column names as not-matched. Fixing those call sites is left as future work, tho obvious ones are flagged here as TODO.

Resolves https://github.com/delta-incubator/delta-kernel-rs/issues/443

### This PR affects the following public APIs

The "shape" of `ColumnName` changes from string-like to slice-of-string-like, and its methods change accordingly. This change is needed because otherwise we cannot reliably handle arbitrary field names.

## How was this change tested?

Extensive existing unit tests.