### PR TITLE
inital take on some miri support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Test with Miri
         run: |
           pushd ffi
-          cargo miri test --features sync-engine
+          MIRIFLAGS=-Zmiri-disable-isolation cargo miri test --features sync-engine
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,21 @@ jobs:
           make
           make test
 
+  miri:
+    name: "Miri"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      - name: Test with Miri
+        run: |
+          pushd ffi
+          cargo miri test --features sync-engine
+
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -59,7 +59,6 @@ pub trait HandleDescriptor {
 
 mod private {
 
-    use std::mem::ManuallyDrop;
     use std::ptr::NonNull;
     use std::sync::Arc;
 
@@ -338,8 +337,8 @@ mod private {
         type Raw = T;
 
         fn into_handle_ptr(val: Box<T>) -> NonNull<T> {
-            let val = ManuallyDrop::new(val);
-            val.as_ref().into()
+            let raw = Box::into_raw(val);
+            NonNull::new(raw).expect("into_raw should be non-null") // into_raw guarantees non-null
         }
         unsafe fn as_ref<'a>(ptr: *const T) -> &'a T {
             &*ptr
@@ -367,8 +366,8 @@ mod private {
         type Raw = T;
 
         fn into_handle_ptr(val: Arc<T>) -> NonNull<T> {
-            let val = ManuallyDrop::new(val);
-            val.as_ref().into()
+            let ptr = Arc::into_raw(val);
+            NonNull::new(ptr as *mut T).expect("into_raw should be non-null")
         }
         unsafe fn as_ref<'a>(ptr: *const T) -> &'a T {
             &*ptr
@@ -400,8 +399,8 @@ mod private {
 
         fn into_handle_ptr(val: Box<T>) -> NonNull<Box<T>> {
             // Double-boxing needed in order to obtain a thin pointer
-            let val = ManuallyDrop::new(Box::new(val));
-            val.as_ref().into()
+            let raw = Box::into_raw(Box::new(val));
+            NonNull::new(raw).expect("into_raw should be non-null") // into_raw guarantees non-null
         }
         unsafe fn as_ref<'a>(ptr: *const Box<T>) -> &'a T {
             let boxed = unsafe { &*ptr };
@@ -434,8 +433,8 @@ mod private {
 
         fn into_handle_ptr(val: Arc<T>) -> NonNull<Arc<T>> {
             // Double-boxing needed in order to obtain a thin pointer
-            let val = ManuallyDrop::new(Box::new(val));
-            val.as_ref().into()
+            let raw = Box::into_raw(Box::new(val));
+            NonNull::new(raw).expect("into_raw should be non-null") // into_raw guarantees non-null
         }
         unsafe fn as_ref<'a>(ptr: *const Arc<T>) -> &'a T {
             let arc = unsafe { &*ptr };

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -934,7 +934,7 @@ mod tests {
 
     #[test]
     fn engine_builder() {
-        let path = "/tmp";
+        let path = "s3://doesntmatter/foo";
         let path = kernel_string_slice!(path);
         let builder = unsafe { ok_or_panic(get_engine_builder(path, allocate_err)) };
         // TODO: When miri supports epoll_wait
@@ -945,6 +945,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "sync-engine")]
     fn sync_engine() {
         let engine = unsafe { get_sync_engine(allocate_err) };
         let engine = ok_or_panic(engine);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -897,3 +897,59 @@ impl<T> Default for ReferenceSet<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[no_mangle]
+    extern "C" fn allocate_err(etype: KernelError, _: KernelStringSlice) -> *mut EngineError {
+        let boxed = Box::new(EngineError { etype });
+        Box::leak(boxed)
+    }
+
+    fn ok_or_panic<T>(result: ExternResult<T>) -> T {
+        match result {
+            ExternResult::Ok(t) => t,
+            ExternResult::Err(e) => unsafe {
+                panic!("Got engine error with type {:?}", (*e).etype);
+            },
+        }
+    }
+
+    #[test]
+    fn string_slice() {
+        let s = "foo";
+        let _ = kernel_string_slice!(s);
+    }
+
+    #[test]
+    fn bool_slice() {
+        let bools = vec![true, false, true];
+        let bool_slice = KernelBoolSlice::from(bools);
+        unsafe {
+            free_bool_slice(bool_slice);
+        }
+    }
+
+    #[test]
+    fn engine_builder() {
+        let path = "/tmp";
+        let path = kernel_string_slice!(path);
+        let builder = unsafe { ok_or_panic(get_engine_builder(path, allocate_err)) };
+        // TODO: When miri supports epoll_wait
+        // let engine = unsafe { builder_build(builder) };
+
+        // for now just rebox so it gets dropped and miri doesn't complain
+        let _box = unsafe { Box::from_raw(builder) };
+    }
+
+    #[test]
+    fn sync_engine() {
+        let engine = unsafe { get_sync_engine(allocate_err) };
+        let engine = ok_or_panic(engine);
+        unsafe {
+            free_engine(engine);
+        }
+    }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?


This PR adds a test where we start to use [miri](https://github.com/rust-lang/miri) to make sure we're not doing anything crazy in our FFI. Initially it just tests a couple of things, which already uncovered an issue (see below). We need to add lots more unit tests for the various ffi functions to get miri to validate what we're doing.

This uncovered that the way we were getting pointers in handles was actually unsound. Previously we would do something like:
```rust
 let val = ManuallyDrop::new(Box::new(val));
 val.as_ref().into()
```

To get the pointer. This is fine, but note that we are converting from `&T` into a `NonNull<T>` here, which is supported in the trait, but marks the memory as `SharedReadOnly` because we don't own the reference.

But to free the memory we use `into_inner()` which wants to do:
```rust
*Box::from_raw(ptr)
```

This takes `Unique` ownership of the pointer, which is not valid because we only created it in `SharedReadOnly`.

This PR switches to use `Box::leak` to get pointers, which constructs them with the correct memory tag. It's possible there are cases where we DO want the memory tagged as `SharedReadOnly`, but in that case I think we'd _have_ to keep a reference around in rust to _ever_ be able to free things, since experimenting indicates that all the `from_raw` calls (Arc, Rc, Box) want the memory to be at least `SharedReadWrite`. 

Box in particular wants `Unique`. I need to do some more research about if Arc/Rc::into_raw produce a thin pointer or not, as they place less stringent requirements in their `from_raw`.

For now, to minimize change, I'm sticking with Box.

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

Added some unit tests