### PR TITLE
parse table metadata.configuration as `TableProperties`

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -9,7 +9,8 @@ use visitors::{AddVisitor, MetadataVisitor, ProtocolVisitor};
 
 use self::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::schemas::GetStructField;
-use crate::features::{ReaderFeatures, WriterFeatures};
+use crate::table_properties::TableProperties;
+use crate::table_features::{ReaderFeatures, WriterFeatures};
 use crate::schema::{SchemaRef, StructType};
 use crate::{DeltaResult, EngineData};
 
@@ -99,7 +100,7 @@ pub struct Metadata {
     pub partition_columns: Vec<String>,
     /// The time when this metadata action is created, in milliseconds since the Unix epoch
     pub created_time: Option<i64>,
-    /// Configuration options for the metadata action
+    /// Configuration options for the metadata action. These are parsed into `TableProperties`.
     pub configuration: HashMap<String, String>,
 }
 
@@ -112,6 +113,10 @@ impl Metadata {
 
     pub fn schema(&self) -> DeltaResult<StructType> {
         Ok(serde_json::from_str(&self.schema_string)?)
+    }
+
+    pub fn get_table_properties(&self) -> DeltaResult<TableProperties> {
+        todo!()
     }
 }
 

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -9,9 +9,9 @@ use visitors::{AddVisitor, MetadataVisitor, ProtocolVisitor};
 
 use self::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::schemas::GetStructField;
-use crate::table_properties::TableProperties;
-use crate::table_features::{ReaderFeatures, WriterFeatures};
 use crate::schema::{SchemaRef, StructType};
+use crate::table_features::{ReaderFeatures, WriterFeatures};
+use crate::table_properties::TableProperties;
 use crate::{DeltaResult, EngineData};
 
 pub mod deletion_vector;
@@ -115,8 +115,9 @@ impl Metadata {
         Ok(serde_json::from_str(&self.schema_string)?)
     }
 
+    /// Parse the metadata configuration HashMap<String, String> into a TableProperties struct.
     pub fn get_table_properties(&self) -> DeltaResult<TableProperties> {
-        todo!()
+        TableProperties::new(&self.configuration)
     }
 }
 

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -2,9 +2,12 @@ use std::borrow::Borrow;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+
+use serde::Deserialize;
+
 /// A (possibly nested) column name.
 // TODO: Track name as a path rather than a single string
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Deserialize)]
 pub struct ColumnName {
     path: String,
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -73,8 +73,8 @@ pub mod scan;
 pub mod schema;
 pub mod snapshot;
 pub mod table;
-pub mod transaction;
 pub mod table_properties;
+pub mod transaction;
 pub(crate) mod utils;
 
 pub use delta_kernel_derive;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -62,7 +62,7 @@ pub mod actions;
 pub mod engine_data;
 pub mod error;
 pub mod expressions;
-pub mod features;
+pub mod table_features;
 
 #[cfg(feature = "developer-visibility")]
 pub mod path;
@@ -74,6 +74,7 @@ pub mod schema;
 pub mod snapshot;
 pub mod table;
 pub mod transaction;
+pub mod table_properties;
 pub(crate) mod utils;
 
 pub use delta_kernel_derive;

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -10,10 +10,10 @@ use url::Url;
 use crate::actions::deletion_vector::{split_vector, treemap_to_bools, DeletionVectorDescriptor};
 use crate::actions::{get_log_add_schema, get_log_schema, ADD_NAME, REMOVE_NAME};
 use crate::expressions::{ColumnName, Expression, ExpressionRef, Scalar};
-use crate::table_features::ColumnMappingMode;
 use crate::scan::state::{DvInfo, Stats};
 use crate::schema::{DataType, Schema, SchemaRef, StructField, StructType};
 use crate::snapshot::Snapshot;
+use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Engine, EngineData, Error, FileMeta};
 
 use self::log_replay::scan_action_iter;

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -10,7 +10,7 @@ use url::Url;
 use crate::actions::deletion_vector::{split_vector, treemap_to_bools, DeletionVectorDescriptor};
 use crate::actions::{get_log_add_schema, get_log_schema, ADD_NAME, REMOVE_NAME};
 use crate::expressions::{ColumnName, Expression, ExpressionRef, Scalar};
-use crate::features::ColumnMappingMode;
+use crate::table_features::ColumnMappingMode;
 use crate::scan::state::{DvInfo, Stats};
 use crate::schema::{DataType, Schema, SchemaRef, StructField, StructType};
 use crate::snapshot::Snapshot;
