### PR TITLE
[chore] Rename EngineData::length as EngineData::len

### DIFF
--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -31,7 +31,7 @@ use super::handle::Handle;
 #[no_mangle]
 pub unsafe extern "C" fn engine_data_length(data: &mut Handle<ExclusiveEngineData>) -> usize {
     let data = unsafe { data.as_mut() };
-    data.length()
+    data.len()
 }
 
 /// Allow an engine to "unwrap" an [`ExclusiveEngineData`] into the raw pointer for the case it wants

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -292,7 +292,7 @@ fn do_work(
 
         for read_result in read_results {
             let read_result = read_result.unwrap();
-            let len = read_result.length();
+            let len = read_result.len();
 
             // ask the kernel to transform the physical data into the correct logical form
             let logical = transform_to_logical(

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -42,10 +42,10 @@ impl EngineData for ArrowEngineData {
     fn extract(&self, schema: SchemaRef, visitor: &mut dyn DataVisitor) -> DeltaResult<()> {
         let mut col_array = vec![];
         self.extract_columns(&mut col_array, &schema)?;
-        visitor.visit(self.length(), &col_array)
+        visitor.visit(self.len(), &col_array)
     }
 
-    fn length(&self) -> usize {
+    fn len(&self) -> usize {
         self.data.num_rows()
     }
 

--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -236,7 +236,7 @@ mod tests {
         let batch = handler
             .parse_json(string_array_to_engine_data(json_strings), output_schema)
             .unwrap();
-        assert_eq!(batch.length(), 4);
+        assert_eq!(batch.len(), 4);
     }
 
     #[test]

--- a/kernel/src/engine_data.rs
+++ b/kernel/src/engine_data.rs
@@ -216,13 +216,11 @@ pub trait DataVisitor {
 ///   fn into_any(self: Box<Self>) -> Box<dyn Any> { self }
 ///   fn extract(&self, schema: SchemaRef, visitor: &mut dyn DataVisitor) -> DeltaResult<()> {
 ///     let getters = self.do_extraction(); // do the extraction
-///     let row_count = self.length();
-///     visitor.visit(row_count, &getters); // call the visitor back with the getters
+///     visitor.visit(self.len(), &getters); // call the visitor back with the getters
 ///     Ok(())
 ///   }
-///   fn length(&self) -> usize {
-///     let len = 0; // actually get the len here
-///     len
+///   fn len(&self) -> usize {
+///     todo!() // actually get the len here
 ///   }
 /// }
 /// ```
@@ -234,7 +232,11 @@ pub trait EngineData: Send + Sync {
     fn extract(&self, schema: SchemaRef, visitor: &mut dyn DataVisitor) -> DeltaResult<()>;
 
     /// Return the number of items (rows) in blob
-    fn length(&self) -> usize;
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     // TODO(nick) implement this and below here in the trait when it doesn't cause a compiler error
     fn as_any(&self) -> &dyn Any;

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -273,19 +273,19 @@ impl DataSkippingFilter {
     pub(crate) fn apply(&self, actions: &dyn EngineData) -> DeltaResult<Vec<bool>> {
         // retrieve and parse stats from actions data
         let stats = self.select_stats_evaluator.evaluate(actions)?;
-        assert_eq!(stats.length(), actions.length());
+        assert_eq!(stats.len(), actions.len());
         let parsed_stats = self
             .json_handler
             .parse_json(stats, self.stats_schema.clone())?;
-        assert_eq!(parsed_stats.length(), actions.length());
+        assert_eq!(parsed_stats.len(), actions.len());
 
         // evaluate the predicate on the parsed stats, then convert to selection vector
         let skipping_predicate = self.skipping_evaluator.evaluate(&*parsed_stats)?;
-        assert_eq!(skipping_predicate.length(), actions.length());
+        assert_eq!(skipping_predicate.len(), actions.len());
         let selection_vector = self
             .filter_evaluator
             .evaluate(skipping_predicate.as_ref())?;
-        assert_eq!(selection_vector.length(), actions.length());
+        assert_eq!(selection_vector.len(), actions.len());
 
         // visit the engine's selection vector to produce a Vec<bool>
         let mut visitor = SelectionVectorVisitor::default();

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -152,10 +152,10 @@ impl LogReplayScanner {
         // below if a file has been removed
         let mut selection_vector = match filter_vector {
             Some(ref filter_vector) => filter_vector.clone(),
-            None => vec![false; actions.length()],
+            None => vec![false; actions.len()],
         };
 
-        assert_eq!(selection_vector.len(), actions.length());
+        assert_eq!(selection_vector.len(), actions.len());
         let adds = self.setup_batch_process(filter_vector, actions, is_log_batch)?;
 
         for (add, index) in adds.into_iter() {

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -149,7 +149,7 @@ impl ScanResult {
     /// _need_ to extend the mask to the full length of the batch or arrow will drop the extra rows.
     pub fn full_mask(&self) -> Option<Vec<bool>> {
         let mut mask = self.raw_mask.clone()?;
-        mask.resize(self.raw_data.as_ref().ok()?.length(), true);
+        mask.resize(self.raw_data.as_ref().ok()?.len(), true);
         Some(mask)
     }
 }
@@ -330,7 +330,7 @@ impl Scan {
                         &self.all_fields,
                         self.have_partition_cols,
                     );
-                    let len = logical.as_ref().map_or(0, |res| res.length());
+                    let len = logical.as_ref().map_or(0, |res| res.len());
                     // need to split the dv_mask. what's left in dv_mask covers this result, and rest
                     // will cover the following results. we `take()` out of `selection_vector` to avoid
                     // trying to return a captured variable. We're going to reassign `selection_vector`
@@ -672,7 +672,7 @@ mod tests {
         let files: Vec<ScanResult> = scan.execute(&engine).unwrap().try_collect().unwrap();
 
         assert_eq!(files.len(), 1);
-        let num_rows = files[0].raw_data.as_ref().unwrap().length();
+        let num_rows = files[0].raw_data.as_ref().unwrap().len();
         assert_eq!(num_rows, 10)
     }
 

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -256,10 +256,10 @@ fn generate_commit_info(
     operation: Option<&str>,
     engine_commit_info: &dyn EngineData,
 ) -> DeltaResult<Box<dyn EngineData>> {
-    if engine_commit_info.length() != 1 {
+    if engine_commit_info.len() != 1 {
         return Err(Error::InvalidCommitInfo(format!(
             "Engine commit info should have exactly one row, found {}",
-            engine_commit_info.length()
+            engine_commit_info.len()
         )));
     }
 
@@ -451,7 +451,7 @@ mod tests {
             }
         });
 
-        assert_eq!(actions.length(), 1);
+        assert_eq!(actions.len(), 1);
         let result = as_json_and_scrub_timestamp(actions);
         assert_eq!(result, expected);
 
@@ -511,7 +511,7 @@ mod tests {
             }
         });
 
-        assert_eq!(actions.length(), 1);
+        assert_eq!(actions.len(), 1);
         let result = as_json_and_scrub_timestamp(actions);
         assert_eq!(result, expected);
 
@@ -584,7 +584,7 @@ mod tests {
         data: Box<dyn EngineData>,
         write_engine_commit_info: bool,
     ) -> DeltaResult<()> {
-        assert_eq!(data.length(), 1);
+        assert_eq!(data.len(), 1);
         let expected = if write_engine_commit_info {
             serde_json::json!({
                 "commitInfo": {

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -20,7 +20,7 @@ fn count_total_scan_rows(
             let mask = scan_result.raw_mask();
             let deleted_rows = mask.into_iter().flatten().filter(|&&m| !m).count();
             let data = scan_result.raw_data?;
-            Ok(data.length() - deleted_rows)
+            Ok(data.len() - deleted_rows)
         })
         .fold_ok(0, Add::add)
 }

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -464,7 +464,7 @@ fn read_with_scan_data(
 
         for read_result in read_results {
             let read_result = read_result.unwrap();
-            let len = read_result.length();
+            let len = read_result.len();
 
             // ask the kernel to transform the physical data into the correct logical form
             let logical = transform_to_logical(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Rust uses methods called `len` not `length`, but we currently have `EngineData::length`. Fix it. 

Also add a corresponding `is_empty` method to keep clippy happy.

### This PR affects the following public APIs

See above. Name change of public method.
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

## How was this change tested?

Compilation + unit tests.