### PR TITLE
Fix decimal in `get_testing_kernel_expression` and visitor printing

### DIFF
--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -5,7 +5,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 /**

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -144,11 +144,11 @@ void print_tree_helper(ExpressionItem ref, int depth) {
         }
         case Decimal: {
           struct Decimal* dec = &lit->value.decimal;
-          printf("Decimal(%lld,%lld, %d, %d)\n",
+          printf("Decimal(%lld,%lld,%d,%d)\n",
                  (long long)dec->value[0],
                  (long long)dec->value[1],
-                 dec->scale,
-                 dec->precision);
+                 dec->precision,
+                 dec->scale);
           break;
         }
         case Null:

--- a/ffi/src/expressions/kernel.rs
+++ b/ffi/src/expressions/kernel.rs
@@ -106,7 +106,7 @@ pub struct EngineExpressionVisitor {
     pub visit_literal_struct: extern "C" fn(
         data: *mut c_void,
         sibling_list_id: usize,
-        child_field_list_value: usize,
+        child_field_list_id: usize,
         child_value_list_id: usize,
     ),
     /// Visit an array literal belonging to the list identified by `sibling_list_id`.

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
         Scalar::Date(32).into(),
         Scalar::Binary(0x0000deadbeefcafeu64.to_be_bytes().to_vec()).into(),
         // Both the most and least significant u64 of the Decimal value will be 1
-        Scalar::Decimal((1 << 64) + 1, 2, 3).into(),
+        Scalar::Decimal((1 << 64) + 1, 5, 3).into(),
         Expr::null_literal(DataType::SHORT),
         Scalar::Struct(top_level_struct).into(),
         Scalar::Array(array_data).into(),

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -16,7 +16,7 @@ And
   TimestampNtz(100)
   Date(32)
   Binary(0000deadbeefcafe)
-  Decimal(1,1, 3, 2)
+  Decimal(1,1,5,3)
   Null
   Struct
     Field: top


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR changes the `Decimal` in `get_testing_kernel_expression` to have a precision larger than the scale, which is a requirement of `Decimal`s. Moreover and the existing behaviour may cause errors in engines that check that `Decimal`s are well-formed.

The child list parameter name in `visit_literal_struct` is renamed to be consistent with the other visitor.

Finally, the printing is patched up in `expression_print.h` to be consistent with the order in the `Decimal` struct.


<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?.
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->
I ran the visit-expression test suite with the new expected output.