@@ -95,7 +95,7 @@ impl ScanBuilder {
         let (all_fields, read_fields, have_partition_cols) = get_state_info(
             logical_schema.as_ref(),
             &self.snapshot.metadata().partition_columns,
-            self.snapshot.column_mapping_mode,
+            self.snapshot.table_properties().column_mapping_mode,
         )?;
         let physical_schema = Arc::new(StructType::new(read_fields));
         Ok(Scan {
@@ -247,7 +247,7 @@ impl Scan {
             partition_columns: self.snapshot.metadata().partition_columns.clone(),
             logical_schema: self.logical_schema.clone(),
             read_schema: self.physical_schema.clone(),
-            column_mapping_mode: self.snapshot.column_mapping_mode,
+            column_mapping_mode: self.snapshot.table_properties().column_mapping_mode,
         }
     }
 

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -8,7 +8,7 @@ use crate::{
         visitors::visit_deletion_vector_at,
     },
     engine_data::{GetData, TypedGetData},
-    features::ColumnMappingMode,
+    table_features::ColumnMappingMode,
     schema::SchemaRef,
     DataVisitor, DeltaResult, Engine, EngineData, Error,
 };

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -8,8 +8,8 @@ use crate::{
         visitors::visit_deletion_vector_at,
     },
     engine_data::{GetData, TypedGetData},
-    table_features::ColumnMappingMode,
     schema::SchemaRef,
+    table_features::ColumnMappingMode,
     DataVisitor, DeltaResult, Engine, EngineData, Error,
 };
 use serde::{Deserialize, Serialize};

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::features::ColumnMappingMode;
+use crate::table_features::ColumnMappingMode;
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -15,7 +15,6 @@ use crate::expressions::column_expr;
 use crate::path::ParsedLogPath;
 use crate::scan::ScanBuilder;
 use crate::schema::{Schema, SchemaRef};
