### PR TITLE
add cargo docs build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: format
         run: cargo fmt -- --check
+  docs:
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install minimal stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - name: build docs
+        run: cargo docs
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: build docs
-        run: cargo docs
+        run: cargo doc
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -6,7 +6,7 @@ use syn::{
 };
 
 /// Parses a dot-delimited column name into an array of field names. See
-/// [`delta_kernel::expressions::column_name::column_name`] macro for details.
+/// `delta_kernel::expressions::column_name::column_name` macro for details.
 #[proc_macro]
 pub fn parse_column_name(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let is_valid = |c: char| c.is_ascii_alphanumeric() || c == '_' || c == '.';

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -109,8 +109,8 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
         self
     }
 
-    // Write `data` to `path`/<uuid>.parquet as parquet using ArrowWriter and return the parquet
-    // metadata (where <uuid> is a generated UUIDv4).
+    // Write `data` to `{path}/<uuid>.parquet` as parquet using ArrowWriter and return the parquet
+    // metadata (where `<uuid>` is a generated UUIDv4).
     //
     // Note: after encoding the data as parquet, this issues a PUT followed by a HEAD to storage in
     // order to obtain metadata about the object just written.
@@ -155,8 +155,8 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
         Ok(DataFileMetadata::new(file_meta))
     }
 
-    /// Write `data` to `path`/<uuid>.parquet as parquet using ArrowWriter and return the parquet
-    /// metadata as an EngineData batch which matches the [write metadata] schema (where <uuid> is
+    /// Write `data` to `{path}/<uuid>.parquet` as parquet using ArrowWriter and return the parquet
+    /// metadata as an EngineData batch which matches the [write metadata] schema (where `<uuid>` is
     /// a generated UUIDv4).
     ///
     /// [write metadata]: crate::transaction::get_write_metadata_schema

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -187,6 +187,8 @@ impl Hash for ColumnName {
 /// let parsed: ColumnName = colname.to_string().parse().unwrap();
 /// assert_eq!(colname, parsed);
 /// ```
+///
+/// [`FromStr`]: std::str::FromStr
 impl Display for ColumnName {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut delim = None;

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -29,9 +29,9 @@ pub(crate) static WRITE_METADATA_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| 
     ]))
 });
 
-/// Get the expected schema for [`write_metadata`].
+/// Get the expected schema for engine data passed to [`add_write_metadata`].
 ///
-/// [`write_metadata`]: crate::transaction::Transaction::write_metadata
+/// [`add_write_metadata`]: crate::transaction::Transaction::add_write_metadata
 pub fn get_write_metadata_schema() -> &'static SchemaRef {
     &WRITE_METADATA_SCHEMA
 }


### PR DESCRIPTION
New CI job called `docs` which will effectively just runs `RUSTDOCFLAGS=-Dwarnings cargo doc` to check for broken docs/links/etc.

Also fixes docs issues to make the new job green :)