### PR TITLE
Define and use new AsAny trait

### DIFF
--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -9,7 +9,6 @@ use arrow_array::{Array, GenericListArray, MapArray, OffsetSizeTrait, RecordBatc
 use arrow_schema::{ArrowError, DataType as ArrowDataType};
 use tracing::{debug, warn};
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -47,14 +46,6 @@ impl EngineData for ArrowEngineData {
 
     fn length(&self) -> usize {
         self.data.num_rows()
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
     }
 }
 

--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -538,7 +538,7 @@ pub struct DefaultExpressionEvaluator {
 impl ExpressionEvaluator for DefaultExpressionEvaluator {
     fn evaluate(&self, batch: &dyn EngineData) -> DeltaResult<Box<dyn EngineData>> {
         let batch = batch
-            .as_any()
+            .any_ref()
             .downcast_ref::<ArrowEngineData>()
             .ok_or_else(|| Error::engine_data_type("ArrowEngineData"))?
             .record_batch();

--- a/kernel/src/engine_data.rs
+++ b/kernel/src/engine_data.rs
@@ -1,10 +1,9 @@
 //! Traits that engines need to implement in order to pass data between themselves and kernel.
 
-use crate::{schema::SchemaRef, DeltaResult, Error};
+use crate::{schema::SchemaRef, AsAny, DeltaResult, Error};
 
 use tracing::debug;
 
-use std::any::Any;
 use std::collections::HashMap;
 
 /// a trait that an engine exposes to give access to a list
@@ -212,8 +211,6 @@ pub trait DataVisitor {
 /// }
 ///
 /// impl EngineData for MyDataType {
-///   fn as_any(&self) -> &dyn Any { self }
-///   fn into_any(self: Box<Self>) -> Box<dyn Any> { self }
 ///   fn extract(&self, schema: SchemaRef, visitor: &mut dyn DataVisitor) -> DeltaResult<()> {
 ///     let getters = self.do_extraction(); // do the extraction
 ///     let row_count = self.length();
@@ -226,7 +223,7 @@ pub trait DataVisitor {
 ///   }
 /// }
 /// ```
-pub trait EngineData: Send + Sync {
+pub trait EngineData: AsAny {
     /// Request that the data be visited for the passed schema. The contract of this method is that
     /// it will call back into the passed [`DataVisitor`]s `visit` method. The call to `visit` must
     /// include `GetData` items for each leaf of the schema, as well as the number of rows in this
@@ -235,9 +232,4 @@ pub trait EngineData: Send + Sync {
 
     /// Return the number of items (rows) in blob
     fn length(&self) -> usize;
-
-    // TODO(nick) implement this and below here in the trait when it doesn't cause a compiler error
-    fn as_any(&self) -> &dyn Any;
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any>;
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -233,6 +233,10 @@ pub trait AsAny: Any + Send + Sync {
     /// let b: Box<Bar> = a.downcast().unwrap();
     /// ```
     fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync>;
+
+    /// Convenient wrapper for [`std::any::type_name`], since [`Any`] does not provide it and
+    /// [`Any::type_id`] is useless as a debugging aid (its `Debug` is just a mess of hex digits).
+    fn type_name(&self) -> &'static str;
 }
 
 // Blanket implementation for all eligible types
@@ -245,6 +249,9 @@ impl<T: Any + Send + Sync> AsAny for T {
     }
     fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync> {
         self
+    }
+    fn type_name(&self) -> &'static str {
+        std::any::type_name::<Self>()
     }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

As part of implementing various kernel operations, engines need the ability to downcast kernel engine traits to their true concrete types. The rust `Any` trait can help with struct downcasting, but it isn't quite strong enough once traits are involved. For example, given `trait Foo: Any + Send + Sync`, and `struct Bar` that implements `Foo`, the following fails to compile:
```rust
let f: Arc<dyn Foo> = Arc::new(Bar);
let f: Arc<Bar> = f.downcast().unwrap(); // `Arc::downcast` method not found 
```
... as does this:
```rust
let f: Arc<Foo> = Arc::new(Foo{});
let a: Arc<dyn Any + Send + Sync> = f; // trait upcasting coercion is not stable rust
let f: Arc<Foo> = a.downcast().unwrap();
```

We solve the trait downcasting problem with a new `trait AsAny: Any + Send + Sync` -- automatically implemented for all `T: Any + Send + Sync` -- which defines methods for downcasting itself to `dyn Any + Send + Sync` (reference, box, or arc).

### This PR affects the following public APIs

The various engine traits (`ParquetHandler`, `EngineData`, etc.) are now constrained to be `AsAny` (which implies `Any + Send + Sync`) rather than merely `Send + Sync`). 

This change should be source compatible in the vast majority of cases, because most types implement `Any` automatically.

## How was this change tested?

Doc tests, and it also replaces similar special-case code in the arrow default engine data implementation.