-use crate::table_features::ColumnMappingMode;
 use crate::table_properties::TableProperties;
 use crate::utils::require;
 use crate::{DeltaResult, Engine, Error, FileMeta, FileSystemClient, Version};

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DeltaResult, Error};
 
 /// Modes of column mapping a table can be in
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum ColumnMappingMode {
     /// No column mapping is applied
@@ -16,9 +16,6 @@ pub enum ColumnMappingMode {
     /// Columns are mapped to a physical name
     Name,
 }
-
-// key to look in metadata.configuration for to get column mapping mode
-pub(crate) const COLUMN_MAPPING_MODE_KEY: &str = "delta.columnMapping.mode";
 
 impl TryFrom<&str> for ColumnMappingMode {
     type Error = Error;

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 pub use column_mapping::ColumnMappingMode;
-pub(crate) use column_mapping::COLUMN_MAPPING_MODE_KEY;
 use strum::{AsRefStr, Display as StrumDisplay, EnumString, VariantNames};
 
 mod column_mapping;

--- a/kernel/src/table_properties.rs
+++ b/kernel/src/table_properties.rs
@@ -1,0 +1,736 @@
+//! Delta Table properties. Note this module implements per-table configuration which governs how
+//! table-level capabilities/properties are configured (turned on/off etc.). This is orthogonal to
+//! protocol-level 'table features' which enable or disable reader/writer features (which then
+//! usually must be enabled/configured by table properties).
+//!
+//! For example (from delta's protocol.md): A feature being supported does not imply that it is
+//! active. For example, a table may have the `appendOnly` feature listed in writerFeatures, but it
+//! does not have a table property delta.appendOnly that is set to `true`. In such a case the table
+//! is not append-only, and writers are allowed to change, remove, and rearrange data. However,
+//! writers must know that the table property delta.appendOnly should be checked before writing the
+//! table.
+//
+// Delete me?
+// Delta table properties are use to configure the table. They are defined in the 'Metadata' action
+// under 'configuration' map. Every table must have at exactly one Protocol and one Metadata action.
+// Only the most recent is used in the case of multiple P/M actions present in a log segment.
+//
+// ex: "configuration":{"delta.enableDeletionVectors":"true"}
+// parsed into a map of DeltaTableProperty
+// = DeltaTableProperty::EnableDeletionVectors -> true
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde::de::{self, Deserializer};
+
+use crate::error::Error;
+use crate::table_features::ColumnMappingMode;
+
+/// Default num index cols
+pub const DEFAULT_NUM_INDEX_COLS: i32 = 32;
+
+// #[derive(Debug)]
+// struct BoundedInt(i32);
+//
+// impl<'de> Deserialize<'de> for BoundedInt {
+//     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+//     where
+//         D: Deserializer<'de>,
+//     {
+//         let val = i32::deserialize(deserializer)?;
+//         if val >= 1 && val <= 10 {
+//             Ok(BoundedInt(val))
+//         } else {
+//             Err(de::Error::custom(format!(
+//                 "Value {} is out of bounds (1-10)",
+//                 val
+//             )))
+//         }
+//     }
+// }
+
+/// Delta table properties
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct TableProperties {
+    /// true for this Delta table to be append-only. If append-only,
+    /// existing records cannot be deleted, and existing values cannot be updated.
+    #[serde(rename = "delta.appendOnly")]
+    pub append_only: Option<bool>,
+
+    /// true for Delta Lake to automatically optimize the layout of the files for this Delta table.
+    #[serde(rename = "delta.autoOptimize.autoCompact")]
+    pub auto_compact: Option<bool>,
+
+    /// true for Delta Lake to automatically optimize the layout of the files for this Delta table
+    /// during writes.
+    #[serde(rename = "delta.autoOptimize.optimizeWrite")]
+    pub optimize_write: Option<bool>,
+
+    /// Interval (expressed as number of commits) after which a new checkpoint should be created.
+    /// E.g. if checkpoint interval = 10, then a checkpoint should be written every 10 commits.
+    #[serde(rename = "delta.checkpointInterval")]
+    pub checkpoint_interval: Option<u64>,
+
+    /// true for Delta Lake to write file statistics in checkpoints in JSON format for the stats column.
+    #[serde(rename = "delta.checkpoint.writeStatsAsJson")]
+    pub checkpoint_write_stats_as_json: Option<bool>,
+
+    /// true for Delta Lake to write file statistics to checkpoints in struct format for the
+    /// stats_parsed column and to write partition values as a struct for partitionValues_parsed.
+    #[serde(rename = "delta.checkpoint.writeStatsAsStruct")]
+    pub checkpoint_write_stats_as_struct: Option<bool>,
+
+    /// Whether column mapping is enabled for Delta table columns and the corresponding
+    /// Parquet columns that use different names.
+    #[serde(rename = "delta.columnMapping.mode")]
+    pub column_mapping_mode: ColumnMappingMode,
+
+    /// The number of columns for Delta Lake to collect statistics about for data skipping.
+    /// A value of -1 means to collect statistics for all columns. Updating this property does
+    /// not automatically collect statistics again; instead, it redefines the statistics schema
+    /// of the Delta table. Specifically, it changes the behavior of future statistics collection
+    /// (such as during appends and optimizations) as well as data skipping (such as ignoring column
+    /// statistics beyond this number, even when such statistics exist).
+    #[serde(rename = "delta.dataSkippingNumIndexedCols")]
+    pub data_skipping_num_indexed_cols: Option<i64>,
+
+    /// A comma-separated list of column names on which Delta Lake collects statistics to enhance
+    /// data skipping functionality. This property takes precedence over
+    /// [DataSkippingNumIndexedCols](DeltaConfigKey::DataSkippingNumIndexedCols).
+    #[serde(rename = "delta.dataSkippingStatsColumns")]
+    pub data_skipping_stats_columns: Option<u64>,
+
+    /// The shortest duration for Delta Lake to keep logically deleted data files before deleting
+    /// them physically. This is to prevent failures in stale readers after compactions or partition
+    /// overwrites.
+    ///
+    /// This value should be large enough to ensure that:
+    ///
+    /// * It is larger than the longest possible duration of a job if you run VACUUM when there are
+    ///   concurrent readers or writers accessing the Delta table.
+    /// * If you run a streaming query that reads from the table, that query does not stop for
+    ///   longer than this value. Otherwise, the query may not be able to restart, as it must still
+    ///   read old files.
+    #[serde(rename = "delta.deletedFileRetentionDuration")]
+    #[serde(deserialize_with = "deserialize_interval")]
+    pub deleted_file_retention_duration: Option<Duration>,
+
+    /// true to enable change data feed.
+    #[serde(rename = "delta.enableChangeDataFeed")]
+    pub enable_change_data_feed: Option<bool>,
+
+    /// true to enable deletion vectors and predictive I/O for updates.
+    #[serde(rename = "delta.enableDeletionVectors")]
+    pub enable_deletion_vectors: Option<bool>,
+
+    /// The degree to which a transaction must be isolated from modifications made by concurrent transactions.
+    ///
+    /// Valid values are `Serializable` and `WriteSerializable`.
+    #[serde(rename = "delta.isolationLevel")]
+    pub isolation_level: Option<IsolationLevel>,
+
+    /// How long the history for a Delta table is kept.
+    ///
+    /// Each time a checkpoint is written, Delta Lake automatically cleans up log entries older
+    /// than the retention interval. If you set this property to a large enough value, many log
+    /// entries are retained. This should not impact performance as operations against the log are
+    /// constant time. Operations on history are parallel but will become more expensive as the log
+    /// size increases.
+    #[serde(rename = "delta.logRetentionDuration")]
+    #[serde(deserialize_with = "deserialize_interval")]
+    pub log_retention_duration: Option<Duration>,
+
+    /// TODO I could not find this property in the documentation, but was defined here and makes sense..?
+    #[serde(rename = "delta.enableExpiredLogCleanup")]
+    pub enable_expired_log_cleanup: Option<bool>,
+
+    /// The minimum required protocol reader version for a reader that allows to read from this Delta table.
+    #[serde(rename = "delta.minReaderVersion")]
+    pub min_reader_version: Option<u8>,
+
+    /// The minimum required protocol writer version for a writer that allows to write to this Delta table.
+    #[serde(rename = "delta.minWriterVersion")]
+    pub min_writer_version: Option<u8>,
+
+    /// true for Delta to generate a random prefix for a file path instead of partition information.
+    ///
+    /// For example, this may improve Amazon S3 performance when Delta Lake needs to send very high
+    /// volumes of Amazon S3 calls to better partition across S3 servers.
+    #[serde(rename = "delta.randomizeFilePrefixes")]
+    pub randomize_file_prefixes: Option<bool>,
+
+    /// When delta.randomizeFilePrefixes is set to true, the number of characters that Delta
+    /// generates for random prefixes.
+    #[serde(rename = "delta.randomPrefixLength")]
+    pub random_prefix_length: Option<bool>,
+
+    /// The shortest duration within which new snapshots will retain transaction identifiers (for
+    /// example, SetTransactions). When a new snapshot sees a transaction identifier older than or
+    /// equal to the duration specified by this property, the snapshot considers it expired and
+    /// ignores it. The SetTransaction identifier is used when making the writes idempotent.
+    #[serde(rename = "delta.setTransactionRetentionDuration")]
+    #[serde(deserialize_with = "deserialize_interval")]
+    pub set_transaction_retention_duration: Option<Duration>,
+
+    /// The target file size in bytes or higher units for file tuning. For example, 104857600
+    /// (bytes) or 100mb.
+    #[serde(rename = "delta.targetFileSize")]
+    pub target_file_size: Option<u64>,
+
+    /// The target file size in bytes or higher units for file tuning. For example, 104857600
+    /// (bytes) or 100mb.
+    #[serde(rename = "delta.tuneFileSizesForRewrites")]
+    pub tune_file_sizes_for_rewrites: Option<bool>,
+
+    /// 'classic' for classic Delta Lake checkpoints. 'v2' for v2 checkpoints.
+    #[serde(rename = "delta.checkpointPolicy")]
+    pub checkpoint_policy: Option<CheckpointPolicy>,
+}
+
+// /// Delta configuration error
+// #[derive(thiserror::Error, Debug, PartialEq, Eq)]
+// pub enum DeltaConfigError {
+//     /// Error returned when configuration validation failed.
+//     #[error("Validation failed - {0}")]
+//     Validation(String),
+// }
+//
+// impl From<DeltaConfigError> for Error {
+//     fn from(e: DeltaConfigError) -> Self {
+//         Error::InvalidConfiguration(e.to_string())
+//     }
+// }
+
+//     /// The shortest duration for Delta Lake to keep logically deleted data files before deleting
+//     /// them physically. This is to prevent failures in stale readers after compactions or partition
+//     /// overwrites.
+//     ///
+//     /// This value should be large enough to ensure that:
+//     ///
+//     /// * It is larger than the longest possible duration of a job if you run VACUUM when there are
+//     ///   concurrent readers or writers accessing the Delta table.
+//     /// * If you run a streaming query that reads from the table, that query does not stop for
+//     ///   longer than this value. Otherwise, the query may not be able to restart, as it must still
+//     ///   read old files.
+//     pub fn deleted_file_retention_duration(&self) -> Duration {
+//         static DEFAULT_FILE_RETENTION_DURATION: LazyLock<Duration> =
+//             LazyLock::new(|| parse_interval("interval 1 weeks").unwrap());
+//         self.0
+//             .get(DeltaTableProperty::DeletedFileRetentionDuration.as_ref())
+//             .and_then(|v| parse_interval(v).ok())
+//             .unwrap_or_else(|| DEFAULT_FILE_RETENTION_DURATION.to_owned())
+//     }
+//
+//     /// How long the history for a Delta table is kept.
+//     ///
+//     /// Each time a checkpoint is written, Delta Lake automatically cleans up log entries older
+//     /// than the retention interval. If you set this property to a large enough value, many log
+//     /// entries are retained. This should not impact performance as operations against the log are
+//     /// constant time. Operations on history are parallel but will become more expensive as the log
+//     /// size increases.
+//     pub fn log_retention_duration(&self) -> Duration {
+//         static DEFAULT_LOG_RETENTION_DURATION: LazyLock<Duration> =
+//             LazyLock::new(|| parse_interval("interval 30 days").unwrap());
+//         self.0
+//             .get(DeltaTableProperty::LogRetentionDuration.as_ref())
+//             .and_then(|v| parse_interval(v).ok())
+//             .unwrap_or_else(|| DEFAULT_LOG_RETENTION_DURATION.to_owned())
+//     }
+//
+//     /// The degree to which a transaction must be isolated from modifications made by concurrent
+//     /// transactions.
+//     ///
+//     /// Valid values are `Serializable` and `WriteSerializable`.
+//     pub fn isolation_level(&self) -> IsolationLevel {
+//         self.0
+//             .get(DeltaTableProperty::IsolationLevel.as_ref())
+//             .and_then(|v| v.parse().ok())
+//             .unwrap_or_default()
+//     }
+//
+//     /// Policy applied during chepoint creation
+//     pub fn checkpoint_policy(&self) -> CheckpointPolicy {
+//         self.0
+//             .get(DeltaTableProperty::CheckpointPolicy.as_ref())
+//             .and_then(|v| v.parse().ok())
+//             .unwrap_or_default()
+//     }
+//
+//     /// Return the column mapping mode according to delta.columnMapping.mode
+//     pub fn column_mapping_mode(&self) -> ColumnMappingMode {
+//         self.0
+//             .get(DeltaTableProperty::ColumnMappingMode.as_ref())
+//             .and_then(|v| v.parse().ok())
+//             .unwrap_or_default()
+//     }
+//
+//     /// Return the check constraints on the current table
+//     pub fn get_constraints(&self) -> Vec<Constraint> {
+//         self.0
+//             .iter()
+//             .filter_map(|(field, value)| {
+//                 if field.starts_with("delta.constraints") {
+//                     field
+//                         .splitn(3, '.')
+//                         .last()
+//                         .map(|n| Constraint::new(n, value))
+//                 } else {
+//                     None
+//                 }
+//             })
+//             .collect()
+//     }
+//
+//     /// Column names on which Delta Lake collects statistics to enhance data skipping functionality.
+//     /// This property takes precedence over [num_indexed_cols](Self::num_indexed_cols).
+//     pub fn stats_columns(&self) -> Option<Vec<&str>> {
+//         self.0
+//             .get(DeltaTableProperty::DataSkippingStatsColumns.as_ref())
+//             .map(|v| v.split(',').collect())
+//     }
+
+/// The isolation level applied during transaction
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum IsolationLevel {
+    /// The strongest isolation level. It ensures that committed write operations
+    /// and all reads are Serializable. Operations are allowed as long as there
+    /// exists a serial sequence of executing them one-at-a-time that generates
+    /// the same outcome as that seen in the table. For the write operations,
+    /// the serial sequence is exactly the same as that seen in the table’s history.
+    Serializable,
+
+    /// A weaker isolation level than Serializable. It ensures only that the write
+    /// operations (that is, not reads) are serializable. However, this is still stronger
+    /// than Snapshot isolation. WriteSerializable is the default isolation level because
+    /// it provides great balance of data consistency and availability for most common operations.
+    WriteSerializable,
+
+    /// SnapshotIsolation is a guarantee that all reads made in a transaction will see a consistent
+    /// snapshot of the database (in practice it reads the last committed values that existed at the
+    /// time it started), and the transaction itself will successfully commit only if no updates
+    /// it has made conflict with any concurrent updates made since that snapshot.
+    SnapshotIsolation,
+}
+
+// Spark assumes Serializable as default isolation level
+// https://github.com/delta-io/delta/blob/abb171c8401200e7772b27e3be6ea8682528ac72/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala#L1023
+impl Default for IsolationLevel {
+    fn default() -> Self {
+        Self::Serializable
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+/// The checkpoint policy applied when writing checkpoints
+#[serde(rename_all = "camelCase")]
+pub enum CheckpointPolicy {
+    /// classic Delta Lake checkpoints
+    Classic,
+    /// v2 checkpoints
+    V2,
+}
+
+impl Default for CheckpointPolicy {
+    fn default() -> Self {
+        Self::Classic
+    }
+}
+
+const SECONDS_PER_MINUTE: u64 = 60;
+const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
+const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
+const SECONDS_PER_WEEK: u64 = 7 * SECONDS_PER_DAY;
+
+fn deserialize_interval<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(deserializer)?;
+    match opt {
+        Some(s) => parse_interval(&s).map(Some).map_err(de::Error::custom),
+        None => Ok(None),
+    }
+}
+
+fn parse_interval(value: &str) -> Result<Duration, String> {
+    let not_an_interval = || format!("'{value}' is not an interval");
+
+    if !value.starts_with("interval ") {
+        return Err(not_an_interval());
+    }
+    let mut it = value.split_whitespace();
+    let _ = it.next(); // skip "interval"
+    let number = parse_int(it.next().ok_or_else(not_an_interval)?)?;
+    if number < 0 {
+        return Err(format!("interval '{value}' cannot be negative"));
+    }
+    let number = number as u64;
+
+    let duration = match it.next().ok_or_else(not_an_interval)? {
+        "nanosecond" | "nanoseconds" => Duration::from_nanos(number),
+        "microsecond" | "microseconds" => Duration::from_micros(number),
+        "millisecond" | "milliseconds" => Duration::from_millis(number),
+        "second" | "seconds" => Duration::from_secs(number),
+        "minute" | "minutes" => Duration::from_secs(number * SECONDS_PER_MINUTE),
+        "hour" | "hours" => Duration::from_secs(number * SECONDS_PER_HOUR),
+        "day" | "days" => Duration::from_secs(number * SECONDS_PER_DAY),
+        "week" | "weeks" => Duration::from_secs(number * SECONDS_PER_WEEK),
+        unit => {
+            return Err(format!("Unknown unit '{unit}'"));
+        }
+    };
+
+    Ok(duration)
+}
+
+fn parse_int(value: &str) -> Result<i64, String> {
+    value
+        .parse()
+        .map_err(|e| format!("Cannot parse '{value}' as integer: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::{Format, Metadata};
+    use crate::schema::StructType;
+    use std::collections::HashMap;
+
+    fn dummy_metadata() -> Metadata {
+        let schema = StructType::new(Vec::new());
+        Metadata {
+            id: "id".into(),
+            name: None,
+            description: None,
+            format: Format::default(),
+            schema_string: serde_json::to_string(&schema).unwrap(),
+            partition_columns: Vec::new(),
+            configuration: HashMap::new(),
+            created_time: None,
+        }
+    }
+
+    #[test]
+    fn zach() {
+
+    }
+
+    // #[test]
+    // fn get_interval_from_metadata_test() {
+    //     let md = dummy_metadata();
+    //     let config = TableConfig(&md.configuration);
+
+    //     // default 1 week
+    //     assert_eq!(
+    //         config.deleted_file_retention_duration().as_secs(),
+    //         SECONDS_PER_WEEK,
+    //     );
+
+    //     // change to 2 day
+    //     let mut md = dummy_metadata();
+    //     md.configuration.insert(
+    //         DeltaTableProperty::DeletedFileRetentionDuration
+    //             .as_ref()
+    //             .to_string(),
+    //         "interval 2 day".to_string(),
+    //     );
+    //     let config = TableConfig(&md.configuration);
+
+    //     assert_eq!(
+    //         config.deleted_file_retention_duration().as_secs(),
+    //         2 * SECONDS_PER_DAY,
+    //     );
+    // }
+
+    // #[test]
+    // fn get_long_from_metadata_test() {
+    //     let md = dummy_metadata();
+    //     let config = TableConfig(&md.configuration);
+    //     assert_eq!(config.checkpoint_interval(), 10,)
+    // }
+
+    // #[test]
+    // fn get_boolean_from_metadata_test() {
+    //     let md = dummy_metadata();
+    //     let config = TableConfig(&md.configuration);
+
+    //     // default value is true
+    //     assert!(config.enable_expired_log_cleanup());
+
+    //     // change to false
+    //     let mut md = dummy_metadata();
+    //     md.configuration.insert(
+    //         DeltaTableProperty::EnableExpiredLogCleanup.as_ref().into(),
+    //         "false".to_string(),
+    //     );
+    //     let config = TableConfig(&md.configuration);
+
+    //     assert!(!config.enable_expired_log_cleanup());
+    // }
+
+    // #[test]
+    // fn parse_interval_test() {
+    //     assert_eq!(
+    //         parse_interval("interval 123 nanosecond").unwrap(),
+    //         Duration::from_nanos(123)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 nanoseconds").unwrap(),
+    //         Duration::from_nanos(123)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 microsecond").unwrap(),
+    //         Duration::from_micros(123)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 microseconds").unwrap(),
+    //         Duration::from_micros(123)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 millisecond").unwrap(),
+    //         Duration::from_millis(123)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 milliseconds").unwrap(),
+    //         Duration::from_millis(123)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 second").unwrap(),
+    //         Duration::from_secs(123)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 seconds").unwrap(),
+    //         Duration::from_secs(123)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 minute").unwrap(),
+    //         Duration::from_secs(123 * 60)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 minutes").unwrap(),
+    //         Duration::from_secs(123 * 60)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 hour").unwrap(),
+    //         Duration::from_secs(123 * 3600)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 hours").unwrap(),
+    //         Duration::from_secs(123 * 3600)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 day").unwrap(),
+    //         Duration::from_secs(123 * 86400)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 days").unwrap(),
+    //         Duration::from_secs(123 * 86400)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 week").unwrap(),
+    //         Duration::from_secs(123 * 604800)
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 123 week").unwrap(),
+    //         Duration::from_secs(123 * 604800)
+    //     );
+    // }
+
+    // #[test]
+    // fn parse_interval_invalid_test() {
+    //     assert_eq!(
+    //         parse_interval("whatever").err().unwrap(),
+    //         DeltaConfigError::Validation("'whatever' is not an interval".to_string())
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval").err().unwrap(),
+    //         DeltaConfigError::Validation("'interval' is not an interval".to_string())
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 2").err().unwrap(),
+    //         DeltaConfigError::Validation("'interval 2' is not an interval".to_string())
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval 2 years").err().unwrap(),
+    //         DeltaConfigError::Validation("Unknown unit 'years'".to_string())
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval two years").err().unwrap(),
+    //         DeltaConfigError::Validation(
+    //             "Cannot parse 'two' as integer: invalid digit found in string".to_string()
+    //         )
+    //     );
+
+    //     assert_eq!(
+    //         parse_interval("interval -25 hours").err().unwrap(),
+    //         DeltaConfigError::Validation(
+    //             "interval 'interval -25 hours' cannot be negative".to_string()
+    //         )
+    //     );
+    // }
+
+    // #[test]
+    // fn test_constraint() {
+    //     let md = dummy_metadata();
+    //     let config = TableConfig(&md.configuration);
+
+    //     assert_eq!(config.get_constraints().len(), 0);
+
+    //     let mut md = dummy_metadata();
+    //     md.configuration.insert(
+    //         "delta.constraints.name".to_string(),
+    //         "name = 'foo'".to_string(),
+    //     );
+    //     md.configuration
+    //         .insert("delta.constraints.age".to_string(), "age > 10".to_string());
+    //     let config = TableConfig(&md.configuration);
+
+    //     let constraints = config.get_constraints();
+    //     assert_eq!(constraints.len(), 2);
+    //     assert!(constraints.contains(&Constraint::new("name", "name = 'foo'")));
+    //     assert!(constraints.contains(&Constraint::new("age", "age > 10")));
+    // }
+
+    // #[test]
+    // fn test_roundtrip_config_key() {
+    //     let cases = [
+    //         (DeltaTableProperty::AppendOnly, "delta.appendOnly"),
+    //         (
+    //             DeltaTableProperty::AutoOptimizeAutoCompact,
+    //             "delta.autoOptimize.autoCompact",
+    //         ),
+    //         (
+    //             DeltaTableProperty::AutoOptimizeOptimizeWrite,
+    //             "delta.autoOptimize.optimizeWrite",
+    //         ),
+    //         (
+    //             DeltaTableProperty::CheckpointInterval,
+    //             "delta.checkpointInterval",
+    //         ),
+    //         (
+    //             DeltaTableProperty::CheckpointWriteStatsAsJson,
+    //             "delta.checkpoint.writeStatsAsJson",
+    //         ),
+    //         (
+    //             DeltaTableProperty::CheckpointWriteStatsAsStruct,
+    //             "delta.checkpoint.writeStatsAsStruct",
+    //         ),
+    //         (
+    //             DeltaTableProperty::ColumnMappingMode,
+    //             "delta.columnMapping.mode",
+    //         ),
+    //         (
+    //             DeltaTableProperty::DataSkippingNumIndexedCols,
+    //             "delta.dataSkippingNumIndexedCols",
+    //         ),
+    //         (
+    //             DeltaTableProperty::DataSkippingStatsColumns,
+    //             "delta.dataSkippingStatsColumns",
+    //         ),
+    //         (
+    //             DeltaTableProperty::DeletedFileRetentionDuration,
+    //             "delta.deletedFileRetentionDuration",
+    //         ),
+    //         (
+    //             DeltaTableProperty::EnableChangeDataFeed,
+    //             "delta.enableChangeDataFeed",
+    //         ),
+    //         (
+    //             DeltaTableProperty::EnableDeletionVectors,
+    //             "delta.enableDeletionVectors",
+    //         ),
+    //         (DeltaTableProperty::IsolationLevel, "delta.isolationLevel"),
+    //         (
+    //             DeltaTableProperty::LogRetentionDuration,
+    //             "delta.logRetentionDuration",
+    //         ),
+    //         (
+    //             DeltaTableProperty::MinReaderVersion,
+    //             "delta.minReaderVersion",
+    //         ),
+    //         (
+    //             DeltaTableProperty::MinWriterVersion,
+    //             "delta.minWriterVersion",
+    //         ),
+    //         (
+    //             DeltaTableProperty::RandomizeFilePrefixes,
+    //             "delta.randomizeFilePrefixes",
+    //         ),
+    //         (
+    //             DeltaTableProperty::RandomPrefixLength,
+    //             "delta.randomPrefixLength",
+    //         ),
+    //         (
+    //             DeltaTableProperty::SetTransactionRetentionDuration,
+    //             "delta.setTransactionRetentionDuration",
+    //         ),
+    //         (
+    //             DeltaTableProperty::EnableExpiredLogCleanup,
+    //             "delta.enableExpiredLogCleanup",
+    //         ),
+    //         (DeltaTableProperty::TargetFileSize, "delta.targetFileSize"),
+    //         (
+    //             DeltaTableProperty::TuneFileSizesForRewrites,
+    //             "delta.tuneFileSizesForRewrites",
+    //         ),
+    //         (
+    //             DeltaTableProperty::CheckpointPolicy,
+    //             "delta.checkpointPolicy",
+    //         ),
+    //     ];
+
+    //     assert_eq!(DeltaTableProperty::VARIANTS.len(), cases.len());
+
+    //     for (key, expected) in cases {
+    //         assert_eq!(key.as_ref(), expected);
+
+    //         let serialized = serde_json::to_string(&key).unwrap();
+    //         assert_eq!(serialized, format!("\"{}\"", expected));
+
+    //         let deserialized: DeltaTableProperty = serde_json::from_str(&serialized).unwrap();
+    //         assert_eq!(deserialized, key);
+
+    //         let from_str: DeltaTableProperty = expected.parse().unwrap();
+    //         assert_eq!(from_str, key);
+    //     }
+    // }
+
+    // #[test]
+    // fn test_default_config() {
+    //     let md = dummy_metadata();
+    //     let config = TableConfig(&md.configuration);
+
+    //     assert_eq!(config.append_only(), false);
+    //     // assert_eq!(config.auto_optimize_auto_compact(), false);
+    //     assert_eq!(config.auto_optimize_optimize_write(), false);
+    //     assert_eq!(config.checkpoint_interval(), 10);
+    //     assert_eq!(config.write_stats_as_json(), true);
+    //     assert_eq!(config.write_stats_as_struct(), false);
+    //     assert_eq!(config.target_file_size(), 104857600);
+    //     assert_eq!(config.enable_change_data_feed(), false);
+    //     assert_eq!(config.enable_deletion_vectors(), false);
+    //     assert_eq!(config.num_indexed_cols(), 32);
+    //     assert_eq!(config.enable_expired_log_cleanup(), true);
+    // }
+}

--- a/kernel/src/table_properties/deserialize.rs
+++ b/kernel/src/table_properties/deserialize.rs
@@ -1,0 +1,157 @@
+use crate::expressions::ColumnName;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::de::{self, DeserializeSeed, Deserializer, MapAccess, Visitor};
+use serde::Deserialize;
+
+const SECONDS_PER_MINUTE: u64 = 60;
+const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
+const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
+const SECONDS_PER_WEEK: u64 = 7 * SECONDS_PER_DAY;
+
+pub(crate) struct StringMapDeserializer<'de> {
+    iter: std::collections::hash_map::Iter<'de, String, String>,
+}
+
+impl<'de> StringMapDeserializer<'de> {
+    pub(crate) fn new(map: &'de HashMap<String, String>) -> Self {
+        StringMapDeserializer { iter: map.iter() }
+    }
+}
+
+impl<'de> Deserializer<'de> for StringMapDeserializer<'de> {
+    type Error = de::value::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_map(HashMapMapAccess {
+            iter: self.iter,
+            value: None,
+        })
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
+        byte_buf option unit unit_struct newtype_struct seq tuple tuple_struct
+        map struct enum identifier ignored_any
+    }
+}
+
+struct HashMapMapAccess<'de> {
+    iter: std::collections::hash_map::Iter<'de, String, String>,
+    value: Option<&'de String>,
+}
+
+impl<'de> MapAccess<'de> for HashMapMapAccess<'de> {
+    type Error = de::value::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                let de = de::value::StrDeserializer::new(key);
+                seed.deserialize(de).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let value = self.value.take().unwrap(); // FIXME
+        let de = de::value::StrDeserializer::new(value);
+        seed.deserialize(de)
+    }
+}
+
+pub(crate) fn deserialize_pos_int<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let s: String = de::Deserialize::deserialize(deserializer)?;
+    let n: u64 = s.parse().unwrap(); // FIXME
+    if n == 0 {
+        panic!("FIXME");
+        // return Err("something");
+    }
+    Ok(n)
+}
+
+pub(crate) fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let s: String = de::Deserialize::deserialize(deserializer)?;
+    match s.as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(de::Error::unknown_variant(&s, &["true", "false"])),
+    }
+}
+
+pub(crate) fn deserialize_column_names<'de, D>(deserializer: D) -> Result<Vec<ColumnName>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let s: String = de::Deserialize::deserialize(deserializer)?;
+    Ok(s.split(',')
+        .map(|name: &str| ColumnName::new([name]))
+        .collect())
+}
+
+pub(crate) fn deserialize_interval<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(deserializer)?;
+    match opt {
+        Some(s) => parse_interval(&s).map(Some).map_err(de::Error::custom),
+        None => Ok(None),
+    }
+}
+
+fn parse_interval(value: &str) -> Result<Duration, String> {
+    let not_an_interval = || format!("'{value}' is not an interval");
+
+    if !value.starts_with("interval ") {
+        return Err(not_an_interval());
+    }
+    let mut it = value.split_whitespace();
+    let _ = it.next(); // skip "interval"
+    let number = parse_int(it.next().ok_or_else(not_an_interval)?)?;
+    if number < 0 {
+        return Err(format!("interval '{value}' cannot be negative"));
+    }
+    let number = number as u64;
+
+    let duration = match it.next().ok_or_else(not_an_interval)? {
+        "nanosecond" | "nanoseconds" => Duration::from_nanos(number),
+        "microsecond" | "microseconds" => Duration::from_micros(number),
+        "millisecond" | "milliseconds" => Duration::from_millis(number),
+        "second" | "seconds" => Duration::from_secs(number),
+        "minute" | "minutes" => Duration::from_secs(number * SECONDS_PER_MINUTE),
+        "hour" | "hours" => Duration::from_secs(number * SECONDS_PER_HOUR),
+        "day" | "days" => Duration::from_secs(number * SECONDS_PER_DAY),
+        "week" | "weeks" => Duration::from_secs(number * SECONDS_PER_WEEK),
+        unit => {
+            return Err(format!("Unknown unit '{unit}'"));
+        }
+    };
+
+    Ok(duration)
+}
+
+fn parse_int(value: &str) -> Result<i64, String> {
+    value
+        .parse()
+        .map_err(|e| format!("Cannot parse '{value}' as integer: {e}"))
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
New `TableProperties` struct parses the `Metadata` action's `configuration` into a strongly-typed configuration struct. Then, throughout the kernel we can leverage the configuration to appropriately handle DVs, column mapping, etc.

Pragmatically, the changes are:
1. New `TableProperties` struct along with new `Snapshot::get_table_properties()` API
2. table_properties module including (1) and a custom serde deserializer to map the HashMap<String, String> into serde's internal data format, and `Deserialize` implementations derived for `TableProperties` and its fields

TODOs
- [ ] do we want to leverage default values for many of the table properties? E.g. if `delta.appendOnly` is omitted, do we want the field `TableProperties.append_only` to be `None` or default to `false`?
- [ ] need to do testing
- [ ] general cleanup like unwraps etc.

## This PR affects the following public APIs
- Removes the old explicit `Snapshot::column_mapping_mode()` in favor of unifying under `Snapshot::get_table_properties().column_mapping_mode`

## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->
more testing TODO!

Credit: @roeap for the original PR which this is based on #222 