### PR TITLE
Move some common test-utils to their own crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "ffi",
     "kernel",
     "kernel/examples/*",
+    "test-utils",
 ]
 # Only check / build main crates by default (check all with `--workspace`)
 default-members = ["acceptance", "kernel"]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -117,7 +117,7 @@ rustc_version = "0.4.1"
 [dev-dependencies]
 arrow = { workspace = true, features = ["json", "prettyprint"] }
 delta_kernel = { path = ".", features = ["default-engine", "sync-engine"] }
-test-utils = { path = "../test-utils" }
+test_utils = { path = "../test-utils" }
 paste = "1.0"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tempfile = "3"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -117,6 +117,7 @@ rustc_version = "0.4.1"
 [dev-dependencies]
 arrow = { workspace = true, features = ["json", "prettyprint"] }
 delta_kernel = { path = ".", features = ["default-engine", "sync-engine"] }
+test-utils = { path = "../test-utils" }
 paste = "1.0"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tempfile = "3"

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -366,6 +366,7 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::ObjectStore;
+    use test_utils::delta_path_for_version;
 
     use crate::engine::default::executor::tokio::TokioBackgroundExecutor;
     use crate::engine::default::filesystem::ObjectStoreFileSystemClient;
@@ -440,10 +441,6 @@ mod tests {
     fn test_read_log_with_out_of_date_last_checkpoint() {
         let store = Arc::new(InMemory::new());
 
-        fn get_path(index: usize, suffix: &str) -> Path {
-            let path = format!("_delta_log/{index:020}.{suffix}");
-            Path::from(path.as_str())
-        }
         let data = bytes::Bytes::from("kernel-data");
 
         let checkpoint_metadata = CheckpointMetadata {
@@ -461,14 +458,14 @@ mod tests {
             .expect("create tokio runtime")
             .block_on(async {
                 for path in [
-                    get_path(0, "json"),
-                    get_path(1, "checkpoint.parquet"),
-                    get_path(2, "json"),
-                    get_path(3, "checkpoint.parquet"),
-                    get_path(4, "json"),
-                    get_path(5, "checkpoint.parquet"),
-                    get_path(6, "json"),
-                    get_path(7, "json"),
+                    delta_path_for_version(0, "json"),
+                    delta_path_for_version(1, "checkpoint.parquet"),
+                    delta_path_for_version(2, "json"),
+                    delta_path_for_version(3, "checkpoint.parquet"),
+                    delta_path_for_version(4, "json"),
+                    delta_path_for_version(5, "checkpoint.parquet"),
+                    delta_path_for_version(6, "json"),
+                    delta_path_for_version(7, "json"),
                 ] {
                     store
                         .put(&path, data.clone().into())

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -3,10 +3,7 @@ use std::ops::Not;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, Int32Array, StringArray};
 use arrow::compute::filter_record_batch;
-use arrow::error::ArrowError;
-use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef as ArrowSchemaRef;
 use arrow_select::concat::concat_batches;
 use delta_kernel::actions::deletion_vector::split_vector;
@@ -17,10 +14,12 @@ use delta_kernel::expressions::{column_expr, BinaryOperator, Expression};
 use delta_kernel::scan::state::{visit_scan_files, DvInfo, Stats};
 use delta_kernel::scan::{transform_to_logical, Scan};
 use delta_kernel::schema::Schema;
-use delta_kernel::{Engine, EngineData, FileMeta, Table};
+use delta_kernel::{Engine, FileMeta, Table};
 use object_store::{memory::InMemory, path::Path, ObjectStore};
-use parquet::arrow::arrow_writer::ArrowWriter;
-use parquet::file::properties::WriterProperties;
+use test_utils::{
+    actions_to_string, add_commit, generate_batch, generate_simple_batch, into_record_batch,
+    record_batch_to_bytes, IntoArray, TestAction, METADATA,
+};
 use url::Url;
 
 mod common;
@@ -29,62 +28,6 @@ use common::{read_scan, to_arrow};
 const PARQUET_FILE1: &str = "part-00000-a72b1fb3-f2df-41fe-a8f0-e65b746382dd-c000.snappy.parquet";
 const PARQUET_FILE2: &str = "part-00001-c506e79a-0bf8-4e2b-a42b-9731b2e490ae-c000.snappy.parquet";
 
-const METADATA: &str = r#"{"commitInfo":{"timestamp":1587968586154,"operation":"WRITE","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]"},"isBlindAppend":true}}
-{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
-{"metaData":{"id":"5fba94ed-9794-4965-ba6e-6ee3c0d22af9","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"val\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}"#;
-
-enum TestAction {
-    Add(String),
-    Remove(String),
-    Metadata,
-}
-
-fn generate_commit(actions: Vec<TestAction>) -> String {
-    actions
-            .into_iter()
-            .map(|test_action| match test_action {
-                TestAction::Add(path) => format!(r#"{{"{action}":{{"path":"{path}","partitionValues":{{}},"size":262,"modificationTime":1587968586000,"dataChange":true, "stats":"{{\"numRecords\":2,\"nullCount\":{{\"id\":0}},\"minValues\":{{\"id\": 1}},\"maxValues\":{{\"id\":3}}}}"}}}}"#, action = "add", path = path),
-                TestAction::Remove(path) => format!(r#"{{"{action}":{{"path":"{path}","partitionValues":{{}},"size":262,"modificationTime":1587968586000,"dataChange":true}}}}"#, action = "remove", path = path),
-                TestAction::Metadata => METADATA.into(),
-            })
-            .fold(String::new(), |a, b| a + &b + "\n")
-}
-
-fn load_parquet(batch: &RecordBatch) -> Vec<u8> {
-    let mut data: Vec<u8> = Vec::new();
-    let props = WriterProperties::builder().build();
-    let mut writer = ArrowWriter::try_new(&mut data, batch.schema(), Some(props)).unwrap();
-    writer.write(batch).expect("Writing batch");
-    // writer must be closed to write footer
-    writer.close().unwrap();
-    data
-}
-
-fn generate_simple_batch() -> Result<RecordBatch, ArrowError> {
-    let ids = Int32Array::from(vec![1, 2, 3]);
-    let vals = StringArray::from(vec!["a", "b", "c"]);
-    RecordBatch::try_from_iter(vec![
-        ("id", Arc::new(ids) as ArrayRef),
-        ("val", Arc::new(vals) as ArrayRef),
-    ])
-}
-
-async fn add_commit(
-    store: &dyn ObjectStore,
-    version: u64,
-    data: String,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let filename = format!("_delta_log/{:0>20}.json", version);
-    store.put(&Path::from(filename), data.into()).await?;
-    Ok(())
-}
-
-fn into_record_batch(engine_data: Box<dyn EngineData>) -> RecordBatch {
-    ArrowEngineData::try_from_engine_data(engine_data)
-        .unwrap()
-        .into()
-}
-
 #[tokio::test]
 async fn single_commit_two_add_files() -> Result<(), Box<dyn std::error::Error>> {
     let batch = generate_simple_batch()?;
@@ -92,7 +35,7 @@ async fn single_commit_two_add_files() -> Result<(), Box<dyn std::error::Error>>
     add_commit(
         storage.as_ref(),
         0,
-        generate_commit(vec![
+        actions_to_string(vec![
             TestAction::Metadata,
             TestAction::Add(PARQUET_FILE1.to_string()),
             TestAction::Add(PARQUET_FILE2.to_string()),
@@ -100,10 +43,16 @@ async fn single_commit_two_add_files() -> Result<(), Box<dyn std::error::Error>>
     )
     .await?;
     storage
-        .put(&Path::from(PARQUET_FILE1), load_parquet(&batch).into())
+        .put(
+            &Path::from(PARQUET_FILE1),
+            record_batch_to_bytes(&batch).into(),
+        )
         .await?;
     storage
-        .put(&Path::from(PARQUET_FILE2), load_parquet(&batch).into())
+        .put(
+            &Path::from(PARQUET_FILE2),
+            record_batch_to_bytes(&batch).into(),
+        )
         .await?;
 
     let location = Url::parse("memory:///")?;
@@ -138,7 +87,7 @@ async fn two_commits() -> Result<(), Box<dyn std::error::Error>> {
     add_commit(
         storage.as_ref(),
         0,
-        generate_commit(vec![
+        actions_to_string(vec![
             TestAction::Metadata,
             TestAction::Add(PARQUET_FILE1.to_string()),
         ]),
@@ -147,14 +96,20 @@ async fn two_commits() -> Result<(), Box<dyn std::error::Error>> {
     add_commit(
         storage.as_ref(),
         1,
-        generate_commit(vec![TestAction::Add(PARQUET_FILE2.to_string())]),
+        actions_to_string(vec![TestAction::Add(PARQUET_FILE2.to_string())]),
     )
     .await?;
     storage
-        .put(&Path::from(PARQUET_FILE1), load_parquet(&batch).into())
+        .put(
+            &Path::from(PARQUET_FILE1),
+            record_batch_to_bytes(&batch).into(),
+        )
         .await?;
     storage
-        .put(&Path::from(PARQUET_FILE2), load_parquet(&batch).into())
+        .put(
+            &Path::from(PARQUET_FILE2),
+            record_batch_to_bytes(&batch).into(),
+        )
         .await?;
 
     let location = Url::parse("memory:///").unwrap();
@@ -190,7 +145,7 @@ async fn remove_action() -> Result<(), Box<dyn std::error::Error>> {
     add_commit(
         storage.as_ref(),
         0,
-        generate_commit(vec![
+        actions_to_string(vec![
             TestAction::Metadata,
             TestAction::Add(PARQUET_FILE1.to_string()),
         ]),
@@ -199,17 +154,20 @@ async fn remove_action() -> Result<(), Box<dyn std::error::Error>> {
     add_commit(
         storage.as_ref(),
         1,
-        generate_commit(vec![TestAction::Add(PARQUET_FILE2.to_string())]),
+        actions_to_string(vec![TestAction::Add(PARQUET_FILE2.to_string())]),
     )
     .await?;
     add_commit(
         storage.as_ref(),
         2,
-        generate_commit(vec![TestAction::Remove(PARQUET_FILE2.to_string())]),
+        actions_to_string(vec![TestAction::Remove(PARQUET_FILE2.to_string())]),
     )
     .await?;
     storage
-        .put(&Path::from(PARQUET_FILE1), load_parquet(&batch).into())
+        .put(
+            &Path::from(PARQUET_FILE1),
+            record_batch_to_bytes(&batch).into(),
+        )
         .await?;
 
     let location = Url::parse("memory:///").unwrap();
@@ -249,23 +207,18 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
             })
             .fold(String::new(), |a, b| a + &b + "\n")
     }
-    fn generate_simple_batch2() -> Result<RecordBatch, ArrowError> {
-        let ids = Int32Array::from(vec![5, 7]);
-        let vals = StringArray::from(vec!["e", "g"]);
-        RecordBatch::try_from_iter(vec![
-            ("id", Arc::new(ids) as ArrayRef),
-            ("val", Arc::new(vals) as ArrayRef),
-        ])
-    }
 
     let batch1 = generate_simple_batch()?;
-    let batch2 = generate_simple_batch2()?;
+    let batch2 = generate_batch(vec![
+        ("id", vec![5, 7].into_array()),
+        ("val", vec!["e", "g"].into_array()),
+    ])?;
     let storage = Arc::new(InMemory::new());
     // valid commit with min/max (0, 2)
     add_commit(
         storage.as_ref(),
         0,
-        generate_commit(vec![
+        actions_to_string(vec![
             TestAction::Metadata,
             TestAction::Add(PARQUET_FILE1.to_string()),
         ]),
@@ -280,11 +233,17 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     storage
-        .put(&Path::from(PARQUET_FILE1), load_parquet(&batch1).into())
+        .put(
+            &Path::from(PARQUET_FILE1),
+            record_batch_to_bytes(&batch1).into(),
+        )
         .await?;
 
     storage
-        .put(&Path::from(PARQUET_FILE2), load_parquet(&batch2).into())
+        .put(
+            &Path::from(PARQUET_FILE2),
+            record_batch_to_bytes(&batch2).into(),
+        )
         .await?;
 
     let location = Url::parse("memory:///").unwrap();

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test-utils"
+name = "test_utils"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "test-utils"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+version.workspace = true
+
+[dependencies]
+arrow-array = { workspace = true, features = ["chrono-tz"] }
+arrow-schema = { workspace = true }
+delta_kernel = { path = "../kernel", features = [ "default-engine" ] }
+itertools = "0.13.0"
+object_store = { workspace = true }
+parquet = { workspace = true }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -82,14 +82,20 @@ pub fn generate_simple_batch() -> Result<RecordBatch, ArrowError> {
     ])
 }
 
+/// get an ObjectStore path for a delta file, based on the version
+pub fn delta_path_for_version(version: u64, suffix: &str) -> Path {
+    let path = format!("_delta_log/{version:020}.{suffix}");
+    Path::from(path.as_str())
+}
+
 /// put a commit file into the specified object store.
 pub async fn add_commit(
     store: &dyn ObjectStore,
     version: u64,
     data: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let filename = format!("_delta_log/{:0>20}.json", version);
-    store.put(&Path::from(filename), data.into()).await?;
+    let path = delta_path_for_version(version, "json");
+    store.put(&path, data.into()).await?;
     Ok(())
 }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,0 +1,102 @@
+//! A number of utilities useful for testing that we want to use in multiple crates
+
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, Int32Array, RecordBatch, StringArray};
+use arrow_schema::ArrowError;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::EngineData;
+use itertools::Itertools;
+use object_store::{path::Path, ObjectStore};
+use parquet::arrow::arrow_writer::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+
+/// A common useful initial metadata and protocol. Also includes a single commitInfo
+pub const METADATA: &str = r#"{"commitInfo":{"timestamp":1587968586154,"operation":"WRITE","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]"},"isBlindAppend":true}}
+{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"metaData":{"id":"5fba94ed-9794-4965-ba6e-6ee3c0d22af9","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"val\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}"#;
+
+pub enum TestAction {
+    Add(String),
+    Remove(String),
+    Metadata,
+}
+
+/// Convert a vector of actions into a newline delimited json string
+pub fn actions_to_string(actions: Vec<TestAction>) -> String {
+    actions
+            .into_iter()
+            .map(|test_action| match test_action {
+                TestAction::Add(path) => format!(r#"{{"add":{{"path":"{path}","partitionValues":{{}},"size":262,"modificationTime":1587968586000,"dataChange":true, "stats":"{{\"numRecords\":2,\"nullCount\":{{\"id\":0}},\"minValues\":{{\"id\": 1}},\"maxValues\":{{\"id\":3}}}}"}}}}"#),
+                TestAction::Remove(path) => format!(r#"{{"remove":{{"path":"{path}","partitionValues":{{}},"size":262,"modificationTime":1587968586000,"dataChange":true}}}}"#),
+                TestAction::Metadata => METADATA.into(),
+            })
+            .join("\n")
+}
+
+/// convert a RecordBatch into a vector of bytes. We can't use `From` since these are both foreign
+/// types
+pub fn record_batch_to_bytes(batch: &RecordBatch) -> Vec<u8> {
+    let mut data: Vec<u8> = Vec::new();
+    let props = WriterProperties::builder().build();
+    let mut writer = ArrowWriter::try_new(&mut data, batch.schema(), Some(props)).unwrap();
+    writer.write(batch).expect("Writing batch");
+    // writer must be closed to write footer
+    writer.close().unwrap();
+    data
+}
+
+/// Anything that implements `IntoArray` can turn itself into a reference to an arrow array
+pub trait IntoArray {
+    fn into_array(self) -> ArrayRef;
+}
+
+impl IntoArray for Vec<i32> {
+    fn into_array(self) -> ArrayRef {
+        Arc::new(Int32Array::from(self))
+    }
+}
+
+impl IntoArray for Vec<&'static str> {
+    fn into_array(self) -> ArrayRef {
+        Arc::new(StringArray::from(self))
+    }
+}
+
+/// Generate a record batch from an iterator over (name, array) pairs. Each pair specifies a column
+/// name and the array to associate with it
+pub fn generate_batch<I, F>(items: I) -> Result<RecordBatch, ArrowError>
+where
+    I: IntoIterator<Item = (F, ArrayRef)>,
+    F: AsRef<str>,
+{
+    RecordBatch::try_from_iter(items)
+}
+
+/// Generate a RecordBatch with two columns (id: int, val: str), with values "1,2,3" and "a,b,c"
+/// respectively
+pub fn generate_simple_batch() -> Result<RecordBatch, ArrowError> {
+    generate_batch(vec![
+        ("id", vec![1, 2, 3].into_array()),
+        ("val", vec!["a", "b", "c"].into_array()),
+    ])
+}
+
+/// put a commit file into the specified object store.
+pub async fn add_commit(
+    store: &dyn ObjectStore,
+    version: u64,
+    data: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let filename = format!("_delta_log/{:0>20}.json", version);
+    store.put(&Path::from(filename), data.into()).await?;
+    Ok(())
+}
+
+/// Try to convert an `EngineData` into a `RecordBatch`. Panics if not using `ArrowEngineData` from
+/// the default module
+pub fn into_record_batch(engine_data: Box<dyn EngineData>) -> RecordBatch {
+    ArrowEngineData::try_from_engine_data(engine_data)
+        .unwrap()
+        .into()
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Move some useful common utils for building an in-memory delta table into their own crate.

I want to start adding tests for actually reading data to the `ffi` crate. To do so we need to use an `InMemory` object store, because all i/o in tokio fails in miri due to it using epoll, which miri doesn't support. So we'll need to build in-memory tables and use the `memory:///` url to get a memory backed `ObjectStore`. 

We already do this in `read.rs` in kernel, but there's no way to get at that code inside the ffi crate. So this moves a bunch of utilities for this sort of thing into its own "test-utils" crate and uses it in read.rs.

I've also cleaned up and renamed things a bit. Most of the code remains unchanged.

Follow-up PR(s) will use this in the ffi crate to test more.
## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

Existing tests